### PR TITLE
fix SecurityError on connect with $SAFE=1

### DIFF
--- a/lib/sequel/core.rb
+++ b/lib/sequel/core.rb
@@ -188,7 +188,7 @@ module Sequel
   # This is used to ensure that the files loaded are from the same version of
   # Sequel as this file.
   def self.require(files, subdir=nil)
-    Array(files).each{|f| super("#{File.dirname(__FILE__)}/#{"#{subdir}/" if subdir}#{f}")}
+    Array(files).each{|f| super("#{File.dirname(__FILE__).untaint}/#{"#{subdir}/" if subdir}#{f}")}
   end
   
   # Set whether to set the single threaded mode for all databases by default. By default,


### PR DESCRIPTION
If core.rb was required without raising a SecurityError, the directory
it was loaded from is trusted enough to untaint.

Steps to reproduce:

``` ruby
$SAFE=1
require 'sequel'
db = Sequel.connect(
  :adapter=>'postgres',
  :database=>'db',
  :user=>'user')
```

At which point, you get "Insecure operation - require (SecurityError)".
