### PR TITLE
Fixed broken link to security documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -255,7 +255,7 @@ See the {Dataset Filtering}[link:files/doc/dataset_filtering_rdoc.html] file for
 === Security
 
 Designing apps with security in mind is a best practice.
-Please read the {Security Guide}[link:files/doc/security_rdoc.html] for details on security
+Please read the {Security Guide}[link:doc/security.rdoc] for details on security
 issues that you should be aware of when using Sequel.
 
 === Summarizing Records


### PR DESCRIPTION
The link to security documentation in README.rdoc is broken now, this commit fixes it.
