### PR TITLE
Added :query_with_result option for the MySQL adapter

### DIFF
--- a/lib/sequel/adapters/mysql.rb
+++ b/lib/sequel/adapters/mysql.rb
@@ -79,7 +79,7 @@ module Sequel
       # * :encoding - Set all the related character sets for this
       #   connection (connection, client, database, server, and results).
       #   :query_with_result - If true, query() also invokes store_result() 
-      #   and returns a Mysql::Result object. Default is true.
+      #   and returns a Mysql::Result object. 
       # * :read_timeout - Set the timeout in seconds for reading back results
       #   to a query.
       # * :socket - Use a unix socket file instead of connecting via TCP/IP.
@@ -88,7 +88,7 @@ module Sequel
       def connect(server)
         opts = server_opts(server)
         conn = Mysql.init
-        conn.query_with_result = opts[:query_with_result] unless opts[:query_with_result].nil?
+        conn.query_with_result = opts[:query_with_result] if opts.has_key?(:query_with_result)
         conn.options(Mysql::READ_DEFAULT_GROUP, opts[:config_default_group] || "client")
         conn.options(Mysql::OPT_LOCAL_INFILE, opts[:config_local_infile]) if opts.has_key?(:config_local_infile)
         conn.ssl_set(opts[:sslkey], opts[:sslcert], opts[:sslca], opts[:sslcapath], opts[:sslcipher]) if opts[:sslca] || opts[:sslkey]


### PR DESCRIPTION
We needed this option for streaming large datasets and I couldn't find an easy way to set it on the mysql connection. So I got this working. 

I didn't see any specs covering options being passed. Let me know if you need me to add some.
