### PR TITLE
I added support for naming foreign keys, using a :constraint_name option

### DIFF
--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -226,6 +226,9 @@ module Sequel
 
       # Add a composite foreign key constraint
       def composite_foreign_key(columns, opts)
+        if (opts[:constraint_name] != nil) then
+            opts[:name] = opts[:constraint_name]
+        end
         constraints << {:type => :foreign_key, :columns => columns}.merge(opts)
       end
       
@@ -384,6 +387,9 @@ module Sequel
 
       # Add a composite primary key constraint
       def add_composite_primary_key(columns, opts)
+        if (opts[:constraint_name] != nil) then
+            opts[:name] = opts[:constraint_name]
+        end
         @operations << {:op => :add_constraint, :type => :primary_key, :columns => columns}.merge(opts)
       end
 


### PR DESCRIPTION
I ran into a problem where I couldn't drop foreign key columns in MySQL.  Turns out you have to explicitly drop the foreign key constraint first, before dropping the column.  From there I discovered there wasn't an easy way to control the name of the constraint with foreign_key.  So, I added a :constraint_name option which lets you name the constraint.
