### PR TITLE
Fixing the parsing of bigint(\d+) unsigned as Bignum

### DIFF
--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -122,7 +122,7 @@ END_MIG
         {:type=>Integer}
       when /\Atinyint(?:\((\d+)\))?\z/o
         {:type =>schema[:type] == :boolean ? TrueClass : Integer}
-      when /\Abigint(?:\((?:\d+)\))?\z/o
+      when /\Abigint(?:\((?:\d+)\))?(?: unsigned)?\z/o
         {:type=>Bignum}
       when /\A(?:real|float|double(?: precision)?)\z/o
         {:type=>Float}


### PR DESCRIPTION
This is a fix for the problem outlined in: http://code.google.com/p/ruby-sequel/issues/detail?id=327
