### PR TITLE
Add missing class attribute reader :dataset to Sequel::Model instance methods

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -764,7 +764,7 @@ module Sequel
 
       private_class_method :class_attr_overridable, :class_attr_reader
 
-      class_attr_reader :columns, :db, :primary_key, :db_schema
+      class_attr_reader :columns, :dataset, :db, :primary_key, :db_schema
       class_attr_overridable *BOOLEAN_SETTINGS
 
       # The hash of attribute values.  Keys are symbols with the names of the


### PR DESCRIPTION
Add class attribute reader :dataset to model instance methods per documentation.

The documentation states "The following instance_methods all call the class method of the same name: columns, dataset, db, primary_key, db_schema.", but in the code, the class_attr_reader call omits "dataset".
