### PR TITLE
Change #each to always yield model instances

### DIFF
--- a/spec/extensions/many_through_many_spec.rb
+++ b/spec/extensions/many_through_many_spec.rb
@@ -880,8 +880,11 @@ describe "Sequel::Plugins::ManyThroughMany eager loading methods" do
     MODEL_DB.sqls.length.should == 1
   end
 
-  it "eager graphing should give you a plain hash when called without .all" do 
-    @c1.eager_graph(:tags, :artists).first.should == {:albums_0_id=>3, :artists_0_id=>10, :id=>1, :tags_id=>2}
+  it "eager graphing should give you model instances when called without .all" do
+    a = @c1.eager_graph(:tags, :artists).first
+    a.should == @c1.load(:id=>1)
+    a.tags.should == [Tag.load(:id=>2)]
+    a.artists.should == [@c1.load(:id=>10)]
   end
 
   it "should be able to use eager and eager_graph together" do

--- a/spec/model/eager_loading_spec.rb
+++ b/spec/model/eager_loading_spec.rb
@@ -1100,11 +1100,13 @@ describe Sequel::Model, "#eager_graph" do
     a.members.first.values.should == {:id => 5}
   end
 
-  it "should give you a plain hash when called without .all" do 
+  it "should give you model instances when called without .all" do
     ds = GraphAlbum.eager_graph(:band)
     ds.sql.should == 'SELECT albums.id, albums.band_id, band.id AS band_id_0, band.vocalist_id FROM albums LEFT OUTER JOIN bands AS band ON (band.id = albums.band_id)'
     ds._fetch = {:id=>1, :band_id=>2, :band_id_0=>2, :vocalist_id=>3}
-    ds.first.should == {:id=>1, :band_id=>2, :band_id_0=>2, :vocalist_id=>3}
+    ds.first.should be_a_kind_of(GraphAlbum)
+    ds.first.values.should == {:id=>1, :band_id=>2}
+    ds.first.band.values.should == {:id=>2, :vocalist_id=>3}
   end
 
   it "should not drop any associated objects if the graph could not be a cartesian product" do


### PR DESCRIPTION
Opening a pull request to gauge your feeling on this change; I think you've said you were open to the idea when it was previously discussed, and it looks pretty easy to do.

I'm upgrading an app from 3.22 which is affected by the backward compatibility changes that came with eager graphing performance improvements (99beb68ecef93dd6d721ce74cc3463f20a516c72). Having each yield model instances in all cases would help ease the upgrade for me.

I tested core, model, integration, mssql, and plugin specs. All are passing except for 2 failures in the LazyAttributes plugin which I'm not sure of the cause.
