### PR TITLE
Support BIT(1) type as boolean in MySQL adapter

### DIFF
--- a/lib/sequel/adapters/mysql.rb
+++ b/lib/sequel/adapters/mysql.rb
@@ -30,7 +30,8 @@ module Sequel
       [0, 246]  => tt.method(:decimal),
       [2, 3, 8, 9, 13, 247, 248]  => tt.method(:integer),
       [4, 5]  => tt.method(:float),
-      [249, 250, 251, 252]  => tt.method(:blob)
+      [249, 250, 251, 252]  => tt.method(:blob),
+      [16] => tt.method(:boolean)
     }.each do |k,v|
       k.each{|n| MYSQL_TYPES[n] = v}
     end


### PR DESCRIPTION
Hi,

Subject says it all. Previously a string was returned with binary in it.

Regards,

Alex
