### PR TITLE
Add INCLUDE to CREATE INDEX for MSSQL

### DIFF
--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -238,7 +238,9 @@ module Sequel
         if index[:type] == :full_text
           "CREATE FULLTEXT INDEX ON #{quote_schema_table(table_name)} #{literal(index[:columns])} KEY INDEX #{literal(index[:key_index])}"
         else
-          "CREATE #{'UNIQUE ' if index[:unique]}#{'CLUSTERED ' if index[:type] == :clustered}INDEX #{quote_identifier(index_name)} ON #{quote_schema_table(table_name)} #{literal(index[:columns])}"
+          "CREATE #{'UNIQUE ' if index[:unique]}#{'CLUSTERED ' if index[:type] == :clustered}INDEX #{quote_identifier(index_name)} \
+          ON #{quote_schema_table(table_name)} #{literal(index[:columns])} \
+          #{'INCLUDE ' + literal(index[:include]) if index[:include]}"
         end
       end
     end

--- a/spec/adapters/mssql_spec.rb
+++ b/spec/adapters/mssql_spec.rb
@@ -75,16 +75,16 @@ describe "MSSQL full_text_search" do
   
   specify "should support fulltext indexes and full_text_search" do
     log do
-    @db.create_table(:posts){Integer :id, :null=>false; String :title; String :body; index :id, :name=>:fts_id_idx, :unique=>true; full_text_index :title, :key_index=>:fts_id_idx; full_text_index [:title, :body], :key_index=>:fts_id_idx}
-    @db[:posts].insert(:title=>'ruby rails', :body=>'y')
-    @db[:posts].insert(:title=>'sequel', :body=>'ruby')
-    @db[:posts].insert(:title=>'ruby scooby', :body=>'x')
+      @db.create_table(:posts){Integer :id, :null=>false; String :title; String :body; index :id, :name=>:fts_id_idx, :unique=>true; full_text_index :title, :key_index=>:fts_id_idx; full_text_index [:title, :body], :key_index=>:fts_id_idx}
+      @db[:posts].insert(:title=>'ruby rails', :body=>'y')
+      @db[:posts].insert(:title=>'sequel', :body=>'ruby')
+      @db[:posts].insert(:title=>'ruby scooby', :body=>'x')
 
-    @db[:posts].full_text_search(:title, 'rails').all.should == [{:title=>'ruby rails', :body=>'y'}]
-    @db[:posts].full_text_search([:title, :body], ['sequel', 'ruby']).all.should == [{:title=>'sequel', :body=>'ruby'}]
+      @db[:posts].full_text_search(:title, 'rails').all.should == [{:title=>'ruby rails', :body=>'y'}]
+      @db[:posts].full_text_search([:title, :body], ['sequel', 'ruby']).all.should == [{:title=>'sequel', :body=>'ruby'}]
 
-    @db[:posts].full_text_search(:title, :$n).call(:select, :n=>'rails').should == [{:title=>'ruby rails', :body=>'y'}]
-    @db[:posts].full_text_search(:title, :$n).prepare(:select, :fts_select).call(:n=>'rails').should == [{:title=>'ruby rails', :body=>'y'}]
+      @db[:posts].full_text_search(:title, :$n).call(:select, :n=>'rails').should == [{:title=>'ruby rails', :body=>'y'}]
+      @db[:posts].full_text_search(:title, :$n).prepare(:select, :fts_select).call(:n=>'rails').should == [{:title=>'ruby rails', :body=>'y'}]
     end
   end
 end if false
@@ -94,8 +94,8 @@ describe "MSSQL Dataset#join_table" do
     MSSQL_DB[:items].join(:categories, [:id]).sql.should ==
       'SELECT * FROM [ITEMS] INNER JOIN [CATEGORIES] ON ([CATEGORIES].[ID] = [ITEMS].[ID])'
     ['SELECT * FROM [ITEMS] INNER JOIN [CATEGORIES] ON (([CATEGORIES].[ID1] = [ITEMS].[ID1]) AND ([CATEGORIES].[ID2] = [ITEMS].[ID2]))',
-     'SELECT * FROM [ITEMS] INNER JOIN [CATEGORIES] ON (([CATEGORIES].[ID2] = [ITEMS].[ID2]) AND ([CATEGORIES].[ID1] = [ITEMS].[ID1]))'].
-    should include(MSSQL_DB[:items].join(:categories, [:id1, :id2]).sql)
+      'SELECT * FROM [ITEMS] INNER JOIN [CATEGORIES] ON (([CATEGORIES].[ID2] = [ITEMS].[ID2]) AND ([CATEGORIES].[ID1] = [ITEMS].[ID1]))'].
+      should include(MSSQL_DB[:items].join(:categories, [:id1, :id2]).sql)
     MSSQL_DB[:items___i].join(:categories___c, [:id]).sql.should ==
       'SELECT * FROM [ITEMS] AS [I] INNER JOIN [CATEGORIES] AS [C] ON ([C].[ID] = [I].[ID])'
   end
@@ -520,5 +520,28 @@ describe "MSSQL::Database#mssql_unicode_strings = false" do
     ds.mssql_unicode_strings.should == true
     ds.insert(:name=>'foo')
     ds.select_map(:name).should == ['foo']
+  end
+end
+
+describe "A MSSQL database adds index with include" do
+  before :all do
+    @table_name = :test_index_include
+    @db = MSSQL_DB
+    @db.create_table! @table_name do
+      integer :col1
+      integer :col2
+      integer :col3
+    end
+  end
+
+  after :all do
+    @db.drop_table @table_name
+  end
+
+  cspecify "should be able add index with include" do
+    @db.alter_table @table_name do
+      add_index [:col1], :include => [:col2,:col3]
+    end
+    @db.indexes(@table_name).should have_key("#{@table_name}_col1_index".to_sym)
   end
 end


### PR DESCRIPTION
This request adds support for INCLUDE feature in MSSQL CREATE INDEX T-SQL. We have been using this  feature with sequel in production for about a year and seems to be working fine with MS SQL 2008. Let us know if something else needs to be done in order to merge it. Thanks. -Alex
