### PR TITLE
updates db2 to use 'FETCH FIRST' syntax when limiting results

### DIFF
--- a/lib/sequel/adapters/db2.rb
+++ b/lib/sequel/adapters/db2.rb
@@ -93,6 +93,14 @@ module Sequel
       def supports_window_functions?
         true
       end
+
+      # Modify the sql to limit the number of rows returned
+      def select_limit_sql(sql)
+        if @opts[:limit]
+          sql << " FETCH FIRST ROW ONLY" if @opts[:limit] == 1
+          sql << " FETCH FIRST #{@opts[:limit]} ROWS ONLY" if @opts[:limit] > 1
+        end
+      end
       
       private
 


### PR DESCRIPTION
Pretty small patch to update the db2 adapter to use 'FETCH FIRST N ROWS ONLY' syntax when limiting results. Just like the as400 adapter.
