### PR TITLE
Misleading error message doesn't hint on how to fix the problem

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -162,7 +162,7 @@ module Sequel
       def db
         return @db if @db
         @db = self == Model ? DATABASES.first : superclass.db
-        raise(Error, "No database associated with #{self}") unless @db
+        raise(Error, "No database associated with #{self}: have you called Sequel#connect or #{self}#db= ?") unless @db
         @db
       end
       


### PR DESCRIPTION
I thought this message was misleading. My real error was I had never called Sequel#connect, not that the database server was absent, unreachable or that the database doesn't exist. Actually, when I read the message the first time I started digging in my PostgreSQL instance to ensure the database and tables existed.

I can't find a spec that checks for that error. I actually removed the spec, and no specs failed. I don't see how this could be spec'd either.

Reproduction recipe:

``` ruby
require "rubygems"
require "sequel"
require "jdbc/postgres"  
class A < Sequel::Model(:a); end
Sequel::Error: No database associated with Sequel::Model
    from /Users/francois/.rvm/gems/jruby-1.6.0/gems/sequel-3.22.0/lib/sequel/model/base.rb:165:in `db'
    from /Users/francois/.rvm/gems/jruby-1.6.0/gems/sequel-3.22.0/lib/sequel/model/base.rb:271:in `inherited'
    from /Users/francois/.rvm/gems/jruby-1.6.0/gems/sequel-3.22.0/lib/sequel/model/associations.rb:696:in `inherited'
    from org/jruby/RubyClass.java:837:in `initialize'
    from /Users/francois/.rvm/gems/jruby-1.6.0/gems/sequel-3.22.0/lib/sequel/model.rb:43:in `Model'
    from (irb):5:in `evaluate'
    from org/jruby/RubyKernel.java:1087:in `eval'
    from /Users/francois/.rvm/rubies/jruby-1.6.0/lib/ruby/1.8/irb.rb:158:in `eval_input'
    from /Users/francois/.rvm/rubies/jruby-1.6.0/lib/ruby/1.8/irb.rb:271:in `signal_status'
    from /Users/francois/.rvm/rubies/jruby-1.6.0/lib/ruby/1.8/irb.rb:155:in `eval_input'
    from org/jruby/RubyKernel.java:1417:in `loop'
    from org/jruby/RubyKernel.java:1190:in `catch'
    from /Users/francois/.rvm/rubies/jruby-1.6.0/lib/ruby/1.8/irb.rb:154:in `eval_input'
    from /Users/francois/.rvm/rubies/jruby-1.6.0/lib/ruby/1.8/irb.rb:71:in `start'
    from org/jruby/RubyKernel.java:1190:in `catch'
    from /Users/francois/.rvm/rubies/jruby-1.6.0/lib/ruby/1.8/irb.rb:70:in `start'
    from /Users/francois/.rvm/rubies/jruby-1.6.0/bin/irb:17:in `(root)'
```
