### PR TITLE
Fix fetching rows with tinytds adapter when identifier_output_method is nil

### DIFF
--- a/lib/sequel/adapters/tinytds.rb
+++ b/lib/sequel/adapters/tinytds.rb
@@ -107,7 +107,7 @@ module Sequel
                 yield r
               end
             else
-              result.each(each_opts, &block)
+              result.each(each_opts, &Proc.new)
             end
           end
         end


### PR DESCRIPTION
In the tinytds adaptor the fetch_rows method is attempting to pass a non-existant 'block' variable to results.each when identifier_output_method is nil.

I've fixed this by replacing the reference to block with a call to `Proc.new` without any arguments, this should magically pick up the block passed to the fetch_rows method, create a proc, and pass it on.

I know it looks a little unusual, but I'm guessing it's better that appending `&block` to fetch_rows arguments, and needlessly creating an expensive proc in the case where identifier_output_method is set
