### PR TITLE
Do not allow SQL placeholders to override ::cast syntax

### DIFF
--- a/lib/sequel/dataset/sql.rb
+++ b/lib/sequel/dataset/sql.rb
@@ -532,11 +532,15 @@ module Sequel
       args = pls.args
       str = pls.str
       sql << PAREN_OPEN if pls.parens
-      if args.is_a?(Hash) and !args.empty?
-        re = /:(#{args.keys.map{|k| Regexp.escape(k.to_s)}.join('|')})\b/
+      if args.is_a?(Hash)
+        re = /:+(#{args.keys.map{|k| Regexp.escape(k.to_s)}.join('|')})\b/
         loop do
           previous, q, str = str.partition(re)
           sql << previous
+          if q.count(":") > 1
+            sql << q
+            next
+          end
           literal_append(sql, args[($1||q[1..-1].to_s).to_sym]) unless q.empty?
           break if str.empty?
         end

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -426,6 +426,10 @@ describe "Dataset#where" do
     @dataset.where('price::float = 10', {}).select_sql.should == "SELECT * FROM test WHERE (price::float = 10)"
   end
 
+  specify "should not replace ::cast syntax, even with matching placeholders" do
+    @dataset.where('created_at::date = :date', { :date => '2013-01-01' }).select_sql.should == "SELECT * FROM test WHERE (created_at::date = '2013-01-01')"
+  end
+
   specify "should affect select, delete and update statements" do
     @d1.select_sql.should == "SELECT * FROM test WHERE (region = 'Asia')"
     @d1.delete_sql.should == "DELETE FROM test WHERE (region = 'Asia')"


### PR DESCRIPTION
This PR resolves an issue in which invalid SQL would be generated when:
- The supplied SQL included PostgreSQL-style typecasting syntax (`column::type`); and
- An empty parameter hash was supplied.

Previously, the placeholder replacement method could generate a regex that matched only `/:\b/`. This would match the last colon of the typecast syntax and replace it with `NULL`, generating PG exceptions like the following:

08:24:04 web.1     | PG::Error: ERROR:  syntax error at or near ":"
08:24:04 web.1     | LINE 4: WHERE timestamp > (now() - '7 days':NULLinterval):NULLdate
08:24:04 web.1     |                                            ^: SELECT
08:24:04 web.1     |   MAX(value) AS deployment_size
08:24:04 web.1     | FROM fse_time_series
08:24:04 web.1     | WHERE timestamp > (now() - '7 days':NULLinterval):NULLdate
08:24:04 web.1     |   AND stat_type='deployment_size';

(where the unadulterated clause was `WHERE timestamp > (now() - '7 days'::interval)::date`). With this patch, the replacement routine is skipped entirely when an empty parameter hash is supplied.

This doesn't solve the general case unfortunately, so situations like `created_at::date = :date` will still be mangled. Resolving this requires either a non-ruby1.8-compatible change to the placeholder regex or some slightly gnarly string checking in the replacement loop. I have a patch available for that as well, but I don't know what versions of ruby `sequel` is supporting. Would you like that added to this PR?
