### PR TITLE
Make identity map plugin work with many-to-many right-side composite primary keys.

### DIFF
--- a/lib/sequel/plugins/identity_map.rb
+++ b/lib/sequel/plugins/identity_map.rb
@@ -52,6 +52,7 @@ module Sequel
             uses_lcks = opts[:uses_left_composite_keys]
             uses_rcks = opts[:uses_right_composite_keys]
             right = opts[:right_key]
+            rcks = opts[:right_keys]
             join_table = opts[:join_table]
             left = opts[:left_key]
             lcks = opts[:left_keys]


### PR DESCRIPTION
I was getting an "undefined local variable or method `rcks'" error. This fixed it for me, but I don't have time right now to wade into the specs.
