### PR TITLE
ruby -w clean fixes for 3.47.0 → current master diff

### DIFF
--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -71,7 +71,7 @@ module Sequel
     #   DB[:table].columns
     #   # => [:id, :name]
     def columns
-      return @columns if @columns
+      return @columns if defined?(@columns) && @columns
       ds = unfiltered.unordered.naked.clone(:distinct => nil, :limit => 1, :offset=>nil)
       ds.each{break}
       @columns = ds.instance_variable_get(:@columns)
@@ -138,7 +138,7 @@ module Sequel
     # running queries inside the block, you should use +all+ instead of +each+
     # for the outer queries, or use a separate thread or shard inside +each+.
     def each
-      if row_proc = @row_proc
+      if defined?(@row_proc) && row_proc = @row_proc
         fetch_rows(select_sql){|r| yield row_proc.call(r)}
       else
         fetch_rows(select_sql){|r| yield r}

--- a/lib/sequel/dataset/query.rb
+++ b/lib/sequel/dataset/query.rb
@@ -77,7 +77,7 @@ module Sequel
       c = super()
       if opts
         c.instance_variable_set(:@opts, @opts.merge(opts))
-        c.instance_variable_set(:@columns, nil) if @columns && !opts.each_key{|o| break if COLUMN_CHANGE_OPTS.include?(o)}
+        c.instance_variable_set(:@columns, nil) if defined?(@columns) && @columns && !opts.each_key{|o| break if COLUMN_CHANGE_OPTS.include?(o)}
       else
         c.instance_variable_set(:@opts, @opts.dup)
       end


### PR DESCRIPTION
This makes `Dataset::Actions` and `Dataset::Query` warning clean again.
