### PR TITLE
interval (postgresql data type) in schema dump

### DIFF
--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -189,6 +189,8 @@ END_MIG
         {:type=>File, :size=>($1.to_i if $1)}
       when /\A(?:year|(?:int )?identity)\z/o
         {:type=>Integer}
+      when /\Ainterval\z/io
+        {:type=>:interval}
       else
         {:type=>String}
       end

--- a/spec/extensions/schema_dumper_spec.rb
+++ b/spec/extensions/schema_dumper_spec.rb
@@ -25,6 +25,7 @@ describe "Sequel::Schema::Generator dump methods" do
       index [:d], :unique=>true
       spatial_index :a
       full_text_index [:b, :c]
+      column :f, :interval
     end
     g2 = @g.new(@d) do
       instance_eval(g.dump_columns, __FILE__, __LINE__)


### PR DESCRIPTION
Sequel have extension for interval data type(in postgres database), but schema dumper change interval type to String.
