### PR TITLE
travis.ci testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /www/public/static/*_presentation
 *.rbc
 *.swp
+*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
+  - ruby-head
+  - jruby-head
+  - ree

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+
+gem 'rake'
+gem 'rspec'


### PR DESCRIPTION
This is pretty simple addition to the repo for what I'd call a pretty powerful safety net.  I'm not sure what all versions of ruby you support, so I threw a ton at it.  This pulls in your commits and runs `bundle install` / `rake test`.  You can easily have failing tests mailed to yourself, or do any other number of useful things.

You can see the test run here:
http://travis-ci.org/#!/tkellen/sequel

Here are the versions tested (if not marked failed, they passed):
`1.8.7` http://travis-ci.org/#!/tkellen/sequel/jobs/1514136
`1.9.2` http://travis-ci.org/#!/tkellen/sequel/jobs/1514137 **(failed)**
`1.9.3` http://travis-ci.org/#!/tkellen/sequel/jobs/1514138
`jruby-18mode` http://travis-ci.org/#!/tkellen/sequel/jobs/1514139
`jruby-19mode` http://travis-ci.org/#!/tkellen/sequel/jobs/1514140 **(failed)**
`rbx-18mode` http://travis-ci.org/#!/tkellen/sequel/jobs/1514141 **(failed)**
`rbx-19mode` http://travis-ci.org/#!/tkellen/sequel/jobs/1514142
`ruby-head` http://travis-ci.org/#!/tkellen/sequel/jobs/1514143
`jruby-head` http://travis-ci.org/#!/tkellen/sequel/jobs/1514144
`ree` http://travis-ci.org/#!/tkellen/sequel/jobs/1514145
