### PR TITLE
Make DatasetPagination#each_page return an Enumerator

### DIFF
--- a/lib/sequel/extensions/pagination.rb
+++ b/lib/sequel/extensions/pagination.rb
@@ -28,8 +28,10 @@ module Sequel
     end
       
     # Yields a paginated dataset for each page and returns the receiver. Does
-    # a count to find the total number of records for this dataset.
+    # a count to find the total number of records for this dataset. Returns
+    # an enumerator if no block is given.
     def each_page(page_size)
+      return to_enum :each_page, page_size unless block_given?
       raise(Error, "You cannot paginate a dataset that already has a limit") if @opts[:limit]
       record_count = count
       total_pages = (record_count / page_size.to_f).ceil

--- a/spec/extensions/pagination_spec.rb
+++ b/spec/extensions/pagination_spec.rb
@@ -96,4 +96,14 @@ describe "Dataset#each_page" do
       'SELECT * FROM items LIMIT 50 OFFSET 150',
     ]
   end
+
+  specify "should return an enumerator if no block is given" do
+    enum = @d.each_page(50)
+    enum.map {|p| p.sql}.should == [
+      'SELECT * FROM items LIMIT 50 OFFSET 0',
+      'SELECT * FROM items LIMIT 50 OFFSET 50',
+      'SELECT * FROM items LIMIT 50 OFFSET 100',
+      'SELECT * FROM items LIMIT 50 OFFSET 150',
+    ]
+  end
 end


### PR DESCRIPTION
When there's no block given to `each_page`, it should return an enumerator. This is consistent with the behaviour of `Enumerable#each` and other each methods like `String#each_char`.
