### PR TITLE
Escape it

### DIFF
--- a/lib/sequel/extensions/pg_hstore.rb
+++ b/lib/sequel/extensions/pg_hstore.rb
@@ -227,6 +227,7 @@ module Sequel
 
       # Append a literalize version of the hstore to the sql.
       def sql_literal_append(ds, sql)
+        sql << 'E'
         ds.literal_append(sql, unquoted_literal)
         sql << HSTORE_CAST
       end

--- a/spec/extensions/pg_hstore_spec.rb
+++ b/spec/extensions/pg_hstore_spec.rb
@@ -24,12 +24,12 @@ describe "pg_hstore extension" do
   end
 
   it "should literalize HStores to strings correctly" do
-    @db.literal({}.hstore).should == '\'\'::hstore'
-    @db.literal({"a"=>"b"}.hstore).should == '\'"a"=>"b"\'::hstore'
-    @db.literal({"c"=>nil}.hstore).should == '\'"c"=>NULL\'::hstore'
-    @db.literal({"c"=>'NULL'}.hstore).should == '\'"c"=>"NULL"\'::hstore'
-    @db.literal({'c'=>'\ "\'=>'}.hstore).should == '\'"c"=>"\\\\ \\"\'\'=>"\'::hstore'
-    ['\'"a"=>"b","c"=>"d"\'::hstore', '\'"c"=>"d","a"=>"b"\'::hstore'].should include(@db.literal({"a"=>"b","c"=>"d"}.hstore))
+    @db.literal({}.hstore).should == 'E\'\'::hstore'
+    @db.literal({"a"=>"b"}.hstore).should == 'E\'"a"=>"b"\'::hstore'
+    @db.literal({"c"=>nil}.hstore).should == 'E\'"c"=>NULL\'::hstore'
+    @db.literal({"c"=>'NULL'}.hstore).should == 'E\'"c"=>"NULL"\'::hstore'
+    @db.literal({'c'=>'\ "\'=>'}.hstore).should == 'E\'"c"=>"\\\\ \\"\'\'=>"\'::hstore'
+    ['E\'"a"=>"b","c"=>"d"\'::hstore', 'E\'"c"=>"d","a"=>"b"\'::hstore'].should include(@db.literal({"a"=>"b","c"=>"d"}.hstore))
   end
 
   it "should have Hash#hstore method for creating HStore instances" do


### PR DESCRIPTION
This is a stupidly naive patch, but I figured the best way to get feedback is to just send a pull request. ;-) 

Basically I can't store some escaped hstore attributes without this.
