### PR TITLE
Fix the query extension to handle blocks that end in nil.

### DIFF
--- a/lib/sequel/extensions/query.rb
+++ b/lib/sequel/extensions/query.rb
@@ -29,7 +29,9 @@ module Sequel
     #
     #  dataset = DB[:items].select(:x, :y, :z).filter{(x > 1) & (y > 2)}.reverse(:z)
     def query(&block)
-      Query.new(self).instance_eval(&block).dataset
+      query = Query.new(self)
+      query.instance_eval(&block)
+      query.dataset
     end
 
     # Proxy object used by Dataset#query.

--- a/spec/extensions/query_spec.rb
+++ b/spec/extensions/query_spec.rb
@@ -77,6 +77,15 @@ describe "Dataset#query" do
     q.class.should == @d.class
     q.sql.should == "SELECT * FROM xyz ORDER BY stamp"
   end
+
+  specify "should support blocks that end in nil" do
+    condition = false
+    q = @d.query do
+      from :xyz
+      order_by :stamp if condition
+    end
+    q.sql.should == "SELECT * FROM xyz"
+  end
   
   specify "should raise on non-chainable method calls" do
     proc {@d.query {row_proc}}.should raise_error(Sequel::Error)


### PR DESCRIPTION
I hadn't actually run the new query block implementation against my test suite until now, but I commonly use conditionals in query blocks, and things blow up if the block ends in nil. The fix is small and simple.

Thanks!
