### PR TITLE
escaping the password to prevent URI:InvalidcomponentError

### DIFF
--- a/lib/sequel/core.rb
+++ b/lib/sequel/core.rb
@@ -1,4 +1,4 @@
-%w'bigdecimal date thread time uri'.each{|f| require f}
+%w'bigdecimal date thread time uri cgi'.each{|f| require f}
 
 # Top level module for Sequel
 #

--- a/lib/sequel/database/misc.rb
+++ b/lib/sequel/database/misc.rb
@@ -224,7 +224,7 @@ module Sequel
         nil
       )
       uri.user = @opts[:user]
-      uri.password = @opts[:password] if uri.user
+      uri.password = CGI.escape(@opts[:password]) if uri.user
       uri.to_s
     end
     


### PR DESCRIPTION
1.9.3p0 :002 >  db = Sequel.connect("mysql://sandeep:s%40d33p@localhost/db1")
 => #<Sequel::MySQL::Database: {:user=>"sandeep", :password=>"s@d33p", :host=>"localhost", :port=>nil, :database=>"db1", :adapter=>"mysql", :disconnection_proc=>#Proc:0x0000000282c7e0@/home/user/.rvm/gems/ruby-1.9.3-p0/gems/sequel-3.31.0/lib/sequel/database/misc.rb:47, :adapter_class=>Sequel::MySQL::Database, :single_threaded=>false}> 
1.9.3p0 :003 > db.url
URI::InvalidComponentError: bad component(expected user component): s@d33p
    from /home/user/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/uri/generic.rb:439:in `check_password'
    from /home/user/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/uri/generic.rb:512:in`password='
    from /home/user/.rvm/gems/ruby-1.9.3-p0/gems/sequel-3.31.0/lib/sequel/database/misc.rb:215:in `uri'
    from /home/user/.rvm/gems/ruby-1.9.3-p0/gems/sequel-3.31.0/lib/sequel/database/misc.rb:221:in`url'
    from (irb):3
    from /home/user/.rvm/rubies/ruby-1.9.3-p0/bin/irb:16:in `<main>'

The above error occurs because even though I give Sequel a CGI escaped password, it passes it to the URI gem in its unescaped form. 
