### PR TITLE
Updated link to correct document

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -71,7 +71,7 @@ Sequel includes an IRB console for quick access to databases (usually referred t
 
 You get an IRB session with the database object stored in DB.
 
-In addition to providing an IRB shell (the default behavior), bin/sequel also has support for migrating databases, dumping schema migrations, and copying databases.  See the {bin/sequel guide}[link:files/doc/bin_sequel_rdoc.html] for more details.
+In addition to providing an IRB shell (the default behavior), bin/sequel also has support for migrating databases, dumping schema migrations, and copying databases.  See the {bin/sequel guide}[link:/jeremyevans/sequel/blob/master/doc/bin_sequel.rdoc] for more details.
 
 == An Introduction
 


### PR DESCRIPTION
The previous link to https://github.com/jeremyevans/sequel/blob/master/doc/bin_sequel.rdoc was broken, this fixes it.
