### PR TITLE
Speed up queries using old versions of MSSQL

### DIFF
--- a/lib/sequel/adapters/ado.rb
+++ b/lib/sequel/adapters/ado.rb
@@ -6,6 +6,11 @@ module Sequel
     class Database < Sequel::Database
       set_adapter_scheme :ado
 
+      # Whether all strings should be prefixed with "N" to imply treat as
+      # unicode strings. True by default, can be set to false to greatly
+      # increase performance depending on your database configuration.
+      attr_accessor :mssql_unicode_strings
+
       def initialize(opts)
         super
         case @opts[:conn_string]
@@ -20,6 +25,7 @@ module Sequel
             extend Sequel::ADO::MSSQL::DatabaseMethods
           end
         end
+        @mssql_unicode_strings = typecast_value_boolean(@opts.fetch(:mssql_unicode_strings, true))
       end
 
       # In addition to the usual database options,
@@ -92,6 +98,17 @@ module Sequel
     end
     
     class Dataset < Sequel::Dataset
+      # Whether all strings should be prefixed with "N" to imply treat as
+      # unicode strings. True by default, can be set to false to greatly
+      # increase performance depending on your database configuration.
+      attr_accessor :mssql_unicode_strings
+
+      # Use the mssql_unicode_strings default setting from the database
+      def initialize(db, opts={})
+        @mssql_unicode_strings = db.mssql_unicode_strings
+        super
+      end
+
       def fetch_rows(sql)
         execute(sql) do |s|
           @columns = cols = s.Fields.extend(Enumerable).map{|column| output_identifier(column.Name)}

--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -101,6 +101,11 @@ module Sequel
       # True by default, can be set to false to roughly double performance when
       # fetching rows.
       attr_accessor :convert_types
+
+      # Whether all strings should be prefixed with "N" to imply treat as
+      # unicode strings. True by default, can be set to false to greatly
+      # increase performance depending on your database configuration.
+      attr_accessor :mssql_unicode_strings
       
       # Call the DATABASE_SETUP proc directly after initialization,
       # so the object always uses sub adapter specific code.  Also,
@@ -109,6 +114,7 @@ module Sequel
       def initialize(opts)
         super
         @convert_types = typecast_value_boolean(@opts.fetch(:convert_types, true))
+        @mssql_unicode_strings = typecast_value_boolean(@opts.fetch(:mssql_unicode_strings, true))
         raise(Error, "No connection string specified") unless uri
         
         resolved_uri = jndi? ? get_uri_from_jndi : uri
@@ -530,10 +536,17 @@ module Sequel
       # Uses the database's setting by default, can be set to false to roughly
       # double performance when fetching rows.
       attr_accessor :convert_types
+
+      # Whether all strings should be prefixed with "N" to imply treat as
+      # unicode strings. True by default, can be set to false to greatly
+      # increase performance depending on your database configuration.
+      attr_accessor :mssql_unicode_strings
       
       # Use the convert_types default setting from the database
+      # Use the mssql_unicode_strings default setting from the database
       def initialize(db, opts={})
         @convert_types = db.convert_types
+        @mssql_unicode_strings = db.mssql_unicode_strings
         super
       end
       

--- a/lib/sequel/adapters/odbc.rb
+++ b/lib/sequel/adapters/odbc.rb
@@ -9,6 +9,11 @@ module Sequel
       DRV_NAME_GUARDS = '{%s}'.freeze
       DISCONNECT_ERRORS = /\A08S01/.freeze 
 
+      # Whether all strings should be prefixed with "N" to imply treat as
+      # unicode strings. True by default, can be set to false to greatly
+      # increase performance depending on your database configuration.
+      attr_accessor :mssql_unicode_strings
+
       def initialize(opts)
         super
         case @opts[:db_type]
@@ -19,6 +24,7 @@ module Sequel
           Sequel.ts_require 'adapters/shared/progress'
           extend Sequel::Progress::DatabaseMethods
         end
+        @mssql_unicode_strings = typecast_value_boolean(@opts.fetch(:mssql_unicode_strings, true))
       end
 
       def connect(server)
@@ -86,6 +92,17 @@ module Sequel
       BOOL_FALSE = '0'.freeze
       ODBC_DATE_FORMAT = "{d '%Y-%m-%d'}".freeze
       TIMESTAMP_FORMAT="{ts '%Y-%m-%d %H:%M:%S'}".freeze
+
+      # Whether all strings should be prefixed with "N" to imply treat as
+      # unicode strings. True by default, can be set to false to greatly
+      # increase performance depending on your database configuration.
+      attr_accessor :mssql_unicode_strings
+
+      # Use the mssql_unicode_strings default setting from the database
+      def initialize(db, opts={})
+        @mssql_unicode_strings = db.mssql_unicode_strings
+        super
+      end
 
       def fetch_rows(sql)
         execute(sql) do |s|

--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -14,7 +14,7 @@ module Sequel
       # The types to check for 0 scale to transform :decimal types
       # to :integer.
       DECIMAL_TYPE_RE = /number|numeric|decimal/io
-      
+
       # Microsoft SQL Server uses the :mssql type.
       def database_type
         :mssql
@@ -441,9 +441,12 @@ module Sequel
         blob
       end
       
-      # Use unicode string syntax for all strings. Don't double backslashes.
+      # Optionally use unicode string syntax for all strings. Don't double
+      # backslashes.
       def literal_string(v)
-        "N'#{v.gsub(/'/, "''")}'"
+        str = "'#{v.gsub(/'/, "''")}'"
+        str = "N#{str}" unless @mssql_unicode_strings == false
+        str
       end
       
       # Use 0 for false on MSSQL

--- a/spec/adapters/mssql_opts_spec.rb
+++ b/spec/adapters/mssql_opts_spec.rb
@@ -1,0 +1,54 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), 'spec_helper.rb')
+
+if RUBY_PLATFORM =~ /java/
+  describe "JDBC" do
+    context "mssql_unicode_strings is default/true" do
+      let(:db) { Sequel.jdbc("jdbc:sqlserver://localhost") }
+      subject  { db[:tb1].filter(:col1 => "test").sql }
+
+      it { should == "SELECT * FROM TB1 WHERE (COL1 = N'test')" }
+    end
+
+    context "mssql_unicode_strings is false" do
+      let(:db) { Sequel.jdbc("jdbc:sqlserver://localhost",
+                            :mssql_unicode_strings => false) }
+      subject  { db[:tb1].filter(:col1 => "test").sql }
+
+      it { should == "SELECT * FROM TB1 WHERE (COL1 = 'test')" }
+    end
+  end
+else
+  describe "ADO" do
+    context "mssql_unicode_strings is default/true" do
+      let(:db) { Sequel.ado(:conn_string => "dummy connection string") }
+      subject  { db[:tb1].filter(:col1 => "test").sql }
+
+      it { should == "SELECT * FROM TB1 WHERE (COL1 = N'test')" }
+    end
+
+    context "mssql_unicode_strings is false" do
+      let(:db) { Sequel.ado(:conn_string => "dummy connection string",
+                            :mssql_unicode_strings => false) }
+      subject  { db[:tb1].filter(:col1 => "test").sql }
+
+      it { should == "SELECT * FROM TB1 WHERE (COL1 = 'test')" }
+    end
+  end
+
+  describe "ODBC" do
+    context "mssql_unicode_strings is default/true" do
+      let(:db) { Sequel.odbc("dummy", :db_type => "mssql") }
+      subject  { db[:tb1].filter(:col1 => "test").sql }
+
+      it { should == "SELECT * FROM TB1 WHERE (COL1 = N'test')" }
+    end
+
+    context "mssql_unicode_strings is false" do
+      let(:db) { Sequel.odbc("dummy", :db_type => "mssql",
+                            :mssql_unicode_strings => false) }
+      subject  { db[:tb1].filter(:col1 => "test").sql }
+
+      it { should == "SELECT * FROM TB1 WHERE (COL1 = 'test')" }
+    end
+  end
+end


### PR DESCRIPTION
add :mssql_unicode_strings opt to mssql db's to enable/disable unicode prefix

This change can greatly improve the speed of queries using older versions of mssql. In my testing, I got speed up's of 10x-100x. I couldn't come to a good solution to update Database#initialize and Dataset#initialize in lib/adapters/shared/mssql.rb, so the code for setting the option is found in the ADO, JDBC and ODBC adapters
