### PR TITLE
select_remove method for altering statements in reverse of existing select_append method

### DIFF
--- a/lib/sequel/dataset/query.rb
+++ b/lib/sequel/dataset/query.rb
@@ -12,7 +12,7 @@ module Sequel
     # Which options don't affect the SQL generation.  Used by simple_select_all?
     # to determine if this is a simple SELECT * FROM table.
     NON_SQL_OPTIONS = [:server, :defaults, :overrides, :graph, :eager_graph, :graph_aliases]
-    
+
     # These symbols have _join methods created (e.g. inner_join) that
     # call join_table with the symbol, passing along the arguments and
     # block from the method call.
@@ -23,10 +23,10 @@ module Sequel
     # argument which is passed to join_table, and they raise an error
     # if called with a block.
     UNCONDITIONED_JOIN_TYPES = [:natural, :natural_left, :natural_right, :natural_full, :cross]
-    
+
     # All methods that return modified datasets with a joined table added.
     JOIN_METHODS = (CONDITIONED_JOIN_TYPES + UNCONDITIONED_JOIN_TYPES).map{|x| "#{x}_join".to_sym} + [:join, :join_table]
-    
+
     # Methods that return modified datasets
     QUERY_METHODS = %w'add_graph_aliases and distinct except exclude exclude_having exclude_where
     filter for_update from from_self graph grep group group_and_count group_by having intersect invert
@@ -35,7 +35,7 @@ module Sequel
     set_defaults set_graph_aliases set_overrides unfiltered ungraphed ungrouped union
     unlimited unordered where with with_recursive with_sql'.collect{|x| x.to_sym} + JOIN_METHODS
 
-    # Adds an further filter to an existing filter using AND. If no filter 
+    # Adds an further filter to an existing filter using AND. If no filter
     # exists an error is raised. This method is identical to #filter except
     # it expects an existing filter.
     #
@@ -44,7 +44,7 @@ module Sequel
       raise(InvalidOperation, "No existing filter found.") unless @opts[:having] || @opts[:where]
       filter(*cond, &block)
     end
-    
+
     # Returns a new clone of the dataset with with the given options merged.
     # If the options changed include options in COLUMN_CHANGE_OPTS, the cached
     # columns are deleted.  This method should generally not be called
@@ -99,7 +99,7 @@ module Sequel
     #
     #   DB[:items].exclude(:category => 'software')
     #   # SELECT * FROM items WHERE (category != 'software')
-    #   
+    #
     #   DB[:items].exclude(:category => 'software', :id=>3)
     #   # SELECT * FROM items WHERE ((category != 'software') OR (id != 3))
     def exclude(*cond, &block)
@@ -128,10 +128,10 @@ module Sequel
       _filter_or_exclude(true, :where, *cond, &block)
     end
 
-    # Returns a copy of the dataset with the given conditions imposed upon it.  
-    # If the query already has a HAVING clause, then the conditions are imposed in the 
+    # Returns a copy of the dataset with the given conditions imposed upon it.
+    # If the query already has a HAVING clause, then the conditions are imposed in the
     # HAVING clause. If not, then they are imposed in the WHERE clause.
-    # 
+    #
     # filter accepts the following argument types:
     #
     # * Hash - list of equality/inclusion expressions
@@ -173,7 +173,7 @@ module Sequel
     #
     #   DB[:items].filter{price < 100}
     #   # SELECT * FROM items WHERE (price < 100)
-    # 
+    #
     # Multiple filter calls can be chained for scoping:
     #
     #   software = dataset.filter(:category => 'software').filter{price < 100}
@@ -183,7 +183,7 @@ module Sequel
     def filter(*cond, &block)
       _filter(@opts[:having] ? :having : :where, *cond, &block)
     end
-    
+
     # Returns a cloned dataset with a :update lock style.
     #
     #   DB[:table].for_update # SELECT * FROM table FOR UPDATE
@@ -286,7 +286,7 @@ module Sequel
       end
     end
 
-    # Returns a copy of the dataset with the results grouped by the value of 
+    # Returns a copy of the dataset with the results grouped by the value of
     # the given columns.  If a block is given, it is treated
     # as a virtual row block, similar to +filter+.
     #
@@ -302,7 +302,7 @@ module Sequel
     def group_by(*columns, &block)
       group(*columns, &block)
     end
-    
+
     # Returns a dataset grouped by the given column with count by group.
     # Column aliases may be supplied, and will be included in the select clause.
     # If a block is given, it is treated as a virtual row block, similar to +filter+.
@@ -310,7 +310,7 @@ module Sequel
     # Examples:
     #
     #   DB[:items].group_and_count(:name).all
-    #   # SELECT name, count(*) AS count FROM items GROUP BY name 
+    #   # SELECT name, count(*) AS count FROM items GROUP BY name
     #   # => [{:name=>'a', :count=>1}, ...]
     #
     #   DB[:items].group_and_count(:first_name, :last_name).all
@@ -335,7 +335,7 @@ module Sequel
     def having(*cond, &block)
       _filter(:having, *cond, &block)
     end
-    
+
     # Adds an INTERSECT clause using a second dataset object.
     # An INTERSECT compound dataset returns all rows in both the current dataset
     # and the given dataset.
@@ -398,7 +398,7 @@ module Sequel
     #     :implicit_qualifier option).
     #     To specify multiple conditions on a single joined table column, you must use an array.
     #     Uses a JOIN with an ON clause.
-    #   * Array - If all members of the array are symbols, considers them as columns and 
+    #   * Array - If all members of the array are symbols, considers them as columns and
     #     uses a JOIN with a USING clause.  Most databases will remove duplicate columns from
     #     the result set if this is used.
     #   * nil - If a block is not given, doesn't use ON or USING, so the JOIN should be a NATURAL
@@ -446,7 +446,7 @@ module Sequel
         last_alias = options[:implicit_qualifier]
       when Symbol, String, SQL::Identifier
         table_alias = options
-        last_alias = nil 
+        last_alias = nil
       else
         raise Error, "invalid options format for join_table: #{options.inspect}"
       end
@@ -490,7 +490,7 @@ module Sequel
       opts[:num_dataset_sources] = table_alias_num if table_alias_num
       clone(opts)
     end
-    
+
     CONDITIONED_JOIN_TYPES.each do |jtype|
       class_eval("def #{jtype}_join(*args, &block); join_table(:#{jtype}, *args, &block) end", __FILE__, __LINE__)
     end
@@ -529,7 +529,7 @@ module Sequel
       end
       clone(opts)
     end
-    
+
     # Returns a cloned dataset with the given lock style.  If style is a
     # string, it will be used directly.  Otherwise, a symbol may be used
     # for database independent locking.  Currently :update is respected
@@ -539,7 +539,7 @@ module Sequel
     def lock_style(style)
       clone(:lock => style)
     end
-    
+
     # Returns a cloned dataset without a row_proc.
     #
     #   ds = DB[:items]
@@ -551,8 +551,8 @@ module Sequel
       ds.row_proc = nil
       ds
     end
-    
-    # Adds an alternate filter to an existing filter using OR. If no filter 
+
+    # Adds an alternate filter to an existing filter using OR. If no filter
     # exists an +Error+ is raised.
     #
     #   DB[:items].filter(:a).or(:b) # SELECT * FROM items WHERE a OR b
@@ -581,7 +581,7 @@ module Sequel
       virtual_row_columns(columns, block)
       clone(:order => (columns.compact.empty?) ? nil : columns)
     end
-    
+
     # Alias of order_more, for naming consistency with order_prepend.
     def order_append(*columns, &block)
       order_more(*columns, &block)
@@ -601,7 +601,7 @@ module Sequel
       columns = @opts[:order] + columns if @opts[:order]
       order(*columns, &block)
     end
-    
+
     # Returns a copy of the dataset with the order columns added
     # to the beginning of the existing order.
     #
@@ -611,7 +611,7 @@ module Sequel
       ds = order(*columns, &block)
       @opts[:order] ? ds.order_more(*@opts[:order]) : ds
     end
-    
+
     # Qualify to the given table, or first source if no table is given.
     #
     #   DB[:items].filter(:id=>1).qualify
@@ -640,7 +640,7 @@ module Sequel
       h[:select] = [SQL::ColumnAll.new(table)] if !o[:select] || o[:select].empty?
       clone(h)
     end
-    
+
     # Qualify the dataset to its current first source.  This is useful
     # if you have unqualified identifiers in the query that all refer to
     # the first source, and you want to join to another table which
@@ -652,7 +652,7 @@ module Sequel
     def qualify_to_first_source
       qualify_to(first_source)
     end
-    
+
     # Returns a copy of the dataset with the order reversed. If no order is
     # given, the existing order is inverted.
     #
@@ -683,7 +683,7 @@ module Sequel
       end
       clone(:select => m)
     end
-    
+
     # Returns a copy of the dataset selecting the wildcard if no arguments
     # are given.  If arguments are given, treat them as tables and select
     # all columns (using the wildcard) from each table.
@@ -698,7 +698,7 @@ module Sequel
         select(*tables.map{|t| SQL::ColumnAll.new(t)})
       end
     end
-    
+
     # Returns a copy of the dataset with the given columns added
     # to the existing selected columns.  If no columns are currently selected,
     # it will select the columns given in addition to *.
@@ -710,6 +710,19 @@ module Sequel
       cur_sel = @opts[:select]
       cur_sel = [WILDCARD] if !cur_sel || cur_sel.empty?
       select(*(cur_sel + columns), &block)
+    end
+
+    # Returns a copy of the dataset with the given columns removed
+    # from the existing selected columns.  If no columns are currently selected,
+    # it will simply return the wildcard
+    #
+    #   DB[:items].select(:a, :b).select_remove(:b) # SELECT a FROM items
+    #   DB[:items].select(:a, :b).select_remove(:c) # SELECT a, b FROM items
+    #   DB[:items].select_remove(:b) # SELECT * FROM items
+    def select_remove(*columns, &block)
+      cur_sel = @opts[:select]
+      cur_sel = [WILDCARD] if !cur_sel || cur_sel.empty?
+      select(*(cur_sel - columns), &block)
     end
 
     # Set both the select and group clauses with the given +columns+.
@@ -728,7 +741,7 @@ module Sequel
 
     # Returns a copy of the dataset with the given columns added
     # to the existing selected columns. If no columns are currently selected
-    # it will just select the columns given. 
+    # it will just select the columns given.
     #
     #   DB[:items].select(:a).select(:b) # SELECT b FROM items
     #   DB[:items].select(:a).select_more(:b) # SELECT a, b FROM items
@@ -737,14 +750,14 @@ module Sequel
       columns = @opts[:select] + columns if @opts[:select]
       select(*columns, &block)
     end
-    
+
     # Set the server for this dataset to use.  Used to pick a specific database
     # shard to run a query against, or to override the default (where SELECT uses
     # :read_only database and all other queries use the :default database).  This
     # method is always available but is only useful when database sharding is being
     # used.
     #
-    #   DB[:items].all # Uses the :read_only or :default server 
+    #   DB[:items].all # Uses the :read_only or :default server
     #   DB[:items].delete # Uses the :default server
     #   DB[:items].server(:blah).delete # Uses the :blah server
     def server(servr)
@@ -753,7 +766,7 @@ module Sequel
 
     # Set the default values for insert and update statements.  The values hash passed
     # to insert or update are merged into this hash, so any values in the hash passed
-    # to insert or update will override values passed to this method.  
+    # to insert or update will override values passed to this method.
     #
     #   DB[:items].set_defaults(:a=>'a', :c=>'c').insert(:a=>'d', :b=>'b')
     #   # INSERT INTO items (a, c, b) VALUES ('d', 'c', 'b')
@@ -770,7 +783,7 @@ module Sequel
     def set_overrides(hash)
       clone(:overrides=>hash.merge(@opts[:overrides]||{}))
     end
-    
+
     # Unbind bound variables from this dataset's filter and return an array of two
     # objects.  The first object is a modified dataset where the filter has been
     # replaced with one that uses bound variable placeholders.  The second object
@@ -788,7 +801,7 @@ module Sequel
     end
 
     # Returns a copy of the dataset with no filters (HAVING or WHERE clause) applied.
-    # 
+    #
     #   DB[:items].group(:a).having(:a=>1).where(:b).unfiltered
     #   # SELECT * FROM items GROUP BY a
     def unfiltered
@@ -796,7 +809,7 @@ module Sequel
     end
 
     # Returns a copy of the dataset with no grouping (GROUP or HAVING clause) applied.
-    # 
+    #
     #   DB[:items].group(:a).having(:a=>1).where(:b).ungrouped
     #   # SELECT * FROM items WHERE b
     def ungrouped
@@ -823,21 +836,21 @@ module Sequel
       opts = {:all=>opts} unless opts.is_a?(Hash)
       compound_clone(:union, dataset, opts)
     end
-    
+
     # Returns a copy of the dataset with no limit or offset.
-    # 
+    #
     #   DB[:items].limit(10, 20).unlimited # SELECT * FROM items
     def unlimited
       clone(:limit=>nil, :offset=>nil)
     end
 
     # Returns a copy of the dataset with no order.
-    # 
+    #
     #   DB[:items].order(:a).unordered # SELECT * FROM items
     def unordered
       order(nil)
     end
-    
+
     # Add a condition to the WHERE clause.  See +filter+ for argument types.
     #
     #   DB[:items].group(:a).having(:a).filter(:b)
@@ -848,7 +861,7 @@ module Sequel
     def where(*cond, &block)
       _filter(:where, *cond, &block)
     end
-    
+
     # Add a common table expression (CTE) with the given name and a dataset that defines the CTE.
     # A common table expression acts as an inline view for the query.
     # Options:
@@ -883,7 +896,7 @@ module Sequel
       raise(Error, 'This datatset does not support common table expressions') unless supports_cte?
       clone(:with=>(@opts[:with]||[]) + [opts.merge(:recursive=>true, :name=>name, :dataset=>nonrecursive.union(recursive, {:all=>opts[:union_all] != false, :from_self=>false}))])
     end
-    
+
     # Returns a copy of the dataset with the static SQL used.  This is useful if you want
     # to keep the same row_proc/graph, but change the SQL used to custom SQL.
     #
@@ -892,7 +905,7 @@ module Sequel
       sql = SQL::PlaceholderLiteralString.new(sql, args) unless args.empty?
       clone(:sql=>sql)
     end
-    
+
     protected
 
     # Return true if the dataset has a non-nil value for any key in opts.
@@ -931,7 +944,7 @@ module Sequel
     def virtual_row_columns(columns, block)
       columns.concat(Array(Sequel.virtual_row(&block))) if block
     end
-    
+
     # Add the dataset to the list of compounds
     def compound_clone(type, dataset, opts)
       ds = compound_from_self.clone(:compounds=>Array(@opts[:compounds]).map{|x| x.dup} + [[type, dataset.compound_from_self, opts[:all]]])
@@ -960,7 +973,7 @@ module Sequel
       when Proc
         filter_expr(Sequel.virtual_row(&expr))
       when SQL::NumericExpression, SQL::StringExpression
-        raise(Error, "Invalid SQL Expression type: #{expr.inspect}") 
+        raise(Error, "Invalid SQL Expression type: #{expr.inspect}")
       when Symbol, SQL::Expression
         expr
       when TrueClass, FalseClass
@@ -971,7 +984,7 @@ module Sequel
         raise(Error, 'Invalid filter argument')
       end
     end
-    
+
     # Inverts the given order by breaking it into a list of column references
     # and inverting them.
     #

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -4,20 +4,20 @@ describe "Dataset" do
   before do
     @dataset = Sequel::Dataset.new("db")
   end
-  
+
   specify "should accept database and opts in initialize" do
     db = "db"
     opts = {:from => :test}
     d = Sequel::Dataset.new(db, opts)
     d.db.should be(db)
     d.opts.should be(opts)
-    
+
     d = Sequel::Dataset.new(db)
     d.db.should be(db)
     d.opts.should be_a_kind_of(Hash)
     d.opts.should == {}
   end
-  
+
   specify "should provide clone for chainability" do
     d1 = @dataset.clone(:from => [:test])
     d1.class.should == @dataset.class
@@ -25,7 +25,7 @@ describe "Dataset" do
     d1.db.should be(@dataset.db)
     d1.opts[:from].should == [:test]
     @dataset.opts[:from].should be_nil
-    
+
     d2 = d1.clone(:order => [:name])
     d2.class.should == @dataset.class
     d2.should_not == d1
@@ -35,11 +35,11 @@ describe "Dataset" do
     d2.opts[:order].should == [:name]
     d1.opts[:order].should be_nil
   end
-  
+
   specify "should include Enumerable" do
     Sequel::Dataset.included_modules.should include(Enumerable)
   end
-  
+
   specify "should get quote_identifiers default from database" do
     db = Sequel::Database.new(:quote_identifiers=>true)
     db[:a].quote_identifiers?.should == true
@@ -66,14 +66,14 @@ describe "Dataset" do
   before do
     @dataset = Sequel::Dataset.new("db")
   end
-  
+
   specify "should have quote_identifiers= method which changes literalization of identifiers" do
     @dataset.quote_identifiers = true
     @dataset.literal(:a).should == '"a"'
     @dataset.quote_identifiers = false
     @dataset.literal(:a).should == 'a'
   end
-  
+
   specify "should have identifier_input_method= method which changes literalization of identifiers" do
     @dataset.identifier_input_method = :upcase
     @dataset.literal(:a).should == 'A'
@@ -82,7 +82,7 @@ describe "Dataset" do
     @dataset.identifier_input_method = :reverse
     @dataset.literal(:at_b).should == 'b_ta'
   end
-  
+
   specify "should have identifier_output_method= method which changes identifiers returned from the database" do
     @dataset.send(:output_identifier, "at_b_C").should == :at_b_C
     @dataset.identifier_output_method = :upcase
@@ -92,7 +92,7 @@ describe "Dataset" do
     @dataset.identifier_output_method = :reverse
     @dataset.send(:output_identifier, "at_b_C").should == :C_b_ta
   end
-  
+
   specify "should have output_identifier handle empty identifiers" do
     @dataset.send(:output_identifier, "").should == :untitled
     @dataset.identifier_output_method = :upcase
@@ -108,7 +108,7 @@ describe "Dataset#clone" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:items)
   end
-  
+
   specify "should create an exact copy of the dataset" do
     @dataset.row_proc = Proc.new{|r| r}
     @clone = @dataset.clone
@@ -118,7 +118,7 @@ describe "Dataset#clone" do
     @clone.opts.should == @dataset.opts
     @clone.row_proc.should == @dataset.row_proc
   end
-  
+
   specify "should deep-copy the dataset opts" do
     @clone = @dataset.clone
 
@@ -126,30 +126,30 @@ describe "Dataset#clone" do
     @dataset.filter!(:a => 'b')
     @clone.opts[:filter].should be_nil
   end
-  
+
   specify "should return a clone self" do
     clone = @dataset.clone({})
     clone.class.should == @dataset.class
     clone.db.should == @dataset.db
     clone.opts.should == @dataset.opts
   end
-  
+
   specify "should merge the specified options" do
     clone = @dataset.clone(1 => 2)
     clone.opts.should == {1 => 2, :from => [:items]}
   end
-  
+
   specify "should overwrite existing options" do
     clone = @dataset.clone(:from => [:other])
     clone.opts.should == {:from => [:other]}
   end
-  
+
   specify "should create a clone with a deep copy of options" do
     clone = @dataset.clone(:from => [:other])
     @dataset.opts[:from].should == [:items]
     clone.opts[:from].should == [:other]
   end
-  
+
   specify "should return an object with the same modules included" do
     m = Module.new do
       def __xyz__; "xyz"; end
@@ -164,7 +164,7 @@ describe "Dataset#==" do
     @db = MockDatabase.new
     @h = {}
   end
-  
+
   specify "should be the true for dataset with the same db, opts, and SQL" do
     @db[:t].should == @db[:t]
   end
@@ -172,11 +172,11 @@ describe "Dataset#==" do
   specify "should be different for datasets with different dbs" do
     @db[:t].should_not == MockDatabase.new[:t]
   end
-  
+
   specify "should be different for datasets with different opts" do
     @db[:t].should_not == @db[:t].clone(:blah=>1)
   end
-  
+
   specify "should be different for datasets with different SQL" do
     ds = @db[:t]
     ds.quote_identifiers = true
@@ -189,7 +189,7 @@ describe "Dataset#hash" do
     @db = MockDatabase.new
     @h = {}
   end
-  
+
   specify "should be the same for dataset with the same db, opts, and SQL" do
     @db[:t].hash.should == @db[:t].hash
     @h[@db[:t]] = 1
@@ -199,11 +199,11 @@ describe "Dataset#hash" do
   specify "should be different for datasets with different dbs" do
     @db[:t].hash.should_not == MockDatabase.new[:t].hash
   end
-  
+
   specify "should be different for datasets with different opts" do
     @db[:t].hash.should_not == @db[:t].clone(:blah=>1).hash
   end
-  
+
   specify "should be different for datasets with different SQL" do
     ds = @db[:t]
     ds.quote_identifiers = true
@@ -215,23 +215,23 @@ describe "A simple dataset" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should format a select statement" do
     @dataset.select_sql.should == 'SELECT * FROM test'
   end
-  
+
   specify "should format a delete statement" do
     @dataset.delete_sql.should == 'DELETE FROM test'
   end
-  
+
   specify "should format a truncate statement" do
     @dataset.truncate_sql.should == 'TRUNCATE TABLE test'
   end
-  
+
   specify "should format an insert statement with default values" do
     @dataset.insert_sql.should == 'INSERT INTO test DEFAULT VALUES'
   end
-  
+
   specify "should format an insert statement with hash" do
     @dataset.insert_sql(:name => 'wxyz', :price => 342).
       should match(/INSERT INTO test \(name, price\) VALUES \('wxyz', 342\)|INSERT INTO test \(price, name\) VALUES \(342, 'wxyz'\)/)
@@ -243,34 +243,34 @@ describe "A simple dataset" do
     @dataset.insert_sql('name' => 'wxyz', 'price' => 342).
       should match(/INSERT INTO test \(name, price\) VALUES \('wxyz', 342\)|INSERT INTO test \(price, name\) VALUES \(342, 'wxyz'\)/)
   end
-  
+
   specify "should format an insert statement with an object that respond_to? :values" do
     dbb = Sequel::Database.new
-    
+
     v = Object.new
     def v.values; {:a => 1}; end
-    
+
     @dataset.insert_sql(v).should == "INSERT INTO test (a) VALUES (1)"
-    
+
     def v.values; {}; end
     @dataset.insert_sql(v).should == "INSERT INTO test DEFAULT VALUES"
   end
-  
+
   specify "should format an insert statement with an arbitrary value" do
     @dataset.insert_sql(123).should == "INSERT INTO test VALUES (123)"
   end
-  
+
   specify "should format an insert statement with sub-query" do
     @sub = Sequel::Dataset.new(nil).from(:something).filter(:x => 2)
     @dataset.insert_sql(@sub).should == \
       "INSERT INTO test SELECT * FROM something WHERE (x = 2)"
   end
-  
+
   specify "should format an insert statement with array" do
     @dataset.insert_sql('a', 2, 6.5).should ==
       "INSERT INTO test VALUES ('a', 2, 6.5)"
   end
-  
+
   specify "should format an update statement" do
     @dataset.update_sql(:name => 'abc').should ==
       "UPDATE test SET name = 'abc'"
@@ -305,7 +305,7 @@ describe "A dataset with multiple tables in its FROM clause" do
   specify "should raise on #delete_sql" do
     proc {@dataset.delete_sql}.should raise_error(Sequel::InvalidOperation)
   end
-  
+
   specify "should raise on #truncate_sql" do
     proc {@dataset.truncate_sql}.should raise_error(Sequel::InvalidOperation)
   end
@@ -323,7 +323,7 @@ describe "Dataset#unused_table_alias" do
   before do
     @ds = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should return given symbol if it hasn't already been used" do
     @ds.unused_table_alias(:blah).should == :blah
   end
@@ -352,7 +352,7 @@ describe "Dataset#exists" do
     @ds2 = @ds1.filter(:price.sql_number < 100)
     @ds3 = @ds1.filter(:price.sql_number > 50)
   end
-  
+
   specify "should work in filters" do
     @ds1.filter(@ds2.exists).sql.should ==
       'SELECT * FROM test WHERE (EXISTS (SELECT * FROM test WHERE (price < 100)))'
@@ -373,7 +373,7 @@ describe "Dataset#where" do
     @d2 = @dataset.where('region = ?', 'Asia')
     @d3 = @dataset.where("a = 1")
   end
-  
+
   specify "should just clone if given an empty argument" do
     @dataset.where({}).sql.should == @dataset.sql
     @dataset.where([]).sql.should == @dataset.sql
@@ -383,17 +383,17 @@ describe "Dataset#where" do
     @dataset.filter([]).sql.should == @dataset.sql
     @dataset.filter('').sql.should == @dataset.sql
   end
-  
+
   specify "should work with hashes" do
     @dataset.where(:name => 'xyz', :price => 342).select_sql.
       should match(/WHERE \(\(name = 'xyz'\) AND \(price = 342\)\)|WHERE \(\(price = 342\) AND \(name = 'xyz'\)\)/)
   end
-  
+
   specify "should work with a string with placeholders and arguments for those placeholders" do
     @dataset.where('price < ? AND id in ?', 100, [1, 2, 3]).select_sql.should ==
       "SELECT * FROM test WHERE (price < 100 AND id in (1, 2, 3))"
   end
-  
+
   specify "should not modify passed array with placeholders" do
     a = ['price < ? AND id in ?', 100, 1, 2, 3]
     b = a.dup
@@ -405,12 +405,12 @@ describe "Dataset#where" do
     @dataset.where('(a = 1 AND b = 2)').select_sql.should ==
       "SELECT * FROM test WHERE ((a = 1 AND b = 2))"
   end
-    
+
   specify "should work with a string with named placeholders and a hash of placeholder value arguments" do
     @dataset.where('price < :price AND id in :ids', :price=>100, :ids=>[1, 2, 3]).select_sql.should ==
       "SELECT * FROM test WHERE (price < 100 AND id in (1, 2, 3))"
   end
-    
+
   specify "should not modify passed array with named placeholders" do
     a = ['price < :price AND id in :ids', {:price=>100}]
     b = a.dup
@@ -422,72 +422,72 @@ describe "Dataset#where" do
     @dataset.where('price < :price AND id in :ids', :price=>100).select_sql.should ==
       "SELECT * FROM test WHERE (price < 100 AND id in :ids)"
   end
-    
+
   specify "should handle partial names" do
     @dataset.where('price < :price AND id = :p', :p=>2, :price=>100).select_sql.should ==
       "SELECT * FROM test WHERE (price < 100 AND id = 2)"
   end
-  
+
   specify "should affect select, delete and update statements" do
     @d1.select_sql.should == "SELECT * FROM test WHERE (region = 'Asia')"
     @d1.delete_sql.should == "DELETE FROM test WHERE (region = 'Asia')"
     @d1.update_sql(:GDP => 0).should == "UPDATE test SET GDP = 0 WHERE (region = 'Asia')"
-    
+
     @d2.select_sql.should == "SELECT * FROM test WHERE (region = 'Asia')"
     @d2.delete_sql.should == "DELETE FROM test WHERE (region = 'Asia')"
     @d2.update_sql(:GDP => 0).should == "UPDATE test SET GDP = 0 WHERE (region = 'Asia')"
-    
+
     @d3.select_sql.should == "SELECT * FROM test WHERE (a = 1)"
     @d3.delete_sql.should == "DELETE FROM test WHERE (a = 1)"
     @d3.update_sql(:GDP => 0).should == "UPDATE test SET GDP = 0 WHERE (a = 1)"
-    
+
   end
-  
+
   specify "should be composable using AND operator (for scoping)" do
     # hashes are merged, no problem
-    @d1.where(:size => 'big').select_sql.should == 
+    @d1.where(:size => 'big').select_sql.should ==
       "SELECT * FROM test WHERE ((region = 'Asia') AND (size = 'big'))"
-    
+
     # hash and string
     @d1.where('population > 1000').select_sql.should ==
       "SELECT * FROM test WHERE ((region = 'Asia') AND (population > 1000))"
     @d1.where('(a > 1) OR (b < 2)').select_sql.should ==
     "SELECT * FROM test WHERE ((region = 'Asia') AND ((a > 1) OR (b < 2)))"
-    
+
     # hash and array
-    @d1.where('GDP > ?', 1000).select_sql.should == 
+    @d1.where('GDP > ?', 1000).select_sql.should ==
       "SELECT * FROM test WHERE ((region = 'Asia') AND (GDP > 1000))"
-    
+
     # array and array
     @d2.where('GDP > ?', 1000).select_sql.should ==
       "SELECT * FROM test WHERE ((region = 'Asia') AND (GDP > 1000))"
-    
+
     # array and hash
     @d2.where(:name => ['Japan', 'China']).select_sql.should ==
       "SELECT * FROM test WHERE ((region = 'Asia') AND (name IN ('Japan', 'China')))"
-      
+
     # array and string
     @d2.where('GDP > ?').select_sql.should ==
       "SELECT * FROM test WHERE ((region = 'Asia') AND (GDP > ?))"
-    
+
     # string and string
     @d3.where('b = 2').select_sql.should ==
       "SELECT * FROM test WHERE ((a = 1) AND (b = 2))"
-    
+
     # string and hash
-    @d3.where(:c => 3).select_sql.should == 
+    @d3.where(:c => 3).select_sql.should ==
       "SELECT * FROM test WHERE ((a = 1) AND (c = 3))"
-      
+
     # string and array
     @d3.where('d = ?', 4).select_sql.should ==
       "SELECT * FROM test WHERE ((a = 1) AND (d = 4))"
   end
-      
+
   specify "should be composable using AND operator (for scoping) with block" do
     @d3.where{:e.sql_number < 5}.select_sql.should ==
       "SELECT * FROM test WHERE ((a = 1) AND (e < 5))"
   end
-  
+
   specify "should accept ranges" do
     @dataset.filter(:id => 4..7).sql.should ==
       'SELECT * FROM test WHERE ((id >= 4) AND (id <= 7))'
@@ -509,7 +509,7 @@ describe "Dataset#where" do
     @dataset.filter('gdp > ?', @d1.select(:avg.sql_function(:gdp))).sql.should ==
       "SELECT * FROM test WHERE (gdp > (SELECT avg(gdp) FROM test WHERE (region = 'Asia')))"
   end
-  
+
   specify "should handle all types of IN/NOT IN queries" do
     @dataset.filter(:id => @d1.select(:id)).sql.should == "SELECT * FROM test WHERE (id IN (SELECT id FROM test WHERE (region = 'Asia')))"
     @dataset.filter(:id => []).sql.should == "SELECT * FROM test WHERE (id != id)"
@@ -553,7 +553,7 @@ describe "Dataset#where" do
     @dataset.exclude([:id1, :id2] => d1).sql.should == "SELECT * FROM test WHERE (((id1 != 1) OR (id2 != 2)) AND ((id1 != 3) OR (id2 != 4)))"
     db.sqls.should == ["SELECT id1, id2 FROM test WHERE (region = 'Asia')"]
   end
-  
+
   specify "should handle IN/NOT IN queries with multiple columns and an empty dataset where the database doesn't support it" do
     @dataset.meta_def(:supports_multiple_column_in?){false}
     db = MockDatabase.new()
@@ -569,7 +569,7 @@ describe "Dataset#where" do
     @dataset.exclude([:id1, :id2] => d1).sql.should == "SELECT * FROM test WHERE (1 = 1)"
     db.sqls.should == ["SELECT id1, id2 FROM test WHERE (region = 'Asia')"]
   end
-  
+
   specify "should handle IN/NOT IN queries for datasets with row_procs" do
     @dataset.meta_def(:supports_multiple_column_in?){false}
     db = MockDatabase.new()
@@ -588,24 +588,24 @@ describe "Dataset#where" do
     @dataset.exclude([:id1, :id2] => d1).sql.should == "SELECT * FROM test WHERE (((id1 != 1) OR (id2 != 2)) AND ((id1 != 3) OR (id2 != 4)))"
     db.sqls.should == ["SELECT id1, id2 FROM test WHERE (region = 'Asia')"]
   end
-  
+
   specify "should accept a subquery for an EXISTS clause" do
     a = @dataset.filter(:price.sql_number < 100)
     @dataset.filter(a.exists).sql.should ==
       'SELECT * FROM test WHERE (EXISTS (SELECT * FROM test WHERE (price < 100)))'
   end
-  
+
   specify "should accept proc expressions" do
     d = @d1.select(:avg.sql_function(:gdp))
     @dataset.filter {:gdp.sql_number > d}.sql.should ==
       "SELECT * FROM test WHERE (gdp > (SELECT avg(gdp) FROM test WHERE (region = 'Asia')))"
-    
+
     @dataset.filter {:a.sql_number < 1}.sql.should ==
       'SELECT * FROM test WHERE (a < 1)'
 
     @dataset.filter {(:a.sql_number >= 1) & (:b.sql_number <= 2)}.sql.should ==
       'SELECT * FROM test WHERE ((a >= 1) AND (b <= 2))'
-      
+
     @dataset.filter {:c.like 'ABC%'}.sql.should ==
       "SELECT * FROM test WHERE (c LIKE 'ABC%')"
 
@@ -615,7 +615,7 @@ describe "Dataset#where" do
     @dataset.filter {:c.like 'ABC%', '%XYZ'}.sql.should ==
       "SELECT * FROM test WHERE ((c LIKE 'ABC%') OR (c LIKE '%XYZ'))"
   end
-  
+
   specify "should work for grouped datasets" do
     @dataset.group(:a).filter(:b => 1).sql.should ==
       'SELECT * FROM test WHERE (b = 1) GROUP BY a'
@@ -673,33 +673,33 @@ describe "Dataset#or" do
     @dataset = Sequel::Dataset.new(nil).from(:test)
     @d1 = @dataset.where(:x => 1)
   end
-  
+
   specify "should raise if no filter exists" do
     proc {@dataset.or(:a => 1)}.should raise_error(Sequel::Error)
   end
-  
+
   specify "should add an alternative expression to the where clause" do
-    @d1.or(:y => 2).sql.should == 
+    @d1.or(:y => 2).sql.should ==
       'SELECT * FROM test WHERE ((x = 1) OR (y = 2))'
   end
-  
+
   specify "should accept all forms of filters" do
     @d1.or('y > ?', 2).sql.should ==
       'SELECT * FROM test WHERE ((x = 1) OR (y > 2))'
     @d1.or(:yy.sql_number > 3).sql.should ==
       'SELECT * FROM test WHERE ((x = 1) OR (yy > 3))'
-  end    
+  end
 
   specify "should accept blocks passed to filter" do
     @d1.or{:yy.sql_number > 3}.sql.should ==
       'SELECT * FROM test WHERE ((x = 1) OR (yy > 3))'
   end
-  
+
   specify "should correctly add parens to give predictable results" do
-    @d1.filter(:y => 2).or(:z => 3).sql.should == 
+    @d1.filter(:y => 2).or(:z => 3).sql.should ==
       'SELECT * FROM test WHERE (((x = 1) AND (y = 2)) OR (z = 3))'
 
-    @d1.or(:y => 2).filter(:z => 3).sql.should == 
+    @d1.or(:y => 2).filter(:z => 3).sql.should ==
       'SELECT * FROM test WHERE (((x = 1) OR (y = 2)) AND (z = 3))'
   end
 
@@ -714,19 +714,19 @@ describe "Dataset#and" do
     @dataset = Sequel::Dataset.new(nil).from(:test)
     @d1 = @dataset.where(:x => 1)
   end
-  
+
   specify "should raise if no filter exists" do
     proc {@dataset.and(:a => 1)}.should raise_error(Sequel::Error)
     proc {@dataset.where(:a => 1).group(:t).and(:b => 2)}.should_not raise_error(Sequel::Error)
     @dataset.where(:a => 1).group(:t).and(:b => 2).sql ==
       "SELECT * FROM test WHERE (a = 1) AND (b = 2) GROUP BY t"
   end
-  
+
   specify "should add an alternative expression to the where clause" do
-    @d1.and(:y => 2).sql.should == 
+    @d1.and(:y => 2).sql.should ==
       'SELECT * FROM test WHERE ((x = 1) AND (y = 2))'
   end
-  
+
   specify "should accept all forms of filters" do
     # probably not exhaustive, but good enough
     @d1.and('y > ?', 2).sql.should ==
@@ -734,17 +734,17 @@ describe "Dataset#and" do
     @d1.and(:yy.sql_number > 3).sql.should ==
       'SELECT * FROM test WHERE ((x = 1) AND (yy > 3))'
   end
-      
+
   specify "should accept blocks passed to filter" do
     @d1.and {:yy.sql_number > 3}.sql.should ==
       'SELECT * FROM test WHERE ((x = 1) AND (yy > 3))'
   end
-  
+
   specify "should correctly add parens to give predictable results" do
-    @d1.or(:y => 2).and(:z => 3).sql.should == 
+    @d1.or(:y => 2).and(:z => 3).sql.should ==
       'SELECT * FROM test WHERE (((x = 1) OR (y = 2)) AND (z = 3))'
 
-    @d1.and(:y => 2).or(:z => 3).sql.should == 
+    @d1.and(:y => 2).or(:z => 3).sql.should ==
       'SELECT * FROM test WHERE (((x = 1) AND (y = 2)) OR (z = 3))'
   end
 end
@@ -784,16 +784,16 @@ describe "Dataset#exclude" do
     @dataset.exclude(:region => 'Asia').exclude(:name => 'Japan').select_sql.should ==
       "SELECT * FROM test WHERE ((region != 'Asia') AND (name != 'Japan'))"
   end
-  
+
   specify "should support proc expressions" do
-    @dataset.exclude{:id.sql_number < 6}.sql.should == 
+    @dataset.exclude{:id.sql_number < 6}.sql.should ==
       'SELECT * FROM test WHERE (id >= 6)'
   end
-  
+
   specify "should allow the use of blocks and arguments simultaneously" do
-    @dataset.exclude(:id => (7..11)){:id.sql_number < 6}.sql.should == 
+    @dataset.exclude(:id => (7..11)){:id.sql_number < 6}.sql.should ==
       'SELECT * FROM test WHERE ((id < 7) OR (id > 11) OR (id >= 6))'
-    @dataset.exclude([:id, 1], [:x, 3]){:id.sql_number < 6}.sql.should == 
+    @dataset.exclude([:id, 1], [:x, 3]){:id.sql_number < 6}.sql.should ==
       'SELECT * FROM test WHERE ((id != 1) OR (x != 3) OR (id >= 6))'
   end
 end
@@ -852,14 +852,14 @@ describe "Dataset#having" do
     @dataset.having([]).sql.should == @dataset.sql
     @dataset.having('').sql.should == @dataset.sql
   end
-  
+
   specify "should affect select statements" do
     @d1.select_sql.should ==
       "SELECT #{@columns} FROM test GROUP BY region HAVING (sum(population) > 10)"
   end
 
   specify "should support proc expressions" do
-    @grouped.having {:sum.sql_function(:population) > 10}.sql.should == 
+    @grouped.having {:sum.sql_function(:population) > 10}.sql.should ==
       "SELECT #{@columns} FROM test GROUP BY region HAVING (sum(population) > 10)"
   end
 
@@ -881,7 +881,7 @@ describe "a grouped dataset" do
   specify "should raise when trying to generate a delete statement" do
     proc {@dataset.delete_sql}.should raise_error
   end
-  
+
   specify "should raise when trying to generate a truncate statement" do
     proc {@dataset.truncate_sql}.should raise_error
   end
@@ -894,7 +894,7 @@ describe "a grouped dataset" do
     @dataset.select_sql.should ==
       "SELECT * FROM test GROUP BY type_id"
   end
-  
+
   specify "should format the right statement for counting (as a subquery)" do
     db = MockDatabase.new
     db[:test].select(:name).group(:name).count
@@ -963,7 +963,7 @@ describe "Dataset#literal" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should escape strings properly" do
     @dataset.literal('abc').should == "'abc'"
     @dataset.literal('a"x"bc').should == "'a\"x\"bc'"
@@ -973,7 +973,7 @@ describe "Dataset#literal" do
     @dataset.literal("a\\\\bc").should == "'a\\\\\\\\bc'"
     @dataset.literal("a\\'bc").should == "'a\\\\''bc'"
   end
-  
+
   specify "should escape blobs as strings by default" do
     @dataset.literal('abc'.to_sequel_blob).should == "'abc'"
   end
@@ -1010,28 +1010,28 @@ describe "Dataset#literal" do
     end
     @dataset.literal(@a.new).should == "called ds"
   end
-  
+
   specify "should raise an error for unsupported types with no sql_literal method" do
     proc {@dataset.literal(Object.new)}.should raise_error
   end
-  
+
   specify "should literalize datasets as subqueries" do
     d = @dataset.from(:test)
     d.literal(d).should == "(#{d.sql})"
   end
-  
+
   specify "should literalize Time properly" do
     t = Time.now
     s = t.strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}.#{sprintf('%06i', t.usec)}'"
   end
-  
+
   specify "should literalize DateTime properly" do
     t = DateTime.now
     s = t.strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}.#{sprintf('%06i', t.sec_fraction * (RUBY_VERSION < '1.9.0' ? 86400000000 : 1000000))}'"
   end
-  
+
   specify "should literalize Date properly" do
     d = Date.today
     s = d.strftime("'%Y-%m-%d'")
@@ -1060,7 +1060,7 @@ describe "Dataset#literal" do
     s = d.strftime("DATE '%Y-%m-%d'")
     @dataset.literal(d).should == s
   end
-  
+
   specify "should literalize Time and DateTime properly if the database support timezones in timestamps" do
     @dataset.meta_def(:supports_timestamp_timezones?){true}
 
@@ -1072,10 +1072,10 @@ describe "Dataset#literal" do
     s = t.strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}.#{sprintf('%06i', t.sec_fraction* (RUBY_VERSION < '1.9.0' ? 86400000000 : 1000000))}+0000'"
   end
-  
+
   specify "should literalize Time and DateTime properly if the database doesn't support usecs in timestamps" do
     @dataset.meta_def(:supports_timestamp_usecs?){false}
-    
+
     t = Time.now.utc
     s = t.strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}'"
@@ -1083,9 +1083,9 @@ describe "Dataset#literal" do
     t = DateTime.now.new_offset(0)
     s = t.strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}'"
-    
+
     @dataset.meta_def(:supports_timestamp_timezones?){true}
-    
+
     t = Time.now.utc
     s = t.strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}+0000'"
@@ -1094,11 +1094,11 @@ describe "Dataset#literal" do
     s = t.strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}+0000'"
   end
-  
+
   specify "should not modify literal strings" do
     @dataset.literal('col1 + 2'.lit).should == 'col1 + 2'
-    
-    @dataset.update_sql(:a => 'a + 2'.lit).should == 
+
+    @dataset.update_sql(:a => 'a + 2'.lit).should ==
       'UPDATE test SET a = a + 2'
   end
 
@@ -1127,22 +1127,22 @@ describe "Dataset#from" do
     @dataset.from(@dataset.from(:a).where(:a=>1)).select_sql.should ==
       "SELECT * FROM (SELECT * FROM a WHERE (a = 1)) AS t1"
   end
-  
+
   specify "should automatically alias sub-queries" do
     @dataset.from(@dataset.from(:a).group(:b)).select_sql.should ==
       "SELECT * FROM (SELECT * FROM a GROUP BY b) AS t1"
-      
+
     d1 = @dataset.from(:a).group(:b)
     d2 = @dataset.from(:c).group(:d)
-    
-    @dataset.from(d1, d2).sql.should == 
+
+    @dataset.from(d1, d2).sql.should ==
       "SELECT * FROM (SELECT * FROM a GROUP BY b) AS t1, (SELECT * FROM c GROUP BY d) AS t2"
   end
-  
+
   specify "should accept a hash for aliasing" do
     @dataset.from(:a => :b).sql.should ==
       "SELECT * FROM a AS b"
-      
+
     @dataset.from(:a => 'b').sql.should ==
       "SELECT * FROM a AS b"
 
@@ -1154,15 +1154,15 @@ describe "Dataset#from" do
     @dataset.from(@dataset.from(:a)).select_sql.should ==
       "SELECT * FROM (SELECT * FROM a) AS t1"
   end
-  
+
   specify "should remove all FROM tables if called with no arguments" do
     @dataset.from.sql.should == 'SELECT *'
   end
-  
+
   specify "should accept sql functions" do
     @dataset.from(:abc.sql_function(:def)).select_sql.should ==
       "SELECT * FROM abc(def)"
-    
+
     @dataset.from(:a.sql_function(:i)).select_sql.should ==
       "SELECT * FROM a(i)"
   end
@@ -1198,16 +1198,16 @@ describe "Dataset#select" do
     @d.select(:name).sql.should == 'SELECT name FROM test'
     @d.select(:a, :b, :test__c).sql.should == 'SELECT a, b, test.c FROM test'
   end
-  
+
   specify "should accept symbols and literal strings" do
     @d.select('aaa'.lit).sql.should == 'SELECT aaa FROM test'
     @d.select(:a, 'b'.lit).sql.should == 'SELECT a, b FROM test'
-    @d.select(:test__cc, 'test.d AS e'.lit).sql.should == 
+    @d.select(:test__cc, 'test.d AS e'.lit).sql.should ==
       'SELECT test.cc, test.d AS e FROM test'
-    @d.select('test.d AS e'.lit, :test__cc).sql.should == 
+    @d.select('test.d AS e'.lit, :test__cc).sql.should ==
       'SELECT test.d AS e, test.cc FROM test'
 
-    # symbol helpers      
+    # symbol helpers
     @d.select(:test.*).sql.should ==
       'SELECT test.* FROM test'
     @d.select(:test__name.as(:n)).sql.should ==
@@ -1219,7 +1219,7 @@ describe "Dataset#select" do
   specify "should use the wildcard if no arguments are given" do
     @d.select.sql.should == 'SELECT * FROM test'
   end
-  
+
   specify "should accept a hash for AS values" do
     @d.select(:name => 'n', :__ggh => 'age').sql.should =~
       /SELECT ((name AS n, __ggh AS age)|(__ggh AS age, name AS n)) FROM test/
@@ -1229,7 +1229,7 @@ describe "Dataset#select" do
     @d.select!(:a, :b, :c).select.sql.should == 'SELECT * FROM test'
     @d.select!(:price).select(:name).sql.should == 'SELECT name FROM test'
   end
-  
+
   specify "should accept arbitrary objects and literalize them correctly" do
     @d.select(1, :a, 't').sql.should == "SELECT 1, a, 't' FROM test"
 
@@ -1273,7 +1273,7 @@ describe "Dataset#select_group" do
     @d.select_group(:name){f(v).as(a)}.sql.should == 'SELECT name, f(v) AS a FROM test GROUP BY name, f(v)'
   end
 end
-  
+
 describe "Dataset#select_all" do
   before do
     @d = Sequel::Dataset.new(nil).from(:test)
@@ -1282,7 +1282,7 @@ describe "Dataset#select_all" do
   specify "should select the wildcard" do
     @d.select_all.sql.should == 'SELECT * FROM test'
   end
-  
+
   specify "should overrun the previous select option" do
     @d.select!(:a, :b, :c).select_all.sql.should == 'SELECT * FROM test'
   end
@@ -1290,7 +1290,7 @@ describe "Dataset#select_all" do
   specify "should select all columns in a table if given an argument" do
     @d.select_all(:test).sql.should == 'SELECT test.* FROM test'
   end
-  
+
   specify "should select all columns all tables if given a multiple arguments" do
     @d.select_all(:test, :foo).sql.should == 'SELECT test.*, foo.* FROM test'
   end
@@ -1300,7 +1300,7 @@ describe "Dataset#select_more" do
   before do
     @d = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should act like #select for datasets with no selection" do
     @d.select_more(:a, :b).sql.should == 'SELECT a, b FROM test'
     @d.select_all.select_more(:a, :b).sql.should == 'SELECT a, b FROM test'
@@ -1322,7 +1322,7 @@ describe "Dataset#select_append" do
   before do
     @d = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should select * in addition to columns if no columns selected" do
     @d.select_append(:a, :b).sql.should == 'SELECT *, a, b FROM test'
     @d.select_all.select_append(:a, :b).sql.should == 'SELECT *, a, b FROM test'
@@ -1340,43 +1340,69 @@ describe "Dataset#select_append" do
   end
 end
 
+describe "Dataset#select_remove" do
+  before do
+    @d = Sequel::Dataset.new(nil).from(:test)
+  end
+
+  specify "should select * if no columns selected and ignore missing columns" do
+    @d.select(:b).select_remove(:a).sql.should == 'SELECT b FROM test'
+  end
+
+  specify "should chain with added columns" do
+    @d.select_all.select_append(:a, :b).select_remove(:b).sql.should == 'SELECT *, a FROM test'
+  end
+
+  specify "should revert to wildcard when no columns exist" do
+    @d.select(:a).select_remove(:a).sql.should == 'SELECT * FROM test'
+    @d.select(:a,:b,:c).select_remove(:a,:b,:c).sql.should == 'SELECT * FROM test'
+  end
+
+  specify "should remove from the currently selected columns" do
+    @d.select(:a, :b).select_remove(:b).sql.should == 'SELECT a FROM test'
+    @d.select(:a.*,:b.*).select_remove(:b.*).sql.should == 'SELECT a.* FROM test'
+    @d.select(:a.*,:b.*).select_remove(:b).sql.should == 'SELECT a.*, b.* FROM test'
+  end
+
+end
+
 describe "Dataset#order" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should include an ORDER BY clause in the select statement" do
-    @dataset.order(:name).sql.should == 
+    @dataset.order(:name).sql.should ==
       'SELECT * FROM test ORDER BY name'
   end
-  
+
   specify "should accept multiple arguments" do
     @dataset.order(:name, :price.desc).sql.should ==
       'SELECT * FROM test ORDER BY name, price DESC'
   end
-  
+
   specify "should accept :nulls options for asc and desc" do
     @dataset.order(:name.asc(:nulls=>:last), :price.desc(:nulls=>:first)).sql.should ==
       'SELECT * FROM test ORDER BY name ASC NULLS LAST, price DESC NULLS FIRST'
   end
-  
+
   specify "should overrun a previous ordering" do
     @dataset.order(:name).order(:stamp).sql.should ==
       'SELECT * FROM test ORDER BY stamp'
   end
-  
+
   specify "should accept a literal string" do
     @dataset.order('dada ASC'.lit).sql.should ==
       'SELECT * FROM test ORDER BY dada ASC'
   end
-  
+
   specify "should accept a hash as an expression" do
     @dataset.order(:name=>nil).sql.should ==
       'SELECT * FROM test ORDER BY (name IS NULL)'
   end
-  
+
   specify "should accept a nil to remove ordering" do
-    @dataset.order(:bah).order(nil).sql.should == 
+    @dataset.order(:bah).order(nil).sql.should ==
       'SELECT * FROM test'
   end
 
@@ -1423,11 +1449,11 @@ describe "Dataset#with_sql" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should use static sql" do
     @dataset.with_sql('SELECT 1 FROM test').sql.should == 'SELECT 1 FROM test'
   end
-  
+
   specify "should work with placeholders" do
     @dataset.with_sql('SELECT ? FROM test', 1).sql.should == 'SELECT 1 FROM test'
   end
@@ -1445,29 +1471,29 @@ describe "Dataset#order_by" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should include an ORDER BY clause in the select statement" do
-    @dataset.order_by(:name).sql.should == 
+    @dataset.order_by(:name).sql.should ==
       'SELECT * FROM test ORDER BY name'
   end
-  
+
   specify "should accept multiple arguments" do
     @dataset.order_by(:name, :price.desc).sql.should ==
       'SELECT * FROM test ORDER BY name, price DESC'
   end
-  
+
   specify "should overrun a previous ordering" do
     @dataset.order_by(:name).order(:stamp).sql.should ==
       'SELECT * FROM test ORDER BY stamp'
   end
-  
+
   specify "should accept a string" do
     @dataset.order_by('dada ASC'.lit).sql.should ==
       'SELECT * FROM test ORDER BY dada ASC'
   end
 
   specify "should accept a nil to remove ordering" do
-    @dataset.order_by(:bah).order_by(nil).sql.should == 
+    @dataset.order_by(:bah).order_by(nil).sql.should ==
       'SELECT * FROM test'
   end
 end
@@ -1476,12 +1502,12 @@ describe "Dataset#order_more and order_append" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should include an ORDER BY clause in the select statement" do
     @dataset.order_more(:name).sql.should == 'SELECT * FROM test ORDER BY name'
     @dataset.order_append(:name).sql.should == 'SELECT * FROM test ORDER BY name'
   end
-  
+
   specify "should add to the end of a previous ordering" do
     @dataset.order(:name).order_more(:stamp.desc).sql.should == 'SELECT * FROM test ORDER BY name, stamp DESC'
     @dataset.order(:name).order_append(:stamp.desc).sql.should == 'SELECT * FROM test ORDER BY name, stamp DESC'
@@ -1499,12 +1525,12 @@ describe "Dataset#order_prepend" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should include an ORDER BY clause in the select statement" do
-    @dataset.order_prepend(:name).sql.should == 
+    @dataset.order_prepend(:name).sql.should ==
       'SELECT * FROM test ORDER BY name'
   end
-  
+
   specify "should add to the beginning of a previous ordering" do
     @dataset.order(:name).order_prepend(:stamp.desc).sql.should ==
       'SELECT * FROM test ORDER BY stamp DESC, name'
@@ -1520,22 +1546,22 @@ describe "Dataset#reverse_order" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should use DESC as default order" do
-    @dataset.reverse_order(:name).sql.should == 
+    @dataset.reverse_order(:name).sql.should ==
       'SELECT * FROM test ORDER BY name DESC'
   end
-  
+
   specify "should invert the order given" do
     @dataset.reverse_order(:name.desc).sql.should ==
       'SELECT * FROM test ORDER BY name ASC'
   end
-  
+
   specify "should invert the order for ASC expressions" do
     @dataset.reverse_order(:name.asc).sql.should ==
       'SELECT * FROM test ORDER BY name DESC'
   end
-  
+
   specify "should accept multiple arguments" do
     @dataset.reverse_order(:name, :price.desc).sql.should ==
       'SELECT * FROM test ORDER BY name DESC, price ASC'
@@ -1552,12 +1578,12 @@ describe "Dataset#reverse_order" do
     @dataset.order(:clumsy.desc, :fool).reverse_order.sql.should ==
       'SELECT * FROM test ORDER BY clumsy ASC, fool DESC'
   end
-  
+
   specify "should return an unordered dataset for a dataset with no order" do
-    @dataset.unordered.reverse_order.sql.should == 
+    @dataset.unordered.reverse_order.sql.should ==
       'SELECT * FROM test'
   end
-  
+
   specify "should have #reverse alias" do
     @dataset.order(:name).reverse.sql.should ==
       'SELECT * FROM test ORDER BY name DESC'
@@ -1568,46 +1594,46 @@ describe "Dataset#limit" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should include a LIMIT clause in the select statement" do
-    @dataset.limit(10).sql.should == 
+    @dataset.limit(10).sql.should ==
       'SELECT * FROM test LIMIT 10'
   end
-  
+
   specify "should accept ranges" do
     @dataset.limit(3..7).sql.should ==
       'SELECT * FROM test LIMIT 5 OFFSET 3'
-      
+
     @dataset.limit(3...7).sql.should ==
       'SELECT * FROM test LIMIT 4 OFFSET 3'
   end
-  
+
   specify "should include an offset if a second argument is given" do
     @dataset.limit(6, 10).sql.should ==
       'SELECT * FROM test LIMIT 6 OFFSET 10'
     end
-    
+
   specify "should convert regular strings to integers" do
     @dataset.limit('6', 'a() - 1').sql.should ==
       'SELECT * FROM test LIMIT 6 OFFSET 0'
   end
-  
+
   specify "should not convert literal strings to integers" do
     @dataset.limit('6'.lit, 'a() - 1'.lit).sql.should ==
       'SELECT * FROM test LIMIT 6 OFFSET a() - 1'
   end
-    
+
   specify "should not convert other objects" do
     @dataset.limit(6, :a.sql_function - 1).sql.should ==
       'SELECT * FROM test LIMIT 6 OFFSET (a() - 1)'
   end
-  
+
   specify "should work with fixed sql datasets" do
     @dataset.opts[:sql] = 'select * from cccc'
     @dataset.limit(6, 10).sql.should ==
       'SELECT * FROM (select * from cccc) AS t1 LIMIT 6 OFFSET 10'
   end
-  
+
   specify "should raise an error if an invalid limit or offset is used" do
     proc{@dataset.limit(-1)}.should raise_error(Sequel::Error)
     proc{@dataset.limit(0)}.should raise_error(Sequel::Error)
@@ -1624,7 +1650,7 @@ describe "Dataset#naked" do
     @d2 = @d1.clone
     @d2.row_proc = Proc.new{|r| r}
   end
-  
+
   specify "should remove any existing row_proc" do
     naked = @d2.naked
     naked.row_proc.should be_nil
@@ -1635,13 +1661,13 @@ describe "Dataset#qualified_column_name" do
   before do
     @dataset = Sequel::Dataset.new(nil).from(:test)
   end
-  
+
   specify "should return the literal value if not given a symbol" do
     @dataset.literal(@dataset.send(:qualified_column_name, 'ccc__b', :items)).should == "'ccc__b'"
     @dataset.literal(@dataset.send(:qualified_column_name, 3, :items)).should == '3'
     @dataset.literal(@dataset.send(:qualified_column_name, 'a'.lit, :items)).should == 'a'
   end
-  
+
   specify "should qualify the column with the supplied table name if given an unqualified symbol" do
     @dataset.literal(@dataset.send(:qualified_column_name, :b1, :items)).should == 'items.b1'
   end
@@ -1670,15 +1696,15 @@ describe "Dataset#map" do
   before do
     @d = DummyDataset.new(nil).from(:items)
   end
-  
+
   specify "should provide the usual functionality if no argument is given" do
     @d.map {|n| n[:a] + n[:b]}.should == [3, 7, 11]
   end
-  
+
   specify "should map using #[column name] if column name is given" do
     @d.map(:a).should == [1, 3, 5]
   end
-  
+
   specify "should return the complete dataset values if nothing is given" do
     @d.map.to_a.should == DummyDataset::VALUES
   end
@@ -1688,12 +1714,12 @@ describe "Dataset#to_hash" do
   before do
     @d = DummyDataset.new(nil).from(:items)
   end
-  
+
   specify "should provide a hash with the first column as key and the second as value" do
     @d.to_hash(:a, :b).should == {1 => 2, 3 => 4, 5 => 6}
     @d.to_hash(:b, :a).should == {2 => 1, 4 => 3, 6 => 5}
   end
-  
+
   specify "should provide a hash with the first column as key and the entire hash as value if the value column is blank or nil" do
     @d.to_hash(:a).should == {1 => {:a => 1, :b => 2}, 3 => {:a => 3, :b => 4}, 5 => {:a => 5, :b => 6}}
     @d.to_hash(:b).should == {2 => {:a => 1, :b => 2}, 4 => {:a => 3, :b => 4}, 6 => {:a => 5, :b => 6}}
@@ -1705,16 +1731,16 @@ describe "Dataset#distinct" do
     @db = MockDatabase.new
     @dataset = @db[:test].select(:name)
   end
-  
+
   specify "should include DISTINCT clause in statement" do
     @dataset.distinct.sql.should == 'SELECT DISTINCT name FROM test'
   end
-  
+
   specify "should raise an error if columns given and DISTINCT ON is not supported" do
     proc{@dataset.distinct}.should_not raise_error
     proc{@dataset.distinct(:a)}.should raise_error(Sequel::InvalidOperation)
   end
-  
+
   specify "should use DISTINCT ON if columns are given and DISTINCT ON is supported" do
     @dataset.meta_def(:supports_distinct_on?){true}
     @dataset.distinct(:a, :b).sql.should == 'SELECT DISTINCT ON (a, b) name FROM test'
@@ -1733,7 +1759,7 @@ describe "Dataset#count" do
       def self.sql
         @@sql
       end
-      
+
       def fetch_rows(sql)
         @columns = [sql =~ /SELECT COUNT/i ? :count : :a]
         @@sql = sql
@@ -1742,17 +1768,17 @@ describe "Dataset#count" do
     end
     @dataset = @c.new(nil).from(:test)
   end
-  
+
   specify "should format SQL properly" do
     @dataset.count.should == 1
     @c.sql.should == 'SELECT COUNT(*) AS count FROM test LIMIT 1'
   end
-  
+
   specify "should include the where clause if it's there" do
     @dataset.filter(:abc.sql_number < 30).count.should == 1
     @c.sql.should == 'SELECT COUNT(*) AS count FROM test WHERE (abc < 30) LIMIT 1'
   end
-  
+
   specify "should count properly for datasets with fixed sql" do
     @dataset.opts[:sql] = "select abc from xyz"
     @dataset.count.should == 1
@@ -1772,7 +1798,7 @@ describe "Dataset#count" do
     @dataset.limit(5).count.should == 1
     @c.sql.should == "SELECT COUNT(*) AS count FROM (SELECT * FROM test LIMIT 5) AS t1 LIMIT 1"
   end
-  
+
   it "should work on a graphed_dataset" do
     @dataset.should_receive(:columns).twice.and_return([:a])
     @dataset.graph(@dataset, [:a], :table_alias=>:test2).count.should == 1
@@ -1795,7 +1821,7 @@ describe "Dataset#group_and_count" do
       def self.sql
         @@sql
       end
-      
+
       def fetch_rows(sql)
         @@sql = sql
         yield({1 => 1})
@@ -1803,14 +1829,14 @@ describe "Dataset#group_and_count" do
     end
     @ds = @c.new(nil).from(:test)
   end
-  
+
   specify "should format SQL properly" do
-    @ds.group_and_count(:name).sql.should == 
+    @ds.group_and_count(:name).sql.should ==
       "SELECT name, count(*) AS count FROM test GROUP BY name"
   end
 
   specify "should accept multiple columns for grouping" do
-    @ds.group_and_count(:a, :b).sql.should == 
+    @ds.group_and_count(:a, :b).sql.should ==
       "SELECT a, b, count(*) AS count FROM test GROUP BY a, b"
   end
 
@@ -1851,7 +1877,7 @@ describe "Dataset#empty?" do
       def self.sql
         @@sql
       end
-      
+
       def fetch_rows(sql)
         @@sql = sql
         yield({1 => 1}) unless sql =~ /WHERE 'f'/
@@ -1868,27 +1894,27 @@ describe "Dataset#first_source_alias" do
   before do
     @ds = Sequel::Dataset.new(nil)
   end
-  
+
   specify "should be the entire first source if not aliased" do
     @ds.from(:t).first_source_alias.should == :t
     @ds.from(:t__a.identifier).first_source_alias.should == :t__a.identifier
     @ds.from(:s__t).first_source_alias.should == :s__t
     @ds.from(:t.qualify(:s)).first_source_alias.should == :t.qualify(:s)
   end
-  
+
   specify "should be the alias if aliased" do
     @ds.from(:t___a).first_source_alias.should == :a
     @ds.from(:s__t___a).first_source_alias.should == :a
     @ds.from(:t.as(:a)).first_source_alias.should == :a
   end
-  
+
   specify "should be aliased as first_source" do
     @ds.from(:t).first_source.should == :t
     @ds.from(:t__a.identifier).first_source.should == :t__a.identifier
     @ds.from(:s__t___a).first_source.should == :a
     @ds.from(:t.as(:a)).first_source.should == :a
   end
-  
+
   specify "should raise exception if table doesn't have a source" do
     proc{@ds.first_source_alias.should == :t}.should raise_error(Sequel::Error)
   end
@@ -1898,20 +1924,20 @@ describe "Dataset#first_source_table" do
   before do
     @ds = Sequel::Dataset.new(nil)
   end
-  
+
   specify "should be the entire first source if not aliased" do
     @ds.from(:t).first_source_table.should == :t
     @ds.from(:t__a.identifier).first_source_table.should == :t__a.identifier
     @ds.from(:s__t).first_source_table.should == :s__t
     @ds.from(:t.qualify(:s)).first_source_table.should == :t.qualify(:s)
   end
-  
+
   specify "should be the unaliased part if aliased" do
     @ds.from(:t___a).first_source_table.should == :t.identifier
     @ds.from(:s__t___a).first_source_table.should == :t.qualify(:s)
     @ds.from(:t.as(:a)).first_source_table.should == :t
   end
-  
+
   specify "should raise exception if table doesn't have a source" do
     proc{@ds.first_source_table.should == :t}.should raise_error(Sequel::Error)
   end
@@ -1921,24 +1947,24 @@ describe "Dataset#from_self" do
   before do
     @ds = Sequel::Dataset.new(nil).from(:test).select(:name).limit(1)
   end
-  
+
   specify "should set up a default alias" do
     @ds.from_self.sql.should == 'SELECT * FROM (SELECT name FROM test LIMIT 1) AS t1'
   end
-  
+
   specify "should modify only the new dataset" do
     @ds.from_self.select(:bogus).sql.should == 'SELECT bogus FROM (SELECT name FROM test LIMIT 1) AS t1'
   end
-  
+
   specify "should use the user-specified alias" do
     @ds.from_self(:alias=>:some_name).sql.should == 'SELECT * FROM (SELECT name FROM test LIMIT 1) AS some_name'
   end
-  
+
   specify "should use the user-specified alias for joins" do
     @ds.from_self(:alias=>:some_name).inner_join(:posts, :alias=>:name).sql.should == \
       'SELECT * FROM (SELECT name FROM test LIMIT 1) AS some_name INNER JOIN posts ON (posts.alias = some_name.name)'
   end
-  
+
   specify "should not options such as server" do
     @ds.server(:blah).from_self(:alias=>:some_name).opts[:server].should == :blah
   end
@@ -1950,32 +1976,32 @@ describe "Dataset#join_table" do
     @d = MockDataset.new(nil).from(:items)
     @d.quote_identifiers = true
   end
-  
+
   specify "should format the JOIN clause properly" do
     @d.join_table(:left_outer, :categories, :category_id => :id).sql.should ==
       'SELECT * FROM "items" LEFT OUTER JOIN "categories" ON ("categories"."category_id" = "items"."id")'
   end
-  
+
   specify "should handle multiple conditions on the same join table column" do
     @d.join_table(:left_outer, :categories, [[:category_id, :id], [:category_id, 0..100]]).sql.should ==
       'SELECT * FROM "items" LEFT OUTER JOIN "categories" ON (("categories"."category_id" = "items"."id") AND ("categories"."category_id" >= 0) AND ("categories"."category_id" <= 100))'
   end
-  
+
   specify "should include WHERE clause if applicable" do
     @d.filter(:price.sql_number < 100).join_table(:right_outer, :categories, :category_id => :id).sql.should ==
       'SELECT * FROM "items" RIGHT OUTER JOIN "categories" ON ("categories"."category_id" = "items"."id") WHERE ("price" < 100)'
   end
-  
+
   specify "should include ORDER BY clause if applicable" do
     @d.order(:stamp).join_table(:full_outer, :categories, :category_id => :id).sql.should ==
       'SELECT * FROM "items" FULL OUTER JOIN "categories" ON ("categories"."category_id" = "items"."id") ORDER BY "stamp"'
   end
-  
+
   specify "should support multiple joins" do
     @d.join_table(:inner, :b, :items_id=>:id).join_table(:left_outer, :c, :b_id => :b__id).sql.should ==
       'SELECT * FROM "items" INNER JOIN "b" ON ("b"."items_id" = "items"."id") LEFT OUTER JOIN "c" ON ("c"."b_id" = "b"."id")'
   end
-  
+
   specify "should support arbitrary join types" do
     @d.join_table(:magic, :categories, :category_id=>:id).sql.should ==
       'SELECT * FROM "items" MAGIC JOIN "categories" ON ("categories"."category_id" = "items"."id")'
@@ -2007,7 +2033,7 @@ describe "Dataset#join_table" do
     @d.cross_join(:categories).sql.should ==
       'SELECT * FROM "items" CROSS JOIN "categories"'
   end
-  
+
   specify "should raise an error if additional arguments are provided to join methods that don't take conditions" do
     proc{@d.natural_join(:categories, :id=>:id)}.should raise_error(ArgumentError)
     proc{@d.natural_left_join(:categories, :id=>:id)}.should raise_error(ArgumentError)
@@ -2033,7 +2059,7 @@ describe "Dataset#join_table" do
     @d.join(:categories, :category_id=>:id).sql.should ==
       'SELECT * FROM "items" INNER JOIN "categories" ON ("categories"."category_id" = "items"."id")'
   end
-  
+
   specify "should support aliased tables using the deprecated argument" do
     @d.from('stats').join('players', {:id => :player_id}, 'p').sql.should ==
       'SELECT * FROM "stats" INNER JOIN "players" AS "p" ON ("p"."id" = "stats"."player_id")'
@@ -2043,19 +2069,19 @@ describe "Dataset#join_table" do
     @d.from('stats').join('players', {:id => :player_id}, :table_alias=>:p).sql.should ==
       'SELECT * FROM "stats" INNER JOIN "players" AS "p" ON ("p"."id" = "stats"."player_id")'
   end
-  
+
   specify "should support aliased tables using an implicit alias" do
     @d.from('stats').join(:players.as(:p), {:id => :player_id}).sql.should ==
       'SELECT * FROM "stats" INNER JOIN "players" AS "p" ON ("p"."id" = "stats"."player_id")'
   end
-  
+
   specify "should support using an alias for the FROM when doing the first join with unqualified condition columns" do
     ds = MockDataset.new(nil).from(:foo => :f)
     ds.quote_identifiers = true
     ds.join_table(:inner, :bar, :id => :bar_id).sql.should ==
       'SELECT * FROM "foo" AS "f" INNER JOIN "bar" ON ("bar"."id" = "f"."bar_id")'
   end
-  
+
   specify "should support implicit schemas in from table symbols" do
     @d.from(:s__t).join(:u__v, {:id => :player_id}).sql.should ==
       'SELECT * FROM "s"."t" INNER JOIN "u"."v" ON ("u"."v"."id" = "s"."t"."player_id")'
@@ -2067,7 +2093,7 @@ describe "Dataset#join_table" do
     @d.from(:s__t___z).join(:u__v___y, {:id => :player_id}).sql.should ==
       'SELECT * FROM "s"."t" AS "z" INNER JOIN "u"."v" AS "y" ON ("y"."id" = "z"."player_id")'
   end
-  
+
   specify "should support AliasedExpressions" do
     @d.from(:s.as(:t)).join(:u.as(:v), {:id => :player_id}).sql.should ==
       'SELECT * FROM "s" AS "t" INNER JOIN "u" AS "v" ON ("v"."id" = "t"."player_id")'
@@ -2077,7 +2103,7 @@ describe "Dataset#join_table" do
     @d.from('stats').join('players', {:id => :player_id}, :implicit_qualifier=>:p).sql.should ==
       'SELECT * FROM "stats" INNER JOIN "players" ON ("players"."id" = "p"."player_id")'
   end
-  
+
   specify "should allow for arbitrary conditions in the JOIN clause" do
     @d.join_table(:left_outer, :categories, :status => 0).sql.should ==
       'SELECT * FROM "items" LEFT OUTER JOIN "categories" ON ("categories"."status" = 0)'
@@ -2088,7 +2114,7 @@ describe "Dataset#join_table" do
     @d.join_table(:left_outer, :categories, :status => [1, 2, 3]).sql.should ==
       'SELECT * FROM "items" LEFT OUTER JOIN "categories" ON ("categories"."status" IN (1, 2, 3))'
   end
-  
+
   specify "should raise error for a table without a source" do
     proc {Sequel::Dataset.new(nil).join('players', :id => :player_id)}. \
       should raise_error(Sequel::Error)
@@ -2096,10 +2122,10 @@ describe "Dataset#join_table" do
 
   specify "should support joining datasets" do
     ds = Sequel::Dataset.new(nil).from(:categories)
-    
+
     @d.join_table(:left_outer, ds, :item_id => :id).sql.should ==
       'SELECT * FROM "items" LEFT OUTER JOIN (SELECT * FROM categories) AS "t1" ON ("t1"."item_id" = "items"."id")'
-      
+
     ds.filter!(:active => true)
 
     @d.join_table(:left_outer, ds, :item_id => :id).sql.should ==
@@ -2108,14 +2134,14 @@ describe "Dataset#join_table" do
     @d.from_self.join_table(:left_outer, ds, :item_id => :id).sql.should ==
       'SELECT * FROM (SELECT * FROM "items") AS "t1" LEFT OUTER JOIN (SELECT * FROM categories WHERE (active IS TRUE)) AS "t2" ON ("t2"."item_id" = "t1"."id")'
   end
-  
+
   specify "should support joining datasets and aliasing the join" do
     ds = Sequel::Dataset.new(nil).from(:categories)
-    
+
     @d.join_table(:left_outer, ds, {:ds__item_id => :id}, :ds).sql.should ==
-      'SELECT * FROM "items" LEFT OUTER JOIN (SELECT * FROM categories) AS "ds" ON ("ds"."item_id" = "items"."id")'      
+      'SELECT * FROM "items" LEFT OUTER JOIN (SELECT * FROM categories) AS "ds" ON ("ds"."item_id" = "items"."id")'
   end
-  
+
   specify "should support joining multiple datasets" do
     ds = Sequel::Dataset.new(nil).from(:categories)
     ds2 = Sequel::Dataset.new(nil).from(:nodes).select(:name)
@@ -2130,16 +2156,16 @@ describe "Dataset#join_table" do
   specify "should support joining objects that respond to :table_name" do
     ds = Object.new
     def ds.table_name; :categories end
-    
+
     @d.join(ds, :item_id => :id).sql.should ==
       'SELECT * FROM "items" INNER JOIN "categories" ON ("categories"."item_id" = "items"."id")'
   end
-  
+
   specify "should support using a SQL String as the join condition" do
     @d.join(:categories, %{c.item_id = items.id}, :c).sql.should ==
       'SELECT * FROM "items" INNER JOIN "categories" AS "c" ON (c.item_id = items.id)'
   end
-  
+
   specify "should support using a boolean column as the join condition" do
     @d.join(:categories, :active).sql.should ==
       'SELECT * FROM "items" INNER JOIN "categories" ON "active"'
@@ -2176,25 +2202,25 @@ describe "Dataset#join_table" do
   end
 
   specify "should support using a block that receieves the join table/alias, last join table/alias, and array of previous joins" do
-    @d.join(:categories) do |join_alias, last_join_alias, joins| 
+    @d.join(:categories) do |join_alias, last_join_alias, joins|
       join_alias.should == :categories
       last_join_alias.should == :items
       joins.should == []
     end
 
-    @d.from(:items=>:i).join(:categories, nil, :c) do |join_alias, last_join_alias, joins| 
+    @d.from(:items=>:i).join(:categories, nil, :c) do |join_alias, last_join_alias, joins|
       join_alias.should == :c
       last_join_alias.should == :i
       joins.should == []
     end
 
-    @d.from(:items___i).join(:categories, nil, :c) do |join_alias, last_join_alias, joins| 
+    @d.from(:items___i).join(:categories, nil, :c) do |join_alias, last_join_alias, joins|
       join_alias.should == :c
       last_join_alias.should == :i
       joins.should == []
     end
 
-    @d.join(:blah).join(:categories, nil, :c) do |join_alias, last_join_alias, joins| 
+    @d.join(:blah).join(:categories, nil, :c) do |join_alias, last_join_alias, joins|
       join_alias.should == :c
       last_join_alias.should == :blah
       joins.should be_a_kind_of(Array)
@@ -2203,7 +2229,7 @@ describe "Dataset#join_table" do
       joins.first.join_type.should == :inner
     end
 
-    @d.join_table(:natural, :blah, nil, :b).join(:categories, nil, :c) do |join_alias, last_join_alias, joins| 
+    @d.join_table(:natural, :blah, nil, :b).join(:categories, nil, :c) do |join_alias, last_join_alias, joins|
       join_alias.should == :c
       last_join_alias.should == :b
       joins.should be_a_kind_of(Array)
@@ -2212,7 +2238,7 @@ describe "Dataset#join_table" do
       joins.first.join_type.should == :natural
     end
 
-    @d.join(:blah).join(:categories).join(:blah2) do |join_alias, last_join_alias, joins| 
+    @d.join(:blah).join(:categories).join(:blah2) do |join_alias, last_join_alias, joins|
       join_alias.should == :blah2
       last_join_alias.should == :categories
       joins.should be_a_kind_of(Array)
@@ -2244,8 +2270,8 @@ describe "Dataset#join_table" do
     @d.from(:items.as(:i)).join(:categories.as(:c), {:category_id => :id}, {:table_alias=>:c2, :implicit_qualifier=>:i2}).sql.should ==
       'SELECT * FROM "items" AS "i" INNER JOIN "categories" AS "c2" ON ("c2"."category_id" = "i2"."id")'
   end
-  
-  
+
+
   specify "should not allow insert, update, delete, or truncate" do
     proc{@d.join(:categories, :a=>:d).insert_sql}.should raise_error(Sequel::InvalidOperation)
     proc{@d.join(:categories, :a=>:d).update_sql(:a=>1)}.should raise_error(Sequel::InvalidOperation)
@@ -2265,15 +2291,15 @@ describe "Dataset#[]=" do
       def last_sql
         @@last_sql
       end
-      
+
       def update(*args)
         @@last_sql = update_sql(*args)
       end
     end
-    
+
     @d = c.new(nil).from(:items)
   end
-  
+
   specify "should perform an update on the specified filter" do
     @d[:a => 1] = {:x => 3}
     @d.last_sql.should == 'UPDATE items SET x = 3 WHERE (a = 1)'
@@ -2286,15 +2312,15 @@ describe "Dataset#set" do
       def last_sql
         @@last_sql
       end
-      
+
       def update(*args, &block)
         @@last_sql = update_sql(*args, &block)
       end
     end
-    
+
     @d = c.new(nil).from(:items)
   end
-  
+
   specify "should act as alias to #update" do
     @d.set({:x => 3})
     @d.last_sql.should == 'UPDATE items SET x = 3'
@@ -2311,15 +2337,15 @@ describe "Dataset#insert_multiple" do
         @inserts << arg
       end
     end
-    
+
     @d = c.new(nil)
   end
-  
+
   specify "should insert all items in the supplied array" do
     @d.insert_multiple [:aa, 5, 3, {1 => 2}]
     @d.inserts.should == [:aa, 5, 3, {1 => 2}]
   end
-  
+
   specify "should pass array items through the supplied block if given" do
     a = ["inevitable", "hello", "the ticking clock"]
     @d.insert_multiple(a) {|i| i.gsub('l', 'r')}
@@ -2336,27 +2362,27 @@ describe "Dataset aggregate methods" do
     end
     @d = c.new(nil).from(:test)
   end
-  
+
   specify "should include min" do
     @d.min(:a).should == 'SELECT min(a) FROM test LIMIT 1'
   end
-  
+
   specify "should include max" do
     @d.max(:b).should == 'SELECT max(b) FROM test LIMIT 1'
   end
-  
+
   specify "should include sum" do
     @d.sum(:c).should == 'SELECT sum(c) FROM test LIMIT 1'
   end
-  
+
   specify "should include avg" do
     @d.avg(:d).should == 'SELECT avg(d) FROM test LIMIT 1'
   end
-  
+
   specify "should accept qualified columns" do
     @d.avg(:test__bc).should == 'SELECT avg(test.bc) FROM test LIMIT 1'
   end
-  
+
   specify "should use a subselect for the same conditions as count" do
     d = @d.order(:a).limit(5)
     d.avg(:a).should == 'SELECT avg(a) FROM (SELECT * FROM test ORDER BY a LIMIT 5) AS t1 LIMIT 1'
@@ -2370,9 +2396,9 @@ describe "Dataset#range" do
   before do
     c = Class.new(Sequel::Dataset) do
       class_variable_set(:@@sql, nil)
-      
+
       def last_sql; self.class.send(:class_variable_get, :@@sql); end
-      
+
       def fetch_rows(sql)
         self.class.send(:class_variable_set, :@@sql, sql)
         yield(:v1 => 1, :v2 => 10)
@@ -2380,7 +2406,7 @@ describe "Dataset#range" do
     end
     @d = c.new(nil).from(:test)
   end
-  
+
   specify "should generate a correct SQL statement" do
     @d.range(:stamp)
     @d.last_sql.should == "SELECT min(stamp) AS v1, max(stamp) AS v2 FROM test LIMIT 1"
@@ -2388,11 +2414,11 @@ describe "Dataset#range" do
     @d.filter(:price.sql_number > 100).range(:stamp)
     @d.last_sql.should == "SELECT min(stamp) AS v1, max(stamp) AS v2 FROM test WHERE (price > 100) LIMIT 1"
   end
-  
+
   specify "should return a range object" do
     @d.range(:tryme).should == (1..10)
   end
-  
+
   specify "should use a subselect for the same conditions as count" do
     @d.order(:stamp).limit(5).range(:stamp).should == (1..10)
     @d.last_sql.should == 'SELECT min(stamp) AS v1, max(stamp) AS v2 FROM (SELECT * FROM test ORDER BY stamp LIMIT 5) AS t1 LIMIT 1'
@@ -2403,9 +2429,9 @@ describe "Dataset#interval" do
   before do
     c = Class.new(Sequel::Dataset) do
       class_variable_set(:@@sql, nil)
-      
+
       def last_sql; self.class.send(:class_variable_get, :@@sql); end
-      
+
       def fetch_rows(sql)
         self.class.send(:class_variable_set, :@@sql, sql)
         yield(:v => 1234)
@@ -2413,7 +2439,7 @@ describe "Dataset#interval" do
     end
     @d = c.new(nil).from(:test)
   end
-  
+
   specify "should generate a correct SQL statement" do
     @d.interval(:stamp)
     @d.last_sql.should == "SELECT (max(stamp) - min(stamp)) FROM test LIMIT 1"
@@ -2421,11 +2447,11 @@ describe "Dataset#interval" do
     @d.filter(:price.sql_number > 100).interval(:stamp)
     @d.last_sql.should == "SELECT (max(stamp) - min(stamp)) FROM test WHERE (price > 100) LIMIT 1"
   end
-  
+
   specify "should return an integer" do
     @d.interval(:tryme).should == 1234
   end
-  
+
   specify "should use a subselect for the same conditions as count" do
     @d.order(:stamp).limit(5).interval(:stamp).should == 1234
     @d.last_sql.should == 'SELECT (max(stamp) - min(stamp)) FROM (SELECT * FROM test ORDER BY stamp LIMIT 5) AS t1 LIMIT 1'
@@ -2443,7 +2469,7 @@ describe "Dataset #first and #last" do
     end
     @d = @c.new(nil).from(:test)
   end
-  
+
   specify "should return a single record if no argument is given" do
     @d.order(:a).first.should == [:a,1,:b,2, 'SELECT * FROM test ORDER BY a LIMIT 1']
     @d.order(:a).last.should == [:a,1,:b,2, 'SELECT * FROM test ORDER BY a DESC LIMIT 1']
@@ -2455,38 +2481,38 @@ describe "Dataset #first and #last" do
     @d.order(:a).last(:z => 26).should == [:a,1,:b,2, 'SELECT * FROM test WHERE (z = 26) ORDER BY a DESC LIMIT 1']
     @d.order(:a).last('z = ?', 15).should == [:a,1,:b,2, 'SELECT * FROM test WHERE (z = 15) ORDER BY a DESC LIMIT 1']
   end
-  
+
   specify "should set the limit and return an array of records if the given number is > 1" do
     i = rand(10) + 10
     r = @d.order(:a).first(i).should == [[:a,1,:b,2, "SELECT * FROM test ORDER BY a LIMIT #{i}"]] * i
     i = rand(10) + 10
     r = @d.order(:a).last(i).should == [[:a,1,:b,2, "SELECT * FROM test ORDER BY a DESC LIMIT #{i}"]] * i
   end
-  
+
   specify "should return the first matching record if a block is given without an argument" do
     @d.first{:z.sql_number > 26}.should == [:a,1,:b,2, 'SELECT * FROM test WHERE (z > 26) LIMIT 1']
     @d.order(:name).last{:z.sql_number > 26}.should == [:a,1,:b,2, 'SELECT * FROM test WHERE (z > 26) ORDER BY name DESC LIMIT 1']
   end
-  
+
   specify "should combine block and standard argument filters if argument is not an Integer" do
     @d.first(:y=>25){:z.sql_number > 26}.should == [:a,1,:b,2, 'SELECT * FROM test WHERE ((z > 26) AND (y = 25)) LIMIT 1']
     @d.order(:name).last('y = ?', 16){:z.sql_number > 26}.should == [:a,1,:b,2, 'SELECT * FROM test WHERE ((z > 26) AND (y = 16)) ORDER BY name DESC LIMIT 1']
   end
-  
+
   specify "should filter and return an array of records if an Integer argument is provided and a block is given" do
     i = rand(10) + 10
     r = @d.order(:a).first(i){:z.sql_number > 26}.should == [[:a,1,:b,2, "SELECT * FROM test WHERE (z > 26) ORDER BY a LIMIT #{i}"]] * i
     i = rand(10) + 10
     r = @d.order(:a).last(i){:z.sql_number > 26}.should == [[:a,1,:b,2, "SELECT * FROM test WHERE (z > 26) ORDER BY a DESC LIMIT #{i}"]] * i
   end
-  
+
   specify "#last should raise if no order is given" do
     proc {@d.last}.should raise_error(Sequel::Error)
     proc {@d.last(2)}.should raise_error(Sequel::Error)
     proc {@d.order(:a).last}.should_not raise_error
     proc {@d.order(:a).last(2)}.should_not raise_error
   end
-  
+
   specify "#last should invert the order" do
     @d.order(:a).last.pop.should == 'SELECT * FROM test ORDER BY a DESC LIMIT 1'
     @d.order(:b.desc).last.pop.should == 'SELECT * FROM test ORDER BY b ASC LIMIT 1'
@@ -2500,7 +2526,7 @@ describe "Dataset compound operations" do
     @a = Sequel::Dataset.new(nil).from(:a).filter(:z => 1)
     @b = Sequel::Dataset.new(nil).from(:b).filter(:z => 2)
   end
-  
+
   specify "should support UNION and UNION ALL" do
     @a.union(@b).sql.should == \
       "SELECT * FROM (SELECT * FROM a WHERE (z = 1) UNION SELECT * FROM b WHERE (z = 2)) AS t1"
@@ -2527,7 +2553,7 @@ describe "Dataset compound operations" do
     @b.except(@a, :all=>true).sql.should == \
       "SELECT * FROM (SELECT * FROM b WHERE (z = 2) EXCEPT ALL SELECT * FROM a WHERE (z = 1)) AS t1"
   end
-    
+
   specify "should support :alias option for specifying identifier" do
     @a.union(@b, :alias=>:xx).sql.should == \
       "SELECT * FROM (SELECT * FROM a WHERE (z = 1) UNION SELECT * FROM b WHERE (z = 2)) AS xx"
@@ -2544,7 +2570,7 @@ describe "Dataset compound operations" do
       "SELECT * FROM b WHERE (z = 2) INTERSECT SELECT * FROM a WHERE (z = 1)"
     @b.except(@a, :from_self=>false).sql.should == \
       "SELECT * FROM b WHERE (z = 2) EXCEPT SELECT * FROM a WHERE (z = 1)"
-      
+
     @b.union(@a, :from_self=>false, :all=>true).sql.should == \
       "SELECT * FROM b WHERE (z = 2) UNION ALL SELECT * FROM a WHERE (z = 1)"
     @b.intersect(@a, :from_self=>false, :all=>true).sql.should == \
@@ -2560,7 +2586,7 @@ describe "Dataset compound operations" do
     proc{@a.except(@b)}.should raise_error(Sequel::InvalidOperation)
     proc{@a.except(@b, true)}.should raise_error(Sequel::InvalidOperation)
   end
-    
+
   specify "should raise an InvalidOperation if INTERSECT ALL or EXCEPT ALL is used and they are not supported" do
     @a.meta_def(:supports_intersect_except_all?){false}
     proc{@a.intersect(@b)}.should_not raise_error
@@ -2568,7 +2594,7 @@ describe "Dataset compound operations" do
     proc{@a.except(@b)}.should_not raise_error
     proc{@a.except(@b, true)}.should raise_error(Sequel::InvalidOperation)
   end
-    
+
   specify "should handle chained compound operations" do
     @a.union(@b).union(@a, true).sql.should == \
       "SELECT * FROM (SELECT * FROM (SELECT * FROM a WHERE (z = 1) UNION SELECT * FROM b WHERE (z = 2)) AS t1 UNION ALL SELECT * FROM a WHERE (z = 1)) AS t1"
@@ -2577,7 +2603,7 @@ describe "Dataset compound operations" do
     @a.except(@b).except(@a, true).sql.should == \
       "SELECT * FROM (SELECT * FROM (SELECT * FROM a WHERE (z = 1) EXCEPT SELECT * FROM b WHERE (z = 2)) AS t1 EXCEPT ALL SELECT * FROM a WHERE (z = 1)) AS t1"
   end
-  
+
   specify "should use a subselect when using a compound operation with a dataset that already has a compound operation" do
     @a.union(@b.union(@a, true)).sql.should == \
       "SELECT * FROM (SELECT * FROM a WHERE (z = 1) UNION SELECT * FROM (SELECT * FROM b WHERE (z = 2) UNION ALL SELECT * FROM a WHERE (z = 1)) AS t1) AS t1"
@@ -2591,16 +2617,16 @@ describe "Dataset compound operations" do
     @dataset = Sequel::Dataset.new(nil).from(:test)
     @dataset.union(@dataset).limit(2).sql.should ==
       "SELECT * FROM (SELECT * FROM test UNION SELECT * FROM test) AS t1 LIMIT 2"
-    @dataset.limit(2).intersect(@dataset).sql.should == 
+    @dataset.limit(2).intersect(@dataset).sql.should ==
       "SELECT * FROM (SELECT * FROM (SELECT * FROM test LIMIT 2) AS t1 INTERSECT SELECT * FROM test) AS t1"
-    @dataset.except(@dataset.limit(2)).sql.should == 
+    @dataset.except(@dataset.limit(2)).sql.should ==
       "SELECT * FROM (SELECT * FROM test EXCEPT SELECT * FROM (SELECT * FROM test LIMIT 2) AS t1) AS t1"
 
     @dataset.union(@dataset).order(:num).sql.should ==
       "SELECT * FROM (SELECT * FROM test UNION SELECT * FROM test) AS t1 ORDER BY num"
-    @dataset.order(:num).intersect(@dataset).sql.should == 
+    @dataset.order(:num).intersect(@dataset).sql.should ==
       "SELECT * FROM (SELECT * FROM (SELECT * FROM test ORDER BY num) AS t1 INTERSECT SELECT * FROM test) AS t1"
-    @dataset.except(@dataset.order(:num)).sql.should == 
+    @dataset.except(@dataset.order(:num)).sql.should ==
       "SELECT * FROM (SELECT * FROM test EXCEPT SELECT * FROM (SELECT * FROM test ORDER BY num) AS t1) AS t1"
 
     @dataset.limit(2).order(:a).union(@dataset.limit(3).order(:b)).order(:c).limit(4).sql.should ==
@@ -2613,7 +2639,7 @@ describe "Dataset#[]" do
   before do
     @c = Class.new(Sequel::Dataset) do
       class_variable_set(:@@last_dataset, nil)
-      
+
       def self.last_dataset
         class_variable_get(:@@last_dataset)
       end
@@ -2625,7 +2651,7 @@ describe "Dataset#[]" do
     end
     @d = @c.new(nil).from(:test)
   end
-  
+
   specify "should return a single record filtered according to the given conditions" do
     @d[:name => 'didi'].should == {1 => 2, 3 => 4}
     @c.last_dataset.literal(@c.last_dataset.opts[:where]).should == "(name = 'didi')"
@@ -2645,15 +2671,15 @@ describe "Dataset#single_record" do
     @cc = Class.new(@c) do
       def fetch_rows(sql); end
     end
-    
+
     @d = @c.new(nil).from(:test)
     @e = @cc.new(nil).from(:test)
   end
-  
+
   specify "should call each with a limit of 1 and return the record" do
     @d.single_record.should == 'SELECT * FROM test LIMIT 1'
   end
-  
+
   specify "should return nil if no record is present" do
     @e.single_record.should be_nil
   end
@@ -2669,19 +2695,19 @@ describe "Dataset#single_value" do
     @cc = Class.new(@c) do
       def fetch_rows(sql); end
     end
-    
+
     @d = @c.new(nil).from(:test)
     @e = @cc.new(nil).from(:test)
   end
-  
+
   specify "should call each and return the first value of the first record" do
     @d.single_value.should == 'SELECT * FROM test LIMIT 1'
   end
-  
+
   specify "should return nil if no records" do
     @e.single_value.should be_nil
   end
-  
+
   it "should work on a graphed_dataset" do
     @d.should_receive(:columns).twice.and_return([:a])
     @d.graph(@d, [:a], :table_alias=>:test2).single_value.should == 'SELECT test.a, test2.a AS test2_a FROM test LEFT OUTER JOIN test AS test2 USING (a) LIMIT 1'
@@ -2692,34 +2718,34 @@ describe "Dataset#get" do
   before do
     @c = Class.new(Sequel::Dataset) do
       attr_reader :last_sql
-      
+
       def fetch_rows(sql)
         @last_sql = sql
         yield(:name => sql)
       end
     end
-    
+
     @d = @c.new(nil).from(:test)
   end
-  
+
   specify "should select the specified column and fetch its value" do
     @d.get(:name).should == "SELECT name FROM test LIMIT 1"
     @d.get(:abc).should == "SELECT abc FROM test LIMIT 1" # the first available value is returned always
   end
-  
+
   specify "should work with filters" do
     @d.filter(:id => 1).get(:name).should == "SELECT name FROM test WHERE (id = 1) LIMIT 1"
   end
-  
+
   specify "should work with aliased fields" do
     @d.get(:x__b.as(:name)).should == "SELECT x.b AS name FROM test LIMIT 1"
   end
-  
+
   specify "should accept a block that yields a virtual row" do
     @d.get{|o| o.x__b.as(:name)}.should == "SELECT x.b AS name FROM test LIMIT 1"
     @d.get{x(1).as(:name)}.should == "SELECT x(1) AS name FROM test LIMIT 1"
   end
-  
+
   specify "should raise an error if both a regular argument and block argument are used" do
     proc{@d.get(:name){|o| o.x__b.as(:name)}}.should raise_error(Sequel::Error)
   end
@@ -2735,19 +2761,19 @@ describe "Dataset#set_row_proc" do
     end
     @dataset = @c.new(nil).from(:items)
   end
-  
+
   specify "should cause dataset to pass all rows through the filter" do
     @dataset.row_proc = proc{|h| h[:der] = h[:kind] + 2; h}
-    
+
     rows = @dataset.all
     rows.size.should == 10
-    
+
     rows.each {|r| r[:der].should == (r[:kind] + 2)}
   end
-  
+
   specify "should be copied over when dataset is cloned" do
     @dataset.row_proc = proc{|h| h[:der] = h[:kind] + 2; h}
-    
+
     @dataset.filter(:a => 1).first.should == {:kind => 1, :der => 3}
   end
 end
@@ -2759,7 +2785,7 @@ describe "Dataset#<<" do
       1234567890
     end
   end
-  
+
   specify "should call #insert" do
     (@d << {:name => 1}).should == 1234567890
   end
@@ -2769,22 +2795,22 @@ describe "Dataset#columns" do
   before do
     @dataset = DummyDataset.new(nil).from(:items)
     @dataset.meta_def(:columns=) {|c| @columns = c}
-    i = 'a' 
+    i = 'a'
     @dataset.meta_def(:each){@columns = select_sql + i; i = i.next}
   end
-  
+
   specify "should return the value of @columns if @columns is not nil" do
     @dataset.columns = [:a, :b, :c]
     @dataset.columns.should == [:a, :b, :c]
   end
-  
+
   specify "should attempt to get a single record and return @columns if @columns is nil" do
     @dataset.columns = nil
     @dataset.columns.should == 'SELECT * FROM items LIMIT 1a'
     @dataset.opts[:from] = [:nana]
     @dataset.columns.should == 'SELECT * FROM items LIMIT 1a'
   end
-  
+
   specify "should ignore any filters, orders, or DISTINCT clauses" do
     @dataset.filter!(:b=>100).order!(:b).distinct!
     @dataset.columns = nil
@@ -2795,10 +2821,10 @@ end
 describe "Dataset#columns!" do
   before do
     @dataset = DummyDataset.new(nil).from(:items)
-    i = 'a' 
+    i = 'a'
     @dataset.meta_def(:each){@columns = select_sql + i; i = i.next}
   end
-  
+
   specify "should always attempt to get a record and return @columns" do
     @dataset.columns!.should == 'SELECT * FROM items LIMIT 1a'
     @dataset.columns!.should == 'SELECT * FROM items LIMIT 1b'
@@ -2811,13 +2837,13 @@ describe "Dataset#import" do
   before do
     @dbc = Class.new(Sequel::Database) do
       attr_reader :sqls
-      
+
       def execute(sql, opts={})
         @sqls ||= []
         @sqls << sql
       end
       alias execute_dui execute
-      
+
       def transaction(opts={})
         @sqls ||= []
         @sqls << 'BEGIN'
@@ -2826,12 +2852,12 @@ describe "Dataset#import" do
       end
     end
     @db = @dbc.new
-    
+
     @ds = Sequel::Dataset.new(@db).from(:items)
-    
+
     @list = [{:name => 'abc'}, {:name => 'def'}, {:name => 'ghi'}]
   end
-  
+
   specify "should accept string keys as column names" do
     @ds.import(['x', 'y'], [[1, 2], [3, 4]])
     @db.sqls.should == [
@@ -2854,7 +2880,7 @@ describe "Dataset#import" do
 
   specify "should accept a columns array and a dataset" do
     @ds2 = Sequel::Dataset.new(@db).from(:cats).filter(:purr => true).select(:a, :b)
-    
+
     @ds.import([:x, :y], @ds2)
     @db.sqls.should == [
       'BEGIN',
@@ -2891,13 +2917,13 @@ describe "Dataset#multi_insert" do
   before do
     @dbc = Class.new do
       attr_reader :sqls
-      
+
       def execute(sql, opts={})
         @sqls ||= []
         @sqls << sql
       end
       alias execute_dui execute
-      
+
       def transaction(opts={})
         @sqls ||= []
         @sqls << 'BEGIN'
@@ -2906,12 +2932,12 @@ describe "Dataset#multi_insert" do
       end
     end
     @db = @dbc.new
-    
+
     @ds = Sequel::Dataset.new(@db).from(:items)
-    
+
     @list = [{:name => 'abc'}, {:name => 'def'}, {:name => 'ghi'}]
   end
-  
+
   specify "should issue multiple insert statements inside a transaction" do
     @ds.multi_insert(@list)
     @db.sqls.should == [
@@ -2922,7 +2948,7 @@ describe "Dataset#multi_insert" do
       'COMMIT'
     ]
   end
-  
+
   specify "should handle different formats for tables" do
     @ds = @ds.from(:sch__tab)
     @ds.multi_insert(@list)
@@ -2955,7 +2981,7 @@ describe "Dataset#multi_insert" do
       'COMMIT'
     ]
   end
-  
+
   specify "should accept the :commit_every option for committing every x records" do
     @ds.multi_insert(@list, :commit_every => 1)
     @db.sqls.should == [
@@ -2983,7 +3009,7 @@ describe "Dataset#multi_insert" do
       'COMMIT'
     ]
   end
-  
+
   specify "should accept string keys as column names" do
     @ds.multi_insert([{'x'=>1, 'y'=>2}, {'x'=>3, 'y'=>4}])
     @db.sqls.should == [
@@ -3009,7 +3035,7 @@ describe "Dataset" do
     @d.select!(:y)
     @d.sql.should == "SELECT y FROM x"
   end
-  
+
   specify "should support self-changing from!" do
     @d.from!(:y)
     @d.sql.should == "SELECT * FROM y"
@@ -3019,7 +3045,7 @@ describe "Dataset" do
     @d.order!(:y)
     @d.sql.should == "SELECT * FROM x ORDER BY y"
   end
-  
+
   specify "should support self-changing filter!" do
     @d.filter!(:y => 1)
     @d.sql.should == "SELECT * FROM x WHERE (y = 1)"
@@ -3029,17 +3055,17 @@ describe "Dataset" do
     @d.filter!{:y.sql_number < 2}
     @d.sql.should == "SELECT * FROM x WHERE (y < 2)"
   end
-  
+
   specify "should raise for ! methods that don't return a dataset" do
     proc {@d.opts!}.should raise_error(NameError)
   end
-  
+
   specify "should raise for missing methods" do
     proc {@d.xuyz}.should raise_error(NameError)
     proc {@d.xyz!}.should raise_error(NameError)
     proc {@d.xyz?}.should raise_error(NameError)
   end
-  
+
   specify "should support chaining of bang methods" do
       @d.order!(:y)
       @d.filter!(:y => 1)
@@ -3052,22 +3078,22 @@ describe "Dataset#to_csv" do
     @c = Class.new(Sequel::Dataset) do
       attr_accessor :data
       attr_accessor :columns
-      
+
       def fetch_rows(sql, &block)
         @data.each(&block)
       end
-      
+
       # naked should return self here because to_csv wants a naked result set.
       def naked
         self
       end
     end
-    
+
     @ds = @c.new(nil).from(:items)
     @ds.columns = [:a, :b, :c]
     @ds.data = [ {:a=>1, :b=>2, :c=>3}, {:a=>4, :b=>5, :c=>6}, {:a=>7, :b=>8, :c=>9} ]
   end
-  
+
   specify "should format a CSV representation of the records" do
     @ds.to_csv.should ==
       "a, b, c\r\n1, 2, 3\r\n4, 5, 6\r\n7, 8, 9\r\n"
@@ -3083,15 +3109,15 @@ describe "Dataset#update_sql" do
   before do
     @ds = Sequel::Dataset.new(nil).from(:items)
   end
-  
+
   specify "should accept strings" do
     @ds.update_sql("a = b").should == "UPDATE items SET a = b"
   end
-  
+
   specify "should handle implicitly qualified symbols" do
     @ds.update_sql(:items__a=>:b).should == "UPDATE items SET items.a = b"
   end
-  
+
   specify "should accept hash with string keys" do
     @ds.update_sql('c' => 'd').should == "UPDATE items SET c = 'd'"
   end
@@ -3105,7 +3131,7 @@ describe "Dataset#insert_sql" do
   before do
     @ds = Sequel::Dataset.new(nil).from(:items)
   end
-  
+
   specify "should accept hash with symbol keys" do
     @ds.insert_sql(:c => 'd').should == "INSERT INTO items (c) VALUES ('d')"
   end
@@ -3121,51 +3147,51 @@ describe "Dataset#insert_sql" do
   specify "should raise an Error if the dataset has no sources" do
     proc{Sequel::Database.new.dataset.insert_sql}.should raise_error(Sequel::Error)
   end
-  
+
   specify "should accept datasets" do
     @ds.insert_sql(@ds).should == "INSERT INTO items SELECT * FROM items"
   end
-  
+
   specify "should accept datasets with columns" do
     @ds.insert_sql([:a, :b], @ds).should == "INSERT INTO items (a, b) SELECT * FROM items"
   end
-  
+
   specify "should raise if given bad values" do
     proc{@ds.clone(:values=>'a').send(:_insert_sql)}.should raise_error(Sequel::Error)
   end
-  
+
   specify "should accept separate values" do
     @ds.insert_sql(1).should == "INSERT INTO items VALUES (1)"
     @ds.insert_sql(1, 2).should == "INSERT INTO items VALUES (1, 2)"
     @ds.insert_sql(1, 2, 3).should == "INSERT INTO items VALUES (1, 2, 3)"
   end
-  
+
   specify "should accept a single array of values" do
     @ds.insert_sql([1, 2, 3]).should == "INSERT INTO items VALUES (1, 2, 3)"
   end
-  
+
   specify "should accept an array of columns and an array of values" do
     @ds.insert_sql([:a, :b, :c], [1, 2, 3]).should == "INSERT INTO items (a, b, c) VALUES (1, 2, 3)"
   end
-  
+
   specify "should raise an array if the columns and values differ in size" do
     proc{@ds.insert_sql([:a, :b], [1, 2, 3])}.should raise_error(Sequel::Error)
   end
-  
+
   specify "should accept a single LiteralString" do
     @ds.insert_sql('VALUES (1, 2, 3)'.lit).should == "INSERT INTO items VALUES (1, 2, 3)"
   end
-  
+
   specify "should accept an array of columns and an LiteralString" do
     @ds.insert_sql([:a, :b, :c], 'VALUES (1, 2, 3)'.lit).should == "INSERT INTO items (a, b, c) VALUES (1, 2, 3)"
   end
-  
+
   specify "should accept an object that responds to values and returns a hash by using that hash as the columns and values" do
     o = Object.new
     def o.values; {:c=>'d'}; end
     @ds.insert_sql(o).should == "INSERT INTO items (c) VALUES ('d')"
   end
-  
+
   specify "should accept an object that responds to values and returns something other than a hash by using the object itself as a single value" do
     o = Date.civil(2000, 1, 1)
     def o.values; self; end
@@ -3182,12 +3208,12 @@ end
 
 class DummyMummyDatabase < Sequel::Database
   attr_reader :sqls
-  
+
   def execute(sql)
     @sqls ||= []
     @sqls << sql
   end
-  
+
   def transaction; yield; end
 
   def dataset
@@ -3199,7 +3225,7 @@ describe "Dataset#inspect" do
   before do
     @ds = Sequel::Dataset.new(nil).from(:blah)
   end
-  
+
   specify "should include the class name and the corresponding SQL statement" do
     @ds.inspect.should == '#<%s: %s>' % [@ds.class.to_s, @ds.sql.inspect]
   end
@@ -3224,14 +3250,14 @@ describe "Dataset#all" do
       "SELECT * FROM items"
     ]
   end
-  
+
   specify "should iterate over the array if a block is given" do
     a = []
-    
+
     @dataset.all do |r|
       a << (r.is_a?(Hash) ? r[:x] : r)
     end
-    
+
     a.should == [1, 3, "SELECT * FROM items"]
   end
 end
@@ -3240,7 +3266,7 @@ describe "Dataset#grep" do
   before do
     @ds = Sequel::Dataset.new(nil).from(:posts)
   end
-  
+
   specify "should format a SQL filter correctly" do
     @ds.grep(:title, 'ruby').sql.should ==
       "SELECT * FROM posts WHERE ((title LIKE 'ruby'))"
@@ -3250,47 +3276,47 @@ describe "Dataset#grep" do
     @ds.grep([:title, :body], 'ruby').sql.should ==
       "SELECT * FROM posts WHERE ((title LIKE 'ruby') OR (body LIKE 'ruby'))"
   end
-  
+
   specify "should support multiple search terms" do
-    @ds.grep(:title, ['abc', 'def']).sql.should == 
+    @ds.grep(:title, ['abc', 'def']).sql.should ==
       "SELECT * FROM posts WHERE ((title LIKE 'abc') OR (title LIKE 'def'))"
   end
-  
+
   specify "should support multiple columns and search terms" do
     @ds.grep([:title, :body], ['abc', 'def']).sql.should ==
       "SELECT * FROM posts WHERE ((title LIKE 'abc') OR (title LIKE 'def') OR (body LIKE 'abc') OR (body LIKE 'def'))"
   end
-  
+
   specify "should support the :all_patterns option" do
     @ds.grep([:title, :body], ['abc', 'def'], :all_patterns=>true).sql.should ==
       "SELECT * FROM posts WHERE (((title LIKE 'abc') OR (body LIKE 'abc')) AND ((title LIKE 'def') OR (body LIKE 'def')))"
   end
-  
+
   specify "should support the :all_columns option" do
     @ds.grep([:title, :body], ['abc', 'def'], :all_columns=>true).sql.should ==
       "SELECT * FROM posts WHERE (((title LIKE 'abc') OR (title LIKE 'def')) AND ((body LIKE 'abc') OR (body LIKE 'def')))"
   end
-  
+
   specify "should support the :case_insensitive option" do
     @ds.grep([:title, :body], ['abc', 'def'], :case_insensitive=>true).sql.should ==
       "SELECT * FROM posts WHERE ((title ILIKE 'abc') OR (title ILIKE 'def') OR (body ILIKE 'abc') OR (body ILIKE 'def'))"
   end
-  
+
   specify "should support the :all_patterns and :all_columns options together" do
     @ds.grep([:title, :body], ['abc', 'def'], :all_patterns=>true, :all_columns=>true).sql.should ==
       "SELECT * FROM posts WHERE ((title LIKE 'abc') AND (body LIKE 'abc') AND (title LIKE 'def') AND (body LIKE 'def'))"
   end
-  
+
   specify "should support the :all_patterns and :case_insensitive options together" do
     @ds.grep([:title, :body], ['abc', 'def'], :all_patterns=>true, :case_insensitive=>true).sql.should ==
       "SELECT * FROM posts WHERE (((title ILIKE 'abc') OR (body ILIKE 'abc')) AND ((title ILIKE 'def') OR (body ILIKE 'def')))"
   end
-  
+
   specify "should support the :all_columns and :case_insensitive options together" do
     @ds.grep([:title, :body], ['abc', 'def'], :all_columns=>true, :case_insensitive=>true).sql.should ==
       "SELECT * FROM posts WHERE (((title ILIKE 'abc') OR (title ILIKE 'def')) AND ((body ILIKE 'abc') OR (body ILIKE 'def')))"
   end
-  
+
   specify "should support the :all_patterns, :all_columns, and :case_insensitive options together" do
     @ds.grep([:title, :body], ['abc', 'def'], :all_patterns=>true, :all_columns=>true, :case_insensitive=>true).sql.should ==
       "SELECT * FROM posts WHERE ((title ILIKE 'abc') AND (body ILIKE 'abc') AND (title ILIKE 'def') AND (body ILIKE 'def'))"
@@ -3340,18 +3366,18 @@ describe "Dataset default #fetch_rows, #insert, #update, #delete, #truncate, #ex
     @db.should_receive(:execute_dui).once.with('UPDATE items SET number = 1', :server=>:default)
     @ds.update(:number=>1)
   end
-  
+
   specify "#truncate should execute truncate SQL" do
     @db.should_receive(:execute).once.with('TRUNCATE TABLE items', :server=>:default)
     @ds.truncate.should == nil
     @db.should_receive(:execute_ddl).once.with('TRUNCATE TABLE items', :server=>:default)
     @ds.truncate.should == nil
   end
-  
+
   specify "#truncate should raise an InvalidOperation exception if the dataset is filtered" do
     proc{@ds.filter(:a=>1).truncate}.should raise_error(Sequel::InvalidOperation)
   end
-  
+
   specify "#execute should execute the SQL on the database" do
     @db.should_receive(:execute).once.with('SELECT 1', :server=>:read_only)
     @ds.send(:execute, 'SELECT 1')
@@ -3375,7 +3401,7 @@ describe "Dataset prepared statements and bound variables " do
     @ds = @db[:items]
     @ds.meta_def(:insert_sql){|*v| "#{super(*v)}#{' RETURNING *' if opts.has_key?(:returning)}" }
   end
-  
+
   specify "#call should take a type and bind hash and interpolate it" do
     @ds.filter(:num=>:$n).call(:select, :n=>1)
     @ds.filter(:num=>:$n).call(:first, :n=>1)
@@ -3390,7 +3416,7 @@ describe "Dataset prepared statements and bound variables " do
       'INSERT INTO items (num) VALUES (1)',
       'INSERT INTO items (num) VALUES (1) RETURNING *']
   end
-    
+
   specify "#prepare should take a type and name and store it in the database for later use with call" do
     pss = []
     pss << @ds.filter(:num=>:$n).prepare(:select, :sn)
@@ -3414,37 +3440,37 @@ describe "Dataset prepared statements and bound variables " do
       'INSERT INTO items (num) VALUES (1)',
       'INSERT INTO items (num) VALUES (1) RETURNING *']
   end
-    
+
   specify "#inspect should indicate it is a prepared statement with the prepared SQL" do
     @ds.filter(:num=>:$n).prepare(:select, :sn).inspect.should == \
       '<Sequel::Dataset/PreparedStatement "SELECT * FROM items WHERE (num = $n)">'
   end
-    
+
   specify "should handle literal strings" do
     @ds.filter("num = ?", :$n).call(:select, :n=>1)
     @db.sqls.should == ['SELECT * FROM items WHERE (num = 1)']
   end
-    
+
   specify "should handle datasets using static sql and placeholders" do
     @db["SELECT * FROM items WHERE (num = ?)", :$n].call(:select, :n=>1)
     @db.sqls.should == ['SELECT * FROM items WHERE (num = 1)']
   end
-    
+
   specify "should handle subselects" do
     @ds.filter(:$b).filter(:num=>@ds.select(:num).filter(:num=>:$n)).filter(:$c).call(:select, :n=>1, :b=>0, :c=>2)
     @db.sqls.should == ['SELECT * FROM items WHERE (0 AND (num IN (SELECT num FROM items WHERE (num = 1))) AND 2)']
   end
-    
+
   specify "should handle subselects in subselects" do
     @ds.filter(:$b).filter(:num=>@ds.select(:num).filter(:num=>@ds.select(:num).filter(:num=>:$n))).call(:select, :n=>1, :b=>0)
     @db.sqls.should == ['SELECT * FROM items WHERE (0 AND (num IN (SELECT num FROM items WHERE (num IN (SELECT num FROM items WHERE (num = 1))))))']
   end
-    
+
   specify "should handle subselects with literal strings" do
     @ds.filter(:$b).filter(:num=>@ds.select(:num).filter("num = ?", :$n)).call(:select, :n=>1, :b=>0)
     @db.sqls.should == ['SELECT * FROM items WHERE (0 AND (num IN (SELECT num FROM items WHERE (num = 1))))']
   end
-    
+
   specify "should handle subselects with static sql and placeholders" do
     @ds.filter(:$b).filter(:num=>@db["SELECT num FROM items WHERE (num = ?)", :$n]).call(:select, :n=>1, :b=>0)
     @db.sqls.should == ['SELECT * FROM items WHERE (0 AND (num IN (SELECT num FROM items WHERE (num = 1))))']
@@ -3484,7 +3510,7 @@ describe Sequel::Dataset::UnnumberedArgumentMapper do
   specify "#inspect should show the actual SQL submitted to the database" do
     @ps.first.inspect.should == '<Sequel::Dataset/PreparedStatement "SELECT * FROM items WHERE (num = ?)">'
   end
-  
+
   specify "should submitted the SQL to the database with placeholders and bind variables" do
     @ps.each{|p| p.prepared_sql; p.call(:n=>1)}
     @db.sqls.should == [["SELECT * FROM items WHERE (num = ?)", 1],
@@ -3770,7 +3796,7 @@ describe "Sequel::Dataset #with and #with_recursive" do
     @db = MockDatabase.new
     @ds = @db[:t]
   end
-  
+
   specify "#with should take a name and dataset and use a WITH clause" do
     @ds.with(:t, @db[:x]).sql.should == 'WITH t AS (SELECT * FROM x) SELECT * FROM t'
   end
@@ -3778,18 +3804,18 @@ describe "Sequel::Dataset #with and #with_recursive" do
   specify "#with_recursive should take a name, nonrecursive dataset, and recursive dataset, and use a WITH clause" do
     @ds.with_recursive(:t, @db[:x], @db[:t]).sql.should == 'WITH t AS (SELECT * FROM x UNION ALL SELECT * FROM t) SELECT * FROM t'
   end
-  
+
   specify "#with and #with_recursive should add to existing WITH clause if called multiple times" do
     @ds.with(:t, @db[:x]).with(:j, @db[:y]).sql.should == 'WITH t AS (SELECT * FROM x), j AS (SELECT * FROM y) SELECT * FROM t'
     @ds.with_recursive(:t, @db[:x], @db[:t]).with_recursive(:j, @db[:y], @db[:j]).sql.should == 'WITH t AS (SELECT * FROM x UNION ALL SELECT * FROM t), j AS (SELECT * FROM y UNION ALL SELECT * FROM j) SELECT * FROM t'
     @ds.with(:t, @db[:x]).with_recursive(:j, @db[:y], @db[:j]).sql.should == 'WITH t AS (SELECT * FROM x), j AS (SELECT * FROM y UNION ALL SELECT * FROM j) SELECT * FROM t'
   end
-  
+
   specify "#with and #with_recursive should take an :args option" do
     @ds.with(:t, @db[:x], :args=>[:b]).sql.should == 'WITH t(b) AS (SELECT * FROM x) SELECT * FROM t'
     @ds.with_recursive(:t, @db[:x], @db[:t], :args=>[:b, :c]).sql.should == 'WITH t(b, c) AS (SELECT * FROM x UNION ALL SELECT * FROM t) SELECT * FROM t'
   end
-  
+
   specify "#with_recursive should take an :union_all=>false option" do
     @ds.with_recursive(:t, @db[:x], @db[:t], :union_all=>false).sql.should == 'WITH t AS (SELECT * FROM x UNION SELECT * FROM t) SELECT * FROM t'
   end
@@ -3805,7 +3831,7 @@ describe Sequel::SQL::Constants do
   before do
     @db = MockDatabase.new
   end
-  
+
   it "should have CURRENT_DATE" do
     @db.literal(Sequel::SQL::Constants::CURRENT_DATE) == 'CURRENT_DATE'
     @db.literal(Sequel::CURRENT_DATE) == 'CURRENT_DATE'
@@ -3858,7 +3884,7 @@ describe "Sequel timezone support" do
     Sequel.default_timezone = nil
     Sequel.datetime_class = Time
   end
-  
+
   specify "should handle an database timezone of :utc when literalizing values" do
     Sequel.database_timezone = :utc
 
@@ -3870,7 +3896,7 @@ describe "Sequel timezone support" do
     s = t.new_offset(0).strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}+0000'"
   end
-  
+
   specify "should handle an database timezone of :local when literalizing values" do
     Sequel.database_timezone = :local
 
@@ -3882,7 +3908,7 @@ describe "Sequel timezone support" do
     s = t.new_offset(DateTime.now.offset).strftime("'%Y-%m-%d %H:%M:%S")
     @dataset.literal(t).should == "#{s}#{@offset}'"
   end
-  
+
   specify "should handle converting database timestamps into application timestamps" do
     Sequel.database_timezone = :utc
     Sequel.application_timezone = :local
@@ -3890,27 +3916,27 @@ describe "Sequel timezone support" do
     Sequel.database_to_application_timestamp(t).to_s.should == t.getlocal.to_s
     Sequel.database_to_application_timestamp(t.to_s).to_s.should == t.getlocal.to_s
     Sequel.database_to_application_timestamp(t.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == t.getlocal.to_s
-    
+
     Sequel.datetime_class = DateTime
     dt = DateTime.now
     dt2 = dt.new_offset(0)
     Sequel.database_to_application_timestamp(dt2).to_s.should == dt.to_s
     Sequel.database_to_application_timestamp(dt2.to_s).to_s.should == dt.to_s
     Sequel.database_to_application_timestamp(dt2.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == dt.to_s
-    
+
     Sequel.datetime_class = Time
     Sequel.database_timezone = :local
     Sequel.application_timezone = :utc
     Sequel.database_to_application_timestamp(t.getlocal).to_s.should == t.to_s
     Sequel.database_to_application_timestamp(t.getlocal.to_s).to_s.should == t.to_s
     Sequel.database_to_application_timestamp(t.getlocal.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == t.to_s
-    
+
     Sequel.datetime_class = DateTime
     Sequel.database_to_application_timestamp(dt).to_s.should == dt2.to_s
     Sequel.database_to_application_timestamp(dt.to_s).to_s.should == dt2.to_s
     Sequel.database_to_application_timestamp(dt.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == dt2.to_s
   end
-  
+
   specify "should handle typecasting timestamp columns" do
     Sequel.typecast_timezone = :utc
     Sequel.application_timezone = :local
@@ -3918,52 +3944,52 @@ describe "Sequel timezone support" do
     @db.typecast_value(:datetime, t).to_s.should == t.getlocal.to_s
     @db.typecast_value(:datetime, t.to_s).to_s.should == t.getlocal.to_s
     @db.typecast_value(:datetime, t.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == t.getlocal.to_s
-    
+
     Sequel.datetime_class = DateTime
     dt = DateTime.now
     dt2 = dt.new_offset(0)
     @db.typecast_value(:datetime, dt2).to_s.should == dt.to_s
     @db.typecast_value(:datetime, dt2.to_s).to_s.should == dt.to_s
     @db.typecast_value(:datetime, dt2.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == dt.to_s
-    
+
     Sequel.datetime_class = Time
     Sequel.typecast_timezone = :local
     Sequel.application_timezone = :utc
     @db.typecast_value(:datetime, t.getlocal).to_s.should == t.to_s
     @db.typecast_value(:datetime, t.getlocal.to_s).to_s.should == t.to_s
     @db.typecast_value(:datetime, t.getlocal.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == t.to_s
-    
+
     Sequel.datetime_class = DateTime
     @db.typecast_value(:datetime, dt).to_s.should == dt2.to_s
     @db.typecast_value(:datetime, dt.to_s).to_s.should == dt2.to_s
     @db.typecast_value(:datetime, dt.strftime('%Y-%m-%d %H:%M:%S')).to_s.should == dt2.to_s
   end
-  
+
   specify "should handle converting database timestamp columns from an array of values" do
     Sequel.database_timezone = :utc
     Sequel.application_timezone = :local
     t = Time.now.utc
     Sequel.database_to_application_timestamp([t.year, t.mon, t.day, t.hour, t.min, t.sec]).to_s.should == t.getlocal.to_s
-    
+
     Sequel.datetime_class = DateTime
     dt = DateTime.now
     dt2 = dt.new_offset(0)
     Sequel.database_to_application_timestamp([dt2.year, dt2.mon, dt2.day, dt2.hour, dt2.min, dt2.sec]).to_s.should == dt.to_s
-    
+
     Sequel.datetime_class = Time
     Sequel.database_timezone = :local
     Sequel.application_timezone = :utc
     t = t.getlocal
     Sequel.database_to_application_timestamp([t.year, t.mon, t.day, t.hour, t.min, t.sec]).to_s.should == t.getutc.to_s
-    
+
     Sequel.datetime_class = DateTime
     Sequel.database_to_application_timestamp([dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec]).to_s.should == dt2.to_s
   end
-  
+
   specify "should raise an InvalidValue error when an error occurs while converting a timestamp" do
     proc{Sequel.database_to_application_timestamp([0, 0, 0, 0, 0, 0])}.should raise_error(Sequel::InvalidValue)
   end
-  
+
   specify "should raise an error when attempting to typecast to a timestamp from an unsupported type" do
     proc{Sequel.database_to_application_timestamp(Object.new)}.should raise_error(Sequel::InvalidValue)
   end
@@ -3973,7 +3999,7 @@ describe "Sequel timezone support" do
     Sequel.datetime_class = DateTime
     proc{Sequel.database_to_application_timestamp('2009-06-01 10:20:30')}.should raise_error(Sequel::InvalidValue)
   end
-  
+
   specify "should raise an InvalidValue error when the DateTime class is used and when a bad database timezone is used when attempting to convert timestamps" do
     Sequel.database_timezone = :blah
     Sequel.datetime_class = DateTime
@@ -4021,7 +4047,7 @@ describe "Sequel::Dataset#select_map" do
     @ds.select_map("a".lit.as(:b)).should == [1, 2]
     @ds.db.sqls.should == ['SELECT a AS b FROM t']
   end
-  
+
   specify "should accept a block" do
     @ds.select_map{a(t__c)}.should == [1, 2]
     @ds.db.sqls.should == ['SELECT a(t.c) FROM t']
@@ -4063,7 +4089,7 @@ describe "Sequel::Dataset#select_order_map" do
     @ds.select_order_map("a".lit.as(:b)).should == [1, 2]
     @ds.db.sqls.should == ['SELECT a AS b FROM t ORDER BY a']
   end
-  
+
   specify "should accept a block" do
     @ds.select_order_map{a(t__c)}.should == [1, 2]
     @ds.db.sqls.should == ['SELECT a(t.c) FROM t ORDER BY a(t.c)']
@@ -4130,15 +4156,15 @@ describe "Dataset#lock_style and for_update" do
   before do
     @ds = MockDatabase.new[:t]
   end
-  
+
   specify "#for_update should use FOR UPDATE" do
     @ds.for_update.sql.should == "SELECT * FROM t FOR UPDATE"
   end
-  
+
   specify "#lock_style should accept symbols" do
     @ds.lock_style(:update).sql.should == "SELECT * FROM t FOR UPDATE"
   end
-  
+
   specify "#lock_style should accept strings for arbitrary SQL" do
     @ds.lock_style("FOR SHARE").sql.should == "SELECT * FROM t FOR SHARE"
   end


### PR DESCRIPTION
I needed a way to have my generated SQL command on the dataset to be altered with select_append, but also to remove some columns before firing to the db.

This pull simply adds select_remove, as the opposite action for existing select_append.

Test attached.
