### PR TITLE
Make Sequel::Migrator.migrator_class public

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -404,7 +404,6 @@ module Sequel
         self
       end
     end
-    private_class_method :migrator_class
     
     # The column to use to hold the migration version number for integer migrations or
     # filename for timestamp migrations (defaults to :version for integer migrations and


### PR DESCRIPTION
migrator_class is the only way to auto detect which migration filename style is being used without duplicating the same code. SequelRails and other integration libraries could benefit from this being public and usable externally.
