### PR TITLE
Avoid round trip through string for converting from java.sql.Timestamp

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -559,7 +559,9 @@ module Sequel
       # Convert the type.  Used for converting Java types to ruby types.
       def convert_type(v)
         case v
-        when Java::JavaSQL::Timestamp, Java::JavaSQL::Time
+        when Java::JavaSQL::Timestamp
+          Sequel.database_to_application_timestamp(Time.at(v.getTime / 1000, v.getNanos.to_f / 1000))
+        when Java::JavaSQL::Time
           Sequel.database_to_application_timestamp(v.to_string)
         when Java::JavaSQL::Date
           Sequel.string_to_date(v.to_string)


### PR DESCRIPTION
As you well know, Time.parse/DateTime.parse is quite slow.
