### PR TITLE
Implement more informative error messages for attempts to set restricted columns

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1488,7 +1488,15 @@ module Sequel
           if meths.include?(m)
             send(m, v)
           elsif strict
-            raise Error, "method #{m} doesn't exist or access is restricted to it"
+            if respond_to?(m)
+              if Array(model.primary_key).member?(k) && model.restrict_primary_key?
+                raise Error, "#{k} is a restricted primary key"
+              else
+                raise Error, "#{k} is a restricted column"
+              end
+            else
+              raise Error, "method #{m} doesn't exist"
+            end
           end
         end
         self


### PR DESCRIPTION
Pretty straightforward. I considered adding a hint to call "unrestrict_primary_key", too, but I couldn't think of a way to phrase it without sounding encouraging.
