### PR TITLE
Remove last Sequel warning to make it ruby -w clean

### DIFF
--- a/lib/sequel/extensions/core_extensions.rb
+++ b/lib/sequel/extensions/core_extensions.rb
@@ -10,8 +10,13 @@
 #   Sequel.extension :core_extensions
 
 # This extension loads the core extensions.
-def Sequel.core_extensions?
-  true
+module Sequel
+  class << self
+    undef :core_extensions? if method_defined? :core_extensions?
+    def core_extensions?
+      true
+    end
+  end
 end
 
 # Sequel extends +Array+ to add methods to implement the SQL DSL.


### PR DESCRIPTION
I understand that making Sequel `ruby -w`-clean is not your goal (as per 645a3c4) and that this patch is really ugly, but please do cosider merging it; Sequel is the only dependency throwing warnings in one of my projects and this would fix this. :)
