### PR TITLE
Expand the association_pks plugin to handle composite primary keys.

### DIFF
--- a/lib/sequel/plugins/association_pks.rb
+++ b/lib/sequel/plugins/association_pks.rb
@@ -61,7 +61,11 @@ module Sequel
               ds = _join_table_dataset(opts).filter(opts[:left_key]=>send(opts[:left_primary_key]))
               ds.exclude(opts[:right_key]=>pks).delete
               pks -= ds.select_map(opts[:right_key])
-              pks.each{|pk| ds.insert(opts[:left_key]=>send(opts[:left_primary_key]), opts[:right_key]=>pk)}
+              pks.each do |pk|
+                insert = Hash[Array(opts[:right_key]).zip(Array(pk))]
+                insert[opts[:left_key]] = send(opts[:left_primary_key])
+                ds.insert(insert)
+              end
             end
           end
         end


### PR DESCRIPTION
This isn't done yet, I'm just looking for some guidance. I'm trying to get the association_pks plugin to support models with composite primary keys, and so far I've done right-side CPKs for both one-to-many and many-to-many associations. I don't think changing the actual plugin will be difficult, since three of my four test cases passed without even needing to modify the plugin, and the fourth required only minor changes.

The problem is testing, since to be thorough I'd like to support and test for (right|left|both)-side cpks on (one_to_many|many_to_many) associations, and I think the testing will get to be a mess. I think the mocking technique for returning records will become hard to use if I start cramming more queries into it, and I don't know what a good alternative would be. My method of testing the insert sql on the many_to_many setter test is also really hacky, and I'm not sure what to do there either (when I did some similar work in the nested_attributes plugin I was able to just override _insert in the model being tested, but there isn't a model here to do the same).

Suggestions?
