### PR TITLE
Fix single_record method on eager_graphed datasets.

### DIFF
--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -580,8 +580,7 @@ module Sequel
     # has no records. Users should probably use +first+ instead of
     # this method.
     def single_record
-      clone(:limit=>1).each{|r| return r}
-      nil
+      clone(:limit=>1).all.first
     end
 
     # Returns the first value of the first record in the dataset.


### PR DESCRIPTION
Calling single_record on an eager_graphed dataset associated with a model would return a hash rather than a model instance. This is because when calling single_record, post_load was never called on the results and the single row was returned directly.
