### PR TITLE
Add initial support for DB2 via the ODBC adapter

### DIFF
--- a/lib/sequel/adapters/odbc.rb
+++ b/lib/sequel/adapters/odbc.rb
@@ -19,6 +19,9 @@ module Sequel
         when 'progress'
           Sequel.ts_require 'adapters/shared/progress'
           extend Sequel::Progress::DatabaseMethods
+        when 'db2'
+          Sequel.ts_require 'adapters/odbc/db2'
+          extend Sequel::ODBC::DB2::DatabaseMethods
         end
       end
 

--- a/lib/sequel/adapters/odbc/db2.rb
+++ b/lib/sequel/adapters/odbc/db2.rb
@@ -1,0 +1,21 @@
+module Sequel
+  module ODBC
+    # Database and Dataset instance methods for DB2 specific
+    # support via ODBC.
+    module DB2
+      module DatabaseMethods
+        def dataset(opts=nil)
+          Sequel::ODBC::DB2::Dataset.new(self, opts)
+        end
+      end
+      
+      class Dataset < ODBC::Dataset
+        def select_limit_sql(sql)
+          if l = @opts[:limit]
+            sql << " FETCH FIRST #{l == 1 ? 'ROW' : "#{literal(l)} ROWS"} ONLY"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Jeremy thanks for your tireless work on Sequel. This project has saved me more time and sanity over the past couple years than I care to admit. As a way of saying thanks, I'd like to start by contributing this patch to start the ground work of adding DB2 support via ODBC (and JDBC shortly). Thanks again for working so hard to make our jobs in the Ruby community easier.

As I flesh this code out, I plan on moving it into the shared space for the adapters and also pull in already existing stuff from the db2 adapter as it's needed.
