### PR TITLE
Explicitly order by the row number column when using ROW_NUMBER

### DIFF
--- a/lib/sequel/adapters/utils/emulate_offset_with_row_number.rb
+++ b/lib/sequel/adapters/utils/emulate_offset_with_row_number.rb
@@ -50,7 +50,8 @@ module Sequel
         select_append{ROW_NUMBER(:over, :order=>order){}.as(rn)}.
         from_self(:alias=>dsa1).
         limit(@opts[:limit]).
-        where(SQL::Identifier.new(rn) > o))
+        where(SQL::Identifier.new(rn) > o).
+        order(rn))
       sql
     end
 


### PR DESCRIPTION
MSSQL does not guarantee ordering of a result set that uses
ROW_NUMBER unless you explicitly order it.

"These ORDER BY clauses do not determine the order that rows will
be returned from the query.  To guarantee absolutely a certain
output order from the query, you must add an explicit query-level
ORDER BY clause" - http://blogs.msdn.com/b/craigfr/archive/2008/03/19/ranking-functions-row-number.aspx

I haven't found it documented for Oracle or DB2, but I wouldn't be
surprised if they behave the same.
