### PR TITLE
Should fix schema access for Oracle adapter

### DIFF
--- a/lib/sequel/adapters/oracle.rb
+++ b/lib/sequel/adapters/oracle.rb
@@ -236,7 +236,7 @@ module Sequel
         pks = ds.select_map(:cols__column_name)
 
         # Default values
-        defaults =  metadata_dataset.from(:dba_tab_cols).
+        defaults =  metadata_dataset.from(:all_tables).
           where(:table_name=>im.call(table)).
           to_hash(:column_name, :data_default)
 


### PR DESCRIPTION
Hi Jeremy,

It is not possible to SELECT in dba_tab_cols unless you're DBA. So, in
order to get a table list, it's probably better to use 'all_tables', which shows all
tables you're allowed to see with the current credentials (we talked about that before Xmas this year in #sequel).

NOTE : Most of the oracle specs break here, even when using a DBA account in ORACLE_DB = Sequel.connect (spec/adapters/oracle_spec.rb:4) in the original sequel version, so I can not really run the specs and check if everything is fine.
