### PR TITLE
MSSQL makes it difficult to drop a column which has a default value

### DIFF
--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -93,6 +93,13 @@ module Sequel
       def views(opts={})
         information_schema_tables('VIEW', opts)
       end
+      
+      # MSSQL implements column default values as constraints.
+      # This function takes a table and column name. It returns the name of the default constraint or nil if there is not a default value for the column
+      def default_constraint_name(table, column_name)
+        table_name = schema_and_table(table).compact.join('.')
+        self[:sys__default_constraints].where(:parent_object_id => :object_id[table_name]).and(:col_name[:parent_object_id, :parent_column_id] => column_name.to_s).get(:name)
+      end
 
       private
       

--- a/spec/adapters/mssql_spec.rb
+++ b/spec/adapters/mssql_spec.rb
@@ -542,3 +542,38 @@ describe "A MSSQL database adds index with include" do
     @db.indexes(@table_name).should have_key("#{@table_name}_col1_index".to_sym)
   end
 end
+
+describe "MSSQL::Database#default_contrainst_name" do
+  let(:table_name) { :items }
+  let(:constraint_name) { MSSQL_DB.default_constraint_name(table_name, :name) }
+
+  after do
+    MSSQL_DB.drop_table(table_name)
+  end
+
+  specify "returns a constraint name for columns with a default value" do
+    MSSQL_DB.create_table!(table_name){ String :name, :default => 'widget' }
+    constraint_name.should_not be_nil
+  end
+
+  specify "returns nil for columns without a default value" do
+    MSSQL_DB.create_table!(table_name){ String :name }
+    constraint_name.should be_nil
+  end
+  
+  context "with a schema namespace" do
+    before(:all) do
+      MSSQL_DB.execute_ddl "create schema test"
+    end
+    after(:all) do
+      MSSQL_DB.execute_ddl "drop schema test"
+    end
+
+    let(:table_name) { :test__items }
+
+    specify "returns a constraint name for columns with a default value" do
+      MSSQL_DB.create_table!(table_name){ String :name, :default => 'widget' }
+      constraint_name.should_not be_nil
+    end    
+  end
+end


### PR DESCRIPTION
In MSSQL, when you create a column with a default value, it results in a 'default constraint' being created. You can not drop said column unless you first drop the constraint. I believe Sequel's support for `drop_column(:my_col, :cascade => true)` is meant to solve this problem, at least for PostgreSQL. Unfortunately, AFAIK, there is no analogous statement in MSSQL. This patch adds a Database instance method to get the name of a default constraint for a given column. I'm currently using it like this:

``` ruby
Sequel.migration do
  up do
    constraint_name = default_constraint_name(:items, :name)
    alter_table(:items) do
      drop_constraint constraint_name
      drop_column :name
    end
  end
end
```

I considered adding a MSSQL handler for the `:cascade` option in `drop_column` but the resulting SQL is not as 'atomic' as what you normally get out of `drop_column`
