### PR TITLE
Fixed bug with incorrect shard setting processing

### DIFF
--- a/lib/sequel/database/misc.rb
+++ b/lib/sequel/database/misc.rb
@@ -69,9 +69,9 @@ module Sequel
     # If a transaction is not currently in process, yield to the block immediately.
     # Otherwise, add the block to the list of blocks to call after the currently
     # in progress transaction commits (and only if it commits).
-    def after_commit(opts={}, &block)
+    def after_commit(server = nil, &block)
       raise Error, "must provide block to after_commit" unless block
-      synchronize(opts) do |conn|
+      synchronize(server) do |conn|
         if h = @transactions[conn]
           raise Error, "cannot call after_commit in a prepared transaction" if h[:prepare]
           (h[:after_commit] ||= []) << block
@@ -84,9 +84,9 @@ module Sequel
     # If a transaction is not currently in progress, ignore the block.
     # Otherwise, add the block to the list of the blocks to call after the currently
     # in progress transaction rolls back (and only if it rolls back).
-    def after_rollback(opts={}, &block)
+    def after_rollback(server = nil, &block)
       raise Error, "must provide block to after_rollback" unless block
-      synchronize(opts) do |conn|
+      synchronize(server) do |conn|
         if h = @transactions[conn]
           raise Error, "cannot call after_rollback in a prepared transaction" if h[:prepare]
           (h[:after_rollback] ||= []) << block

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1349,8 +1349,7 @@ module Sequel
       # Internal destroy method, separted from destroy to
       # allow running inside a transaction
       def _destroy(opts)
-        sh = {:server=>this_server}
-        db.after_rollback(sh){after_destroy_rollback}
+        db.after_rollback(this_server){after_destroy_rollback}
         called = false
         around_destroy do
           called = true
@@ -1360,7 +1359,7 @@ module Sequel
           true
         end
         raise_hook_failure(:destroy) unless called
-        db.after_commit(sh){after_destroy_commit}
+        db.after_commit(this_server){after_destroy_commit}
         self
       end
       
@@ -1421,8 +1420,7 @@ module Sequel
       # Internal version of save, split from save to allow running inside
       # it's own transaction.
       def _save(columns, opts)
-        sh = {:server=>this_server}
-        db.after_rollback(sh){after_rollback}
+        db.after_rollback(this_server){after_rollback}
         was_new = false
         pk = nil
         called_save = false
@@ -1476,7 +1474,7 @@ module Sequel
           @columns_updated = nil
         end
         @modified = false
-        db.after_commit(sh){after_commit}
+        db.after_commit(this_server){after_commit}
         self
       end
 


### PR DESCRIPTION
Sequel 3.29.0 has a bug that can be represented by simple script: https://gist.github.com/1416991 (can easily be executed with git blame)
