### PR TITLE
Some fixes in IdentityMap plugin

### DIFF
--- a/lib/sequel/plugins/identity_map.rb
+++ b/lib/sequel/plugins/identity_map.rb
@@ -111,9 +111,7 @@ module Sequel
       end
 
       def self.apply(base)
-        unless Sequel::Model.kind_of?(CommonModelMethods)
-          Sequel::Model.send(:include, CommonModelMethods)
-        end
+        Sequel::Model.send(:include, CommonModelMethods)
       end
 
       module CommonModelMethods


### PR DESCRIPTION
First commit fixes check for primary key - currently association_reflection[:primary_key] is not filled by default but lazy filled in method, so that check failed (at least in rails development mode).

Second commit fixes issue that model which had not called `plugin :identity_map` does not respect identity map of associated object. I don't really know, is including methods streight to Sequel::Model a best solution? but it just works.
