### PR TITLE
Postgresql schema

### DIFF
--- a/lib/sequel/database/connecting.rb
+++ b/lib/sequel/database/connecting.rb
@@ -18,7 +18,9 @@ module Sequel
       return scheme if scheme.is_a?(Class)
 
       scheme = scheme.to_s.gsub('-', '_').to_sym
-      
+
+      scheme = :postgres if scheme == :postgresql
+
       unless klass = ADAPTER_MAP[scheme]
         # attempt to load the adapter file
         begin

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -46,6 +46,10 @@ describe "A PostgreSQL database" do
     @db = POSTGRES_DB
   end
 
+  specify "should know how to connect if 'postgresql' specified in connection string" do
+    Sequel.connect('postgresql://postgres:postgres@localhost:5432/reality_spec')
+  end
+
   specify "should provide the server version" do
     @db.server_version.should > 70000
   end


### PR DESCRIPTION
This now works:

```
config = File.read(File.join(File.dirname(__FILE__), '../config/database.yml'))                      
db_info = YAML.load(config)[env]                                                                     
DB = Sequel.connect(db_info) 
```

Without the patch, sequel complains that there's no postgresql adapter.  I thought I had problems on heroku without this patch as well, but that was a while ago.
