### PR TITLE
Attempt to fix conversion proc refresh.

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -407,6 +407,10 @@ module Sequel
       # Reset the database's conversion procs, requires a server query if there
       # any named types.
       def reset_conversion_procs
+        procs = PG_TYPES.dup
+        procs[1184] = procs[1114] = method(:to_application_timestamp)
+        @conversion_procs = procs
+
         @conversion_procs = get_conversion_procs
       end
 


### PR DESCRIPTION
This is not a pretty fix (I'm not much of a Rubyist), but it works.  Without this, I get the error below when including hstore, because `reset_conversion_procs` calls `fetch_rows_set_cols`, which depends on having _some_ conversion procs to decode the output.

```
home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:717:in `block in fetch_rows_set_cols': undefined method `[]' for nil:NilClass (NoMethodError)
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:716:in `times'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:716:in `fetch_rows_set_cols'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:547:in `block in fetch_rows'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:134:in `execute'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:431:in `_execute'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:234:in `block (2 levels) in execute'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:443:in `check_database_errors'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:234:in `block in execute'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/database/connecting.rb:229:in `block in synchronize'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/connection_pool/threaded.rb:105:in `hold'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/database/connecting.rb:229:in `synchronize'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:234:in `execute'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/dataset/actions.rb:762:in `execute'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:547:in `fetch_rows'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/dataset/actions.rb:151:in `each'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/dataset/actions.rb:392:in `map'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/dataset/actions.rb:392:in `map'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/dataset/actions.rb:714:in `_select_map_multiple'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/dataset/actions.rb:748:in `_select_map'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/dataset/actions.rb:500:in `select_map'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/shared/postgres.rb:694:in `get_conversion_procs'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/shared/postgres.rb:410:in `reset_conversion_procs'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/shared/postgres.rb:738:in `initialize_postgres_adapter'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/adapters/postgres.rb:170:in `initialize'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/database/connecting.rb:78:in `new'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/database/connecting.rb:78:in `connect'
        from /home/maciek/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/sequel-3.39.0/lib/sequel/core.rb:147:in `connect'
```
