### PR TITLE
Adding MySQL2 MULTI_STATEMENTS flag

### DIFF
--- a/lib/sequel/adapters/mysql2.rb
+++ b/lib/sequel/adapters/mysql2.rb
@@ -30,7 +30,8 @@ module Sequel
         opts = server_opts(server)
         opts[:host] ||= 'localhost'
         opts[:username] ||= opts.delete(:user)
-        opts[:flags] = ::Mysql2::Client::FOUND_ROWS if ::Mysql2::Client.const_defined?(:FOUND_ROWS)
+        opts[:flags] = ::Mysql2::Client::MULTI_STATEMENTS
+        opts[:flags] << ::Mysql2::Client::FOUND_ROWS if ::Mysql2::Client.const_defined?(:FOUND_ROWS)
         conn = ::Mysql2::Client.new(opts)
         conn.query_options.merge!(:symbolize_keys=>true, :cache_rows=>false)
 


### PR DESCRIPTION
I tested this patch locally after running into `<Sequel::DatabaseError> Mysql2::Error: PROCEDURE <proc> can't return a result set in the given context` errors when running stored procedures via Sequel. All sequel tests also pass.

See https://github.com/brianmario/mysql2/issues/208 for background on the Mysql2::Client::MULTI_STATEMENTS flag. 
