### PR TITLE
NaN and +/-Infinity needs to be quoted for floating point values in postgresql 

### DIFF
--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -88,11 +88,25 @@ module Sequel
   module Postgres
     CONVERTED_EXCEPTIONS << PGError
     
+    NAN             = 0.0/0.0
+    PLUS_INFINITY   = 1.0/0.0
+    MINUS_INFINITY  = -1.0/0.0
+    
     TYPE_TRANSLATOR = tt = Class.new do
       def boolean(s) s == 't' end
       def bytea(s) ::Sequel::SQL::Blob.new(Adapter.unescape_bytea(s)) end
       def integer(s) s.to_i end
-      def float(s) s.to_f end
+      def float(s) 
+        if s == 'NaN'
+          NAN
+        elsif s == 'Infinity'
+          PLUS_INFINITY
+        elsif s == '-Infinity'
+          MINUS_INFINITY
+        else
+          s.to_f 
+        end
+      end
       def date(s) ::Date.new(*s.split("-").map{|x| x.to_i}) end
     end.new
 

--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -959,18 +959,17 @@ module Sequel
       
       # SQL fragment for Float
       # PostgreSQL quotes NaN and Infinity
-      def literal_float(v)
-        value = v.to_s
-        if value == "NaN"
-          value = %{'NaN'}
-        elsif value == 'Infinity'
-          value = %q{'Infinity'}
-        elsif value == '-Infinity'
-          value = %q{'-Infinity'}
+      def literal_float(value)
+        if value.finite?
+          super
+        elsif value.nan?
+          "'NaN'"
+        elsif value.infinite? == 1
+          "'Infinity'"
         else
-          value
+          "'-Infinity'"
         end
-      end
+      end 
 
       # Assume that SQL standard quoting is on, per Sequel's defaults
       def literal_string_append(sql, v)

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -1236,4 +1236,22 @@ describe 'POSTGRES special float handling' do
     inf = -1.0/0.0
     @ds.insert_sql(:value => inf).should == %q{INSERT INTO test5 (value) VALUES ('-Infinity')}
   end
+
+  specify 'inserts NaN' do
+    nan = 0.0/0.0
+    @ds.insert(:value=>nan).should == nil
+    @ds.all[0][:value].nan?.should be_true
+  end
+
+  specify 'inserts +Infinity' do
+    inf = 1.0/0.0
+    @ds.insert(:value=>inf).should == nil
+    @ds.all[0][:value].infinite?.should > 0
+  end
+
+  specify 'inserts -Infinity' do
+    inf = -1.0/0.0
+    @ds.insert(:value=>inf).should == nil
+    @ds.all[0][:value].infinite?.should < 0
+  end
 end


### PR DESCRIPTION
It looks like postgres requires Nan and Infinity to be quoted when trying to insert them into a table. This is a tiny patch check for these values by overriding literal_float in the postgres adapter and adding the required quotes.
