### PR TITLE
Specialized singular rule for /(alias|(?:stat|octop|vir|b)us)$/i

### DIFF
--- a/lib/sequel/model/default_inflections.rb
+++ b/lib/sequel/model/default_inflections.rb
@@ -29,7 +29,7 @@ module Sequel
     singular(/oes$/i, 'o')
     singular(/shoes$/i, 'shoe')
     singular(/(alias|(?:stat|octop|vir|b)us)es$/i, '\1')
-    singular(/(status)$/i, '\1')
+    singular(/(alias|(?:stat|octop|vir|b)us)$/i, '\1')
     singular(/(vert|ind)ices$/i, '\1ex')
     singular(/matrices$/i, 'matrix')
 

--- a/spec/extensions/inflector_spec.rb
+++ b/spec/extensions/inflector_spec.rb
@@ -73,8 +73,9 @@ describe String do
     "egg_and_hams".classify.should == "EggAndHam"
     "post".classify.should == "Post"
     "status".classify.should == "Status"
-    "statuses".classify.should == "Status"
-    "Status".classify.should == "Status"
+    "octopuses".classify.should == "Octopus"
+    "Bus".classify.should == "Bus"
+    "ALIas".classify.should == "ALIas"
   end
   
   it "#foreign_key should create a foreign key name from a class name" do


### PR DESCRIPTION
Adding this specialized singular rule allows one to call "WorkStatus".classify and get back "WorkStatus", vs having to call "WorkStatus".pluralize.classify.
