### PR TITLE
Add ~ method to NilClass to make it easier to query for NOT NULL

### DIFF
--- a/lib/sequel/extensions/core_extensions.rb
+++ b/lib/sequel/extensions/core_extensions.rb
@@ -232,3 +232,9 @@ class Symbol
   end
   alias_method(:[], :sql_function) if RUBY_VERSION < '1.9.0'
 end
+
+class NilClass
+  def ~
+    Sequel::SQL::Constants::NOTNULL
+  end
+end

--- a/spec/core_extensions_spec.rb
+++ b/spec/core_extensions_spec.rb
@@ -245,6 +245,10 @@ describe "Core extensions" do
     @d.l({:y => :z} | :x).should == '((y = z) OR x)'
     @d.l({:x => :a} | {:y => :z}).should == '((x = a) OR (y = z))'
   end
+
+  it "should support ~ on nil" do
+    @d.l({:x => ~nil}).should == '(x IS NOT NULL)'
+  end
 end
 
 describe "Array#case and Hash#case" do


### PR DESCRIPTION
I've been using this pattern in my queries a lot to test for the presence of something:

``` ruby
.where(~{something: nil})
```

This pull request adds the ~ method to NilClass, making this possible:

``` ruby
.where(something: ~nil)
```

Personally I find that to be a big improvement: it's easier to type and it's easier to scan (i.e. the intent of the code is clearer).
