### PR TITLE
fix Dataset#split_symbol. it accept not involving [\w ] character.

### DIFF
--- a/lib/sequel/dataset/sql.rb
+++ b/lib/sequel/dataset/sql.rb
@@ -177,9 +177,9 @@ module Sequel
     BOOL_FALSE = "'f'".freeze
     BOOL_TRUE = "'t'".freeze
     COMMA_SEPARATOR = ', '.freeze
-    COLUMN_REF_RE1 = /\A([\w ]+)__([\w ]+)___([\w ]+)\z/.freeze
-    COLUMN_REF_RE2 = /\A([\w ]+)___([\w ]+)\z/.freeze
-    COLUMN_REF_RE3 = /\A([\w ]+)__([\w ]+)\z/.freeze
+    COLUMN_REF_RE1 = /\A([^(__)]+)__([^(___)]+)___(.+)\z/.freeze
+    COLUMN_REF_RE2 = /\A([^(___)]+)___(.+)\z/.freeze
+    COLUMN_REF_RE3 = /\A([^(__)]+)__(.+)\z/.freeze
     COUNT_FROM_SELF_OPTS = [:distinct, :group, :sql, :limit, :compounds]
     COUNT_OF_ALL_AS_COUNT = SQL::Function.new(:count, LiteralString.new('*'.freeze)).as(:count)
     DATASET_ALIAS_BASE_NAME = 't'.freeze

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -927,22 +927,23 @@ describe "Dataset#literal" do
     @dataset.literal(1).should == "1"
     @dataset.literal(1.5).should == "1.5"
   end
-  
+
   specify "should literalize nil as NULL" do
     @dataset.literal(nil).should == "NULL"
   end
-  
+
   specify "should literalize an array properly" do
     @dataset.literal([]).should == "(NULL)"
     @dataset.literal([1, 'abc', 3]).should == "(1, 'abc', 3)"
     @dataset.literal([1, "a'b''c", 3]).should == "(1, 'a''b''''c', 3)"
   end
-  
+
   specify "should literalize symbols as column references" do
     @dataset.literal(:name).should == "name"
     @dataset.literal(:items__name).should == "items.name"
+    @dataset.literal(:"items__na#m$e").should == "items.na#m$e"
   end
-  
+
   specify "should call sql_literal with dataset on type if not natively supported and the object responds to it" do
     @a = Class.new do
       def sql_literal(ds)
@@ -1114,10 +1115,16 @@ describe "Dataset#from" do
   specify "should accept :schema__table___alias symbol format" do
     @dataset.from(:abc__def).select_sql.should ==
       "SELECT * FROM abc.def"
+    @dataset.from(:'#__#').select_sql.should ==
+      'SELECT * FROM #.#'
     @dataset.from(:abc__def___d).select_sql.should ==
       "SELECT * FROM abc.def AS d"
+    @dataset.from(:'#__#___#').select_sql.should ==
+      'SELECT * FROM #.# AS #'
     @dataset.from(:abc___def).select_sql.should ==
       "SELECT * FROM abc AS def"
+    @dataset.from(:'#___#').select_sql.should ==
+      'SELECT * FROM # AS #'
   end
 end
 


### PR DESCRIPTION
Hi.

I treat legacy DB, and it table name and column name were Japanese language(sigh).
I tried the following code.

```
    DB.literal(:あ__い___う)  # = ""あ__い___う""
```

I want the following result.

```
    DB.literal(:あ__い___う)  # = ""あ"."い" "う""
```

So, I fixed it.

Thanks.
