### PR TITLE
Add a prefetch default value for Oracle adapter

### DIFF
--- a/lib/sequel/adapters/oracle.rb
+++ b/lib/sequel/adapters/oracle.rb
@@ -37,7 +37,7 @@ module Sequel
           dbname = opts[:host]
         end
         conn = OCI8.new(opts[:user], opts[:password], dbname, opts[:privilege])
-        conn.prefetch_rows = typecast_value_integer(opts[:prefetch_rows]) if opts[:prefetch_rows]
+        conn.prefetch_rows = typecast_value_integer(opts.fetch(:prefetch_rows, 100))
         conn.autocommit = true
         conn.non_blocking = true
         


### PR DESCRIPTION
On a company project that I'm working on, we found a performance issue on fetching a very small dataset (about 77 rows). After some research I've found the existence of this oci8's flag which fixes this issue.

Just to exemplify, the forementioned query speed dropped from 6~7 seconds to 0.15s.

To prevent that another one dismiss the sequel library for this kind of problem, I suggest a default value to this flag. By the way, the [oracle_enchanced](https://github.com/rsim/oracle-enhanced/blob/master/lib/active_record/connection_adapters/oracle_enhanced_oci_connection.rb#L302) adapter for ActiveRecord already have this same default value (from where I stealed), so I don't think that it will do any harm :)

Thank you!

PS: Sorry about my bad english
