### PR TITLE
Add automatic migration mechanism.

### DIFF
--- a/spec/core/schema_spec.rb
+++ b/spec/core/schema_spec.rb
@@ -679,6 +679,39 @@ describe "DB#create_table?" do
   end
 end
 
+describe "DB#upgrade_table?" do
+  before do
+    @db = Sequel.mock
+  end
+
+  specify "should pass to create_table if the table does not exist" do
+    created = false
+    meta_def(@db, :table_exists?){|a| false}
+    meta_def(@db, :create_table){|*a| created = true}
+    @db.upgrade_table?(:cats){}
+    created.should == true
+  end
+
+  specify "should request schema if table exists" do
+    requested = false
+    meta_def(@db, :table_exists?){|a| true}
+    meta_def(@db, :schema){|*a| requested = true; []}
+    @db.upgrade_table?(:cats){}
+    requested.should == true
+  end
+
+  specify "should call add_column for non-existing column and only for it" do
+    meta_def(@db, :table_exists?){|a| true}
+    meta_def(@db, :schema){|*a| requested = true; [[:id, {:type=>:integer}], [:name, {:type=>:string}]]}
+    @db.upgrade_table?(:cats) do
+      primary_key :id
+      column :name, String
+      column :title, String, :default => 'foobar'
+    end
+    @db.sqls.should == ["ALTER TABLE cats ADD COLUMN title varchar(255) DEFAULT 'foobar'"]
+  end
+end
+
 describe "DB#create_join_table" do
   before do
     @db = Sequel.mock


### PR DESCRIPTION
Usage:

``` ruby
DB.upgrade_table? :accounts do
  primary_key :id
  column :title, String, :default => 'foobar'
end
class Account < Sequel::Model
end
```

The :accounts table will be created if it does not exist. If it exists and lacks :id or :key column, the corresponding column will be added with ALTER TABLE. If the table already has the column, no action will be performed on it.
