### PR TITLE
Preserve return value in MiniTest example

### DIFF
--- a/doc/testing.rdoc
+++ b/doc/testing.rdoc
@@ -45,7 +45,22 @@ Make sure you are using Sequel 3.29.0 or above when using these examples, as old
   # Must use this class as the base class for your tests
   class SequelTestCase < MiniTest::Unit::TestCase
     def run(*args, &block)
-      Sequel::Model.db.transaction(:rollback=>:always){super}
+      result = nil
+      Sequel::Model.db.transaction(:rollback=>:always){ result = super }
+      result
+    end
+  end
+
+  # Or you could override the base implementation like this
+  class MiniTest::Unit::TestCase
+    alias_method :_original_run, :run
+
+    def run(*args, &block)
+      result = nil
+      Sequel::Model.db.transaction(:rollback => :always) do
+        result = _original_run(*args, &block)
+      end
+      result
     end
   end
 


### PR DESCRIPTION
The return value of MiniTest::Unit::TestCase is significant and needs
to be returned in order for the test reporter to work properly.

I also added an example for overriding the base implementation instead
of doing it in a subclass.
