### PR TITLE
Add rake task rvm_install (install without sudo)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,11 @@ task :install=>[:package] do
   sh %{sudo gem install ./#{NAME}-#{VERS.call} --local}
 end
 
+desc "Install sequel gem without sudo (rvm)"
+task :rvm_install=>[:package] do
+  sh %{gem install ./#{NAME}-#{VERS.call} --local}
+end
+
 desc "Uninstall sequel gem"
 task :uninstall=>[:clean] do
   sh %{sudo gem uninstall #{NAME}}


### PR DESCRIPTION
I downloaded the Sequel repo from my fresh fork on Github and wanted execute `rake install` in a dedicated rvm gemset. I received the results below, because I did not want to yield sudo persmissions to the installer.

``` bash
peterv@ASUS:~/b/github/petervandenabeele/sequel$ rake install help
rm -r sequel-3.32.0.gem
rm -r .config
rm -r rdoc
rm -r coverage
WARNING:  description and summary are identical
  Successfully built RubyGem
  Name: sequel
  Version: 3.32.0
  File: sequel-3.32.0.gem
sudo gem install ./sequel-3.32.0 --local
[sudo] password for peterv: 
rake aborted!
Command failed with status (1): [sudo gem install ./sequel-3.32.0 --local...]

Tasks: TOP => install
(See full trace by running task with --trace)
```

I added an rvm_install command that allowed me to install the gem locally without sudo permissions:

``` bash
peterv@ASUS:~/b/github/petervandenabeele/sequel$ rake -T
...
rake rvm_install                    # Install sequel gem without sudo (rvm)
...
peterv@ASUS:~/b/github/petervandenabeele/sequel$ rake rvm_install
rm -r sequel-3.32.0.gem
rm -r .config
rm -r rdoc
rm -r coverage
WARNING:  description and summary are identical
  Successfully built RubyGem
  Name: sequel
  Version: 3.32.0
  File: sequel-3.32.0.gem
gem install ./sequel-3.32.0 --local
Successfully installed sequel-3.32.0
1 gem installed
```

Please consider this PR for the case of rvm users like myself. Or is there another
solution to install the gem locally from a local fork without sudo?

Thanks !
