### PR TITLE
remove extra slash from require path

### DIFF
--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -1,4 +1,4 @@
-Sequel.require %w'emulate_offset_with_row_number split_alter_table', 'adapters/utils/'
+Sequel.require %w'emulate_offset_with_row_number split_alter_table', 'adapters/utils'
 
 module Sequel
   Dataset::NON_SQL_OPTIONS << :disable_insert_output


### PR DESCRIPTION
Sequel.require already appends a slash after the subdir, so the current code adds an additional slash (`//`). Requiring with a double slash is not a problem in MRI, but this apparently breaks requires in jars on JRuby.
