### PR TITLE
Added filter by array documentation

### DIFF
--- a/doc/dataset_filtering.rdoc
+++ b/doc/dataset_filtering.rdoc
@@ -59,6 +59,14 @@ Ranges (both inclusive and exclusive) can also be used:
   items.filter(:price => 100...200).sql
   #=> "SELECT * FROM items WHERE (price >= 100 AND price < 200)"
 
+== Filtering using an array
+
+If you need to select multiple items from a dataset, you can supply an array:
+
+	item_array = [1, 38, 47, 99]
+	items.filter(:id => item_array).sql
+	#=> "SELECT * FROM items WHERE (id IN (1, 38, 47, 99))"
+
 == Filtering using expressions
 
 Sequel allows you to use ruby expressions directly in the call to filter:


### PR DESCRIPTION
I updated the doc/dataset_filtering.rdoc file to have a section on filtering by array for the selection of multiple rows at once. 

This evening I found myself needing to do this to select various user ids in a database all at once so I could get the usernames on them. I wanted to do this in a single query but found the documentation didn't outline how to do such and this seemed to be an elegant solution that appears to work well. 
