### PR TITLE
Make previous_changes always return a Hash with [] as default value

### DIFF
--- a/lib/sequel/plugins/dirty.rb
+++ b/lib/sequel/plugins/dirty.rb
@@ -52,7 +52,9 @@ module Sequel
         # saved, in the same format as #column_changes.
         # Note that this is not necessarily the same as the columns
         # that were used in the update statement.
-        attr_reader :previous_changes
+        def previous_changes
+          @previous_changes ||= Hash.new{[]}
+        end
 
         # An array with the initial value and the current value
         # of the column, if the column has been changed.  If the
@@ -68,7 +70,7 @@ module Sequel
         #
         #   column_changes # => {:name => ['Initial', 'Current']}
         def column_changes
-          h = {}
+          h = Hash.new{[]}
           initial_values.each do |column, value|
             h[column] = [value, send(column)]
           end
@@ -98,7 +100,7 @@ module Sequel
         #
         #   initial_values # {:name => 'Initial'}
         def initial_values
-          @initial_values ||= {}
+          @initial_values ||= Hash.new{[]}
         end
 
         # Reset the column to its initial value.  If the column was not set

--- a/spec/extensions/dirty_spec.rb
+++ b/spec/extensions/dirty_spec.rb
@@ -148,6 +148,8 @@ describe "Sequel::Plugins::Dirty" do
     it_should_behave_like "dirty plugin"
 
     it "previous_changes should be the previous changes after saving" do
+      @o.previous_changes.should == {}
+      @o.previous_changes[:initial_changes].first.should be_nil
       @o.save
       @o.previous_changes.should == {:initial_changed=>['ic', 'ic2'], :missing_changed=>[nil, 'mc2']}
     end


### PR DESCRIPTION
This avoids code like:

``` ruby
def data_type_was_options?
  (c = (p = previous_changes) && p[:data_type]) && c.first == 'options'
end
```

We could write this instead, which is much clearer to read:

```
  previous_changes[:data_type].first == 'options'
```

Hash.new{[]} is being used instead of Hash.new([]) for avoiding
the situation where someone might change the initial value causing
unexpected behavior.
