### PR TITLE
Small documentation change to Sequel::MySQL.convert_invalid_date_time

### DIFF
--- a/lib/sequel/adapters/mysql.rb
+++ b/lib/sequel/adapters/mysql.rb
@@ -29,6 +29,9 @@ module Sequel
 
     class << self
       # Whether to convert invalid date time values by default.
+      #
+      # Only applies to Sequel::Database instances created after this
+      # has been set.
       attr_accessor :convert_invalid_date_time
     end
     self.convert_invalid_date_time = false


### PR DESCRIPTION
To avoid confusion as to when it applies.

https://github.com/jeremyevans/sequel/issues/430
