### PR TITLE
PgFromOnly extension add #pg_only method to identifiers

### DIFF
--- a/lib/sequel/extensions/pg_from_only.rb
+++ b/lib/sequel/extensions/pg_from_only.rb
@@ -1,0 +1,73 @@
+# The pg_from_only extension adds the pg_only method to any identifier variant
+# (Symbol, SQL::Identifier, SQL::QualifiedIdentifier), which allows to compose
+# PostgreSQL `select * from ONLY table` expression
+#
+#   db[:table.pg_only].sql             # select * from only table
+#   db[:table.pg_only].update(:v => 1) # update only table set v = 1
+#   db[:table.pg_only].delete          # delete from only table
+
+module Sequel
+  module SQL
+    # Includes a +pg_only+ method that created <tt>OnlyIdentifier</tt>s, used for selection from ONLY in PostgreSQL
+    module PgOnlyMethods
+      # Add to a reciever prefix ONLY for using in PostgreSQL inheritance
+      #
+      #   :table.pg_only  # ONLY "table"
+      #   :table.qualify(:schema).pg_only  # ONLY "schema"."table"
+      def pg_only
+        PgOnlyIdentifier.new(self)
+      end
+    end
+
+    class Identifier
+      include PgOnlyMethods
+    end
+
+    class QualifiedIdentifier < GenericExpression
+      include PgOnlyMethods
+    end
+
+    # Represents a selection ONLY from table (PostgreSQL inheritance)
+    class PgOnlyIdentifier < GenericExpression
+      # Reference to a table
+      attr_reader :table
+
+      def initialize(table)
+        @table = table
+      end
+
+      to_s_method :only_identifier_sql
+    end
+  end
+
+  module Postgres
+    module DatasetMethods
+      ONLY = 'ONLY '.freeze
+
+      # Skip ONLY when writting qualified identifier
+      def qualified_identifier_sql_append(sql, qcr)
+        unless SQL::PgOnlyIdentifier === qcr.table
+          super
+        else
+          super(sql, SQL::QualifiedIdentifier.new(qcr.table.table, qcr.column))
+        end
+      end
+
+      # SQL fragment for selection from ONLY table in PostgreSQL
+      def only_identifier_sql_append(sql, only)
+        sql << ONLY
+        case t = only.table
+        when Symbol, SQL::QualifiedIdentifier, SQL::Identifier
+          literal_append(sql, t)
+        else
+          quote_identifier_append(sql, t)
+        end
+      end
+    end
+  end
+
+end
+
+class Symbol
+  include Sequel::SQL::PgOnlyMethods
+end

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -1211,6 +1211,25 @@ if POSTGRES_DB.adapter_scheme == :postgres && SEQUEL_POSTGRES_USES_PG && POSTGRE
   end
 end
 
+describe 'POSTGRES handling ONLY' do
+  require 'sequel/extensions/pg_from_only'
+  specify 'should correctly insert ONLY' do
+    POSTGRES_DB[:test2.pg_only].first
+    POSTGRES_DB.sqls.last.should =~ /from\s+only\s+"?test2"?/i
+    POSTGRES_DB[:test2.qualify(:public).pg_only].first
+    POSTGRES_DB.sqls.last.should =~ /from\s+only\s+"?public"?."?test2"?/i
+    POSTGRES_DB[:public__test2.pg_only].first
+    POSTGRES_DB.sqls.last.should =~ /from\s+only\s+"?public"?."?test2"?/i
+  end
+
+  specify 'ONLY should not lag on join' do
+    POSTGRES_DB[:test2.pg_only].join(:test4.pg_only, :name => :name).first
+    POSTGRES_DB.sqls.last.should =~
+        /from\s+only\s+"?test2"?\s+(inner\s+)?join\s+only\s+"?test4"?\s+
+         on\s+(\(\s*)?"?test4"?\."?name"?\s*=\s*"?test2"?\."?name"?(\s*\))?/ix
+  end
+end
+
 describe 'POSTGRES special float handling' do
   before do
     @db = POSTGRES_DB


### PR DESCRIPTION
This will allow to compose PostgreSQL `select * from only "table"`,  `update only "table"` and `delete from only "table"` expressions (second attempt of #448)

I rewrote it as sequel/extensions/pg_from_only. Is it now better?
I placed tests into spec/adapters/postgres_spec.rb cause they depends on PostgreSQL connection, but may be it is not best place.
