### PR TITLE
Use Pry for sequel command if it's been loaded

### DIFF
--- a/bin/sequel
+++ b/bin/sequel
@@ -219,7 +219,12 @@ if !ARGV.empty?
 elsif !$stdin.isatty
   eval($stdin.read)
 else
-  require 'irb'
+  console = if defined? Pry
+    Pry
+  else
+    require 'irb'
+    IRB
+  end
   puts "Your database is stored in DB..."
-  IRB.start
+  console.start
 end


### PR DESCRIPTION
This allows the user to use the popular IRB alternative by firing up sequel with `sequel -rpry ...`.
