### PR TITLE
Properly handle connecting to Oracle with prefetch_rows set to a nil value 

### DIFF
--- a/lib/sequel/adapters/oracle.rb
+++ b/lib/sequel/adapters/oracle.rb
@@ -37,7 +37,7 @@ module Sequel
           dbname = opts[:host]
         end
         conn = OCI8.new(opts[:user], opts[:password], dbname, opts[:privilege])
-        conn.prefetch_rows = typecast_value_integer(opts.fetch(:prefetch_rows, 100))
+        conn.prefetch_rows = typecast_value_integer(opts[:prefetch_rows] || 100)
         conn.autocommit = true
         conn.non_blocking = true
         


### PR DESCRIPTION
I had a bug in my code, which was effectively doing this on connect:
Sequel.connect("oracle://dummy:dummy@dummy", prefetch_rows: nil)

Although I didn't intend to set prefetch_rows to nil, it still worked until sequel 3.43.0.  Commit baefc7e (Add a default 'prefetch_rows' value for oracle adapter), changed the way prefetch_rows is handled to add a default: 

conn.prefetch_rows = typecast_value_integer(opts.fetch(:prefetch_rows, 100))

Unfortunately, if the prefetch_rows key exists and has a nil value (as above), fetch will return that nil value and not the default.  That nil is then passed into  typecast_value_integer and raises an exception: "TypeError: can't convert nil into Integer" (lib/sequel/database/misc.rb:399).

This will remove fetch and use an || for the default.
