### PR TITLE
Dedicated Dataset#offset method

### DIFF
--- a/lib/sequel/dataset/query.rb
+++ b/lib/sequel/dataset/query.rb
@@ -568,6 +568,19 @@ module Sequel
       ds.row_proc = nil
       ds
     end
+
+    # Returns a copy of the dataset with a specified order. Can be safely combined with limit.
+    # If you call limit with an offset, it will override override the offset if you've called
+    # offset first.
+    #
+    #   DB[:items].offset(10) # SELECT * FROM items OFFSET 10
+    def offset(o)
+      o = o.to_i if o.is_a?(String) && !o.is_a?(LiteralString)
+      if o.is_a?(Integer)
+        raise(Error, 'Offsets must be greater than or equal to 0') unless o >= 0
+      end
+      clone(:offset => o)
+    end
     
     # Adds an alternate filter to an existing filter using OR. If no filter 
     # exists an +Error+ is raised.

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -1625,6 +1625,38 @@ describe "Dataset#limit" do
   end
 end
 
+describe "Dataset#offset" do
+  before do
+    @dataset = Sequel.mock.dataset.from(:test)
+  end
+
+  specify "should include an OFFSET clause in the select statement" do
+    @dataset.offset(10).sql.should == 'SELECT * FROM test OFFSET 10'
+  end
+
+  specify "should convert regular strings to integers" do
+    @dataset.offset('a() - 1').sql.should == 'SELECT * FROM test OFFSET 0'
+  end
+
+  specify "should raise an error if an offset is used" do
+    proc{@dataset.offset(0)}.should_not raise_error(Sequel::Error)
+    proc{@dataset.offset(1)}.should_not raise_error
+    proc{@dataset.offset(-1)}.should raise_error(Sequel::Error)
+  end
+
+  specify "should be able to reset offset with nil values" do
+    @dataset.offset(6).offset(nil).sql.should == 'SELECT * FROM test'
+  end
+
+  specify "should not convert literal strings to integers" do
+    @dataset.offset(Sequel.lit('a() - 1')).sql.should == 'SELECT * FROM test OFFSET a() - 1'
+  end
+
+  specify "should not convert other objects" do
+    @dataset.offset(Sequel.function(:a) - 1).sql.should == 'SELECT * FROM test OFFSET (a() - 1)'
+  end
+end
+
 describe "Dataset#naked" do
   specify "should returned clone dataset without row_proc" do
     d = Sequel.mock.dataset

--- a/spec/integration/dataset_test.rb
+++ b/spec/integration/dataset_test.rb
@@ -157,6 +157,15 @@ describe "Simple Dataset operations" do
     @ds.order(:id).limit(2, 0).all.should == [{:id=>1, :number=>10}, {:id=>2, :number=>20}]
     @ds.order(:id).limit(2, 1).all.should == [{:id=>2, :number=>20}]
   end
+
+  specify "should fetch correctly with a limit and offset using seperate methods" do
+    @ds.order(:id).limit(2).offset(0).all.should == [{:id=>1, :number=>10}]
+    @ds.order(:id).limit(2).offset(1).all.should == []
+    @ds.insert(:number=>20)
+    @ds.order(:id).limit(1).offset(1).all.should == [{:id=>2, :number=>20}]
+    @ds.order(:id).limit(2).offset(0).all.should == [{:id=>1, :number=>10}, {:id=>2, :number=>20}]
+    @ds.order(:id).limit(2).offset(1).all.should == [{:id=>2, :number=>20}]
+  end
   
   specify "should provide correct columns when using a limit and offset" do
     ds = @ds.order(:id).limit(1, 1)


### PR DESCRIPTION
We are migrating from ActiveRecord to Sequel for an internal service, and this makes the API between Sequel and Arel that much more consistent. Personally, I think it also makes sense for offset to be logically separated from limit in code as it is actually separated from limit in SQL itself.
