### PR TITLE
Avoid returning from block in Dataset.single_record

### DIFF
--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -492,8 +492,9 @@ module Sequel
     # has no records. Users should probably use +first+ instead of
     # this method.
     def single_record
-      clone(:limit=>1).each{|r| return r}
-      nil
+      first = nil
+      clone(:limit=>1).each {|r| first = r }
+      first
     end
 
     # Returns the first value of the first record in the dataset.


### PR DESCRIPTION
Hi Jeremy,

I was debugging production issues recently and figured out that Dataset.single_record returns from block. Totaly understand the intent of it. Basically once we get the very first record we can return. However it has a side effect when you override Dataset.fetch_rows and using Model.first method to fetch only one row from DB. Here is snippet of code that overrides fetch_rows in order to handle caching. See comment there with details about the issues. Proposed code change fixes the problem. Run _rspec spec/core/dataset_spec.rb_  and all tests passed

``` ruby
def fetch_rows(sql)
 element = cache_get(sql)
 if element
  (element.value || []).each {|row| yield row }
 else
  arr = []
   super(sql) { |row| arr << row; yield row }
   #!!!! Line below is never executed if Dataset.single_record returns from block
   cache_put(sql, arr.empty? ? nil : arr)
  end
end
```
