### PR TITLE
require 'mysql2' even if, for whatever reason, Mysql2 is already defined

### DIFF
--- a/lib/sequel/adapters/mysql2.rb
+++ b/lib/sequel/adapters/mysql2.rb
@@ -1,4 +1,4 @@
-require 'mysql2' unless defined? Mysql2
+require 'mysql2'
 Sequel.require %w'shared/mysql_prepared_statements', 'adapters'
 
 module Sequel


### PR DESCRIPTION
- the `unless defined?` condition is from @brianmario's [first mysql2 commit](https://github.com/seamusabshere/sequel/commit/72bb4d20bdfc1c2a71322f903cfa2d8b5752a56f#L1R1)
- I looked at other adapters and none of them seem to have a similar check, so I assumed it was OK to remove it

Failing "test":

```
module Mysql2
  # perfectly safe, right?
end
require 'sequel'
DB = Sequel.connect("mysql2://root:password@localhost:3306/earth")
DB['select * from species'].each { |row| p row }
```

Error:

```
MacBook:~ $ ruby foo.rb 
~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/adapters/mysql2.rb:48:in `connect': NameError: uninitialized constant Mysql2::Client (Sequel::DatabaseConnectionError)
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/database/misc.rb:48:in `block in initialize'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool.rb:100:in `call'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool.rb:100:in `make_new'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool/threaded.rb:144:in `make_new'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool/threaded.rb:130:in `available'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool/threaded.rb:120:in `block in acquire'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool/threaded.rb:162:in `block in sync'
  from <internal:prelude>:10:in `synchronize'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool/threaded.rb:162:in `sync'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool/threaded.rb:119:in `acquire'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/connection_pool/threaded.rb:91:in `hold'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/database/connecting.rb:230:in `synchronize'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/adapters/shared/mysql_prepared_statements.rb:23:in `execute'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/dataset/actions.rb:744:in `execute'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/adapters/mysql2.rb:170:in `execute'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/adapters/mysql2.rb:146:in `fetch_rows'
  from ~/.rvm/gems/ruby-1.9.3-p125/gems/sequel-3.34.1/lib/sequel/dataset/actions.rb:133:in `each'
  from foo.rb:7:in `<main>'
```
