### PR TITLE
Failing test case for PG Array parsing into UTF-8 strings

### DIFF
--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require File.join(File.dirname(File.expand_path(__FILE__)), 'spec_helper.rb')
 
 unless defined?(POSTGRES_DB)
@@ -1550,6 +1551,16 @@ describe 'PostgreSQL array handling' do
       @ds.insert(rs.first)
       @ds.all.should == rs
     end
+  end
+
+  specify 'insert and retrieve UTF-8 encoded string arrays' do
+    @db.create_table!(:items) do
+      column :t, 'text[]'
+    end
+    @ds.insert(Sequel.pg_array(['é']))
+    @ds.count.should == 1
+    rs = @ds.all
+    rs.first[:t].first.encoding.should == Encoding.find("UTF-8")
   end
 
   specify 'insert and retrieve string arrays' do


### PR DESCRIPTION
I aggregate multiple rows into a PG Array and turning that into JSON. The problem is Sequel doesn't return UTF-8 strings, but ASCII-8BIT strings instead. Sequel already knows about the database's encoding, so I would assume it can return properly encoded strings.

The following gist allows us to reproduce the problem (Sequel 3.40.0): https://gist.github.com/3955094

Any advice on how to turn this into a passing spec?
