### PR TITLE
Fix semantics of non-strict pg_range left and right operators

### DIFF
--- a/lib/sequel/extensions/pg_range_ops.rb
+++ b/lib/sequel/extensions/pg_range_ops.rb
@@ -29,12 +29,12 @@
 # for easier querying:
 #
 #   r.contains(:other)      # range @> other
-#   r.contained_by(:other)  # range <@ other 
+#   r.contained_by(:other)  # range <@ other
 #   r.overlaps(:other)      # range && other
 #   r.left_of(:other)       # range << other
 #   r.right_of(:other)      # range >> other
-#   r.starts_before(:other) # range &< other
-#   r.ends_after(:other)    # range &> other
+#   r.starts_after(:other)  # range &> other
+#   r.ends_before(:other)   # range &< other
 #   r.adjacent_to(:other)   # range -|- other
 #
 #   r.lower            # lower(range)
@@ -66,8 +66,8 @@ module Sequel
         :contained_by => ["(".freeze, " <@ ".freeze, ")".freeze].freeze,
         :left_of => ["(".freeze, " << ".freeze, ")".freeze].freeze,
         :right_of => ["(".freeze, " >> ".freeze, ")".freeze].freeze,
-        :starts_before => ["(".freeze, " &< ".freeze, ")".freeze].freeze,
-        :ends_after => ["(".freeze, " &> ".freeze, ")".freeze].freeze,
+        :ends_before => ["(".freeze, " &< ".freeze, ")".freeze].freeze,
+        :starts_after => ["(".freeze, " &> ".freeze, ")".freeze].freeze,
         :adjacent_to => ["(".freeze, " -|- ".freeze, ")".freeze].freeze,
         :overlaps => ["(".freeze, " && ".freeze, ")".freeze].freeze,
       }

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -2554,18 +2554,19 @@ describe 'PostgreSQL range types' do
     @db.get(Sequel.pg_range(1..5, :int4range).op.right_of(-1..0)).should be_true
     @db.get(Sequel.pg_range(1..5, :int4range).op.right_of(-1..3)).should be_false
 
-    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_before(6..10)).should be_true
-    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_before(5..10)).should be_true
-    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_before(-1..0)).should be_false
-    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_before(-1..3)).should be_false
-    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_before(-1..7)).should be_false
+    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_before(6..10)).should be_true
+    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_before(5..10)).should be_true
+    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_before(-1..0)).should be_false
+    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_before(-1..3)).should be_false
+    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_before(-1..7)).should be_true
 
-    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_after(6..10)).should be_false
-    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_after(5..10)).should be_false
-    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_after(3..10)).should be_false
-    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_after(-1..10)).should be_false
-    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_after(-1..0)).should be_true
-    @db.get(Sequel.pg_range(1..5, :int4range).op.ends_after(-1..3)).should be_true
+    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_after(6..10)).should be_false
+    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_after(5..10)).should be_false
+    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_after(3..10)).should be_false
+    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_after(-1..10)).should be_true
+    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_after(-1..0)).should be_true
+    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_after(-1..3)).should be_true
+    @db.get(Sequel.pg_range(1..5, :int4range).op.starts_after(-5..-1)).should be_true
 
     @db.get(Sequel.pg_range(1..5, :int4range).op.adjacent_to(6..10)).should be_true
     @db.get(Sequel.pg_range(1...5, :int4range).op.adjacent_to(6..10)).should be_false

--- a/spec/extensions/pg_range_ops_spec.rb
+++ b/spec/extensions/pg_range_ops_spec.rb
@@ -33,8 +33,8 @@ describe "Sequel::Postgres::RangeOp" do
     @ds.literal(@h.overlaps(@h)).should == "(h && h)"
     @ds.literal(@h.left_of(@h)).should == "(h << h)"
     @ds.literal(@h.right_of(@h)).should == "(h >> h)"
-    @ds.literal(@h.starts_before(@h)).should == "(h &< h)"
-    @ds.literal(@h.ends_after(@h)).should == "(h &> h)"
+    @ds.literal(@h.ends_before(@h)).should == "(h &< h)"
+    @ds.literal(@h.starts_after(@h)).should == "(h &> h)"
     @ds.literal(@h.adjacent_to(@h)).should == "(h -|- h)"
   end
 


### PR DESCRIPTION
the previous method names of starts_before and ends_after were not entirely accurate in all cases. This pull requests changes starts_before to ends_before and ends_after to starts_after.

I have split the pull into to two commits. The first commit add specs that demonstrate where the breakdown occurs. The second commit changes the method names.
