### PR TITLE
added views() and view_exists?() methods to Oracle

### DIFF
--- a/lib/sequel/adapters/shared/oracle.rb
+++ b/lib/sequel/adapters/shared/oracle.rb
@@ -30,6 +30,15 @@ module Sequel
         from(:tab).filter(:tname =>dataset.send(:input_identifier, name), :tabtype => 'TABLE').count > 0
       end
 
+      def views(opts={}) 
+        ds = from(:tab).server(opts[:server]).select(:tname).filter(:tabtype => 'VIEW') 
+        ds.map{|r| ds.send(:output_identifier, r[:tname])} 
+      end 
+ 
+      def view_exists?(name) 
+        from(:tab).filter(:tname =>dataset.send(:input_identifier, name), :tabtype => 'VIEW').count > 0 
+      end 
+
       private
 
       def auto_increment_sql


### PR DESCRIPTION
Hi Jeremy,

I'm doing some work with Oracle via Sequel, and wanted to get info from the views that were available. We're missing view support so I added methods to be able to get at their schemas.
