### PR TITLE
Ensure that ILIKE is really case insensitive on MSSQL

### DIFF
--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -283,6 +283,8 @@ module Sequel
       TOP = " TOP ".freeze
       OUTPUT = " OUTPUT ".freeze
       HSTAR = "H*".freeze
+      CASE_SENSITIVE_COLLATION = 'Latin1_General_CS_AS'.freeze
+      CASE_INSENSITIVE_COLLATION = 'Latin1_General_CI_AS'.freeze
 
       # Allow overriding of the mssql_unicode_strings option at the dataset level.
       attr_accessor :mssql_unicode_strings
@@ -299,9 +301,9 @@ module Sequel
         when :'||'
           super(sql, :+, args)
         when :LIKE, :"NOT LIKE"
-          super(sql, op, args.map{|a| LiteralString.new("(#{literal(a)} COLLATE Latin1_General_CS_AS)")})
+          super(sql, op, args.map{|a| LiteralString.new("(#{literal(a)} COLLATE #{CASE_SENSITIVE_COLLATION})")})
         when :ILIKE, :"NOT ILIKE"
-          super(sql, (op == :ILIKE ? :LIKE : :"NOT LIKE"), args)
+          super(sql, (op == :ILIKE ? :LIKE : :"NOT LIKE"), args.map{|a| LiteralString.new("(#{literal(a)} COLLATE #{CASE_INSENSITIVE_COLLATION})")})
         when :<<
           sql << complex_expression_arg_pairs(args){|a, b| "(#{literal(a)} * POWER(2, #{literal(b)}))"}
         when :>>

--- a/spec/integration/dataset_test.rb
+++ b/spec/integration/dataset_test.rb
@@ -1148,7 +1148,10 @@ end
 describe "Dataset string methods" do
   before(:all) do
     @db = INTEGRATION_DB
-    @db.create_table!(:a){String :a; String :b}
+    @db.create_table!(:a) do
+      String :a, ({:collate => @db.dataset.class::CASE_SENSITIVE_COLLATION} if defined? @db.dataset.class::CASE_SENSITIVE_COLLATION)
+      String :b, ({:collate => @db.dataset.class::CASE_INSENSITIVE_COLLATION} if defined? @db.dataset.class::CASE_INSENSITIVE_COLLATION)
+    end
     @ds = @db[:a].order(:a)
   end
   before do
@@ -1200,7 +1203,7 @@ describe "Dataset string methods" do
   it "#like should be case sensitive" do
     @ds.insert('foo', 'bar')
     @ds.filter(:a.like('Foo')).all.should == []
-    @ds.filter(:a.like('baR')).all.should == []
+    @ds.filter(:b.like('baR')).all.should == []
     @ds.filter(:a.like('FOO', 'BAR')).all.should == []
     @ds.exclude(:a.like('Foo')).all.should == [{:a=>'foo', :b=>'bar'}]
     @ds.exclude(:a.like('baR')).all.should == [{:a=>'foo', :b=>'bar'}]
@@ -1219,8 +1222,8 @@ describe "Dataset string methods" do
   
   it "should work with strings created with sql_string_join" do
     @ds.insert('foo', 'bar')
-    @ds.get([:a, :b].sql_string_join).should == 'foobar'
-    @ds.get([:a, :b].sql_string_join(' ')).should == 'foo bar'
+    @ds.get([:a, "bar"].sql_string_join).should == 'foobar'
+    @ds.get(["foo", :b].sql_string_join(' ')).should == 'foo bar'
   end
 end
 


### PR DESCRIPTION
On MSSQL, the LIKE operator uses the collation of the underlying
column or database by default. In order to ensure that it operates
in a case insensitive manner it is necessary to explicitly specify
a case insensitive collation.
