### PR TITLE
MS SQL optimistic locking with timestamp/rowversion column

### DIFF
--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -332,6 +332,8 @@ module Sequel
           :boolean
         when /\A(?:(?:small)?money)\z/io
           :decimal
+        when /\A(timestamp|rowversion)\z/io
+          :blob
         else
           super
         end

--- a/lib/sequel/plugins/sql_optimistic_locking.rb
+++ b/lib/sequel/plugins/sql_optimistic_locking.rb
@@ -1,0 +1,81 @@
+module Sequel
+  module Plugins
+    # This plugin implements the MS SQL optimistic locking mechanism
+    # to ensure that concurrent updates do not override changes. This is
+    # best implemented by a code example:
+    # 
+    #   class Person < Sequel::Model
+    #     plugin :sql_optimistic_locking
+    #   end
+    #   p1 = Person[1]
+    #   p2 = Person[1]
+    #   p1.update(:name=>'Jim') # works
+    #   p2.update(:name=>'Bob') # raises Sequel::Plugins::OptimisticLocking::Error
+    #
+    # In order for this plugin to work, you need to make sure that the database
+    # table has a lock_version column (or other column you name via the lock_column)
+    # of MS SQL type "timestamp" or "rowversion".
+    #
+    # This plugin relies on the instance_filters plugin.
+    module SqlOptimisticLocking
+      # Exception class raised when trying to update or destroy a stale object.
+      Error = Sequel::NoExistingObject
+
+      # Load the instance_filters plugin into the model.
+      def self.apply(model, opts=OPTS)
+        model.plugin :instance_filters
+      end
+
+      # Set the lock_column to the :lock_column option, or :lock_version if
+      # that option is not given.
+      def self.configure(model, opts=OPTS)
+        model.lock_column = opts[:lock_column] || :lock_version
+      end
+
+      module ClassMethods
+        # The column holding the version of the lock
+        attr_accessor :lock_column
+
+        Plugins.inherited_instance_variables(self, :@lock_column => nil)
+      end
+
+      module InstanceMethods
+        # Add the lock column instance filter to the object before destroying it.
+        def before_destroy
+          lock_column_instance_filter
+          super
+        end
+
+        # Add the lock column instance filter to the object before updating it.
+        def before_update
+          lock_column_instance_filter
+          super
+        end
+
+        private
+
+        def _save_update_all_columns_hash
+          v = @values.dup
+          Array(primary_key).each{|x| v.delete(x) unless changed_columns.include?(x)}
+          v.delete(model.lock_column)
+          v
+        end
+
+        # Add the lock column instance filter to the object.
+        def lock_column_instance_filter
+          lc = model.lock_column
+          instance_filter(lc => send(lc))
+        end
+
+        # Clear the instance filters when refreshing, so that attempting to
+        # refresh after a failed save removes the previous lock column filter
+        # (the new one will be added before updating).
+        def _refresh(ds)
+          clear_instance_filters
+          super
+        end
+
+      end
+    end
+  end
+end

--- a/spec/adapters/mssql_spec.rb
+++ b/spec/adapters/mssql_spec.rb
@@ -5,7 +5,7 @@ require File.join(File.dirname(File.expand_path(__FILE__)), 'spec_helper.rb')
 def DB.sqls
   (@sqls ||= [])
 end
-logger = Object.new
+logger = Logger.new($stdout)  #Object.new
 def logger.method_missing(m, msg)
   DB.sqls << msg
 end
@@ -380,6 +380,13 @@ describe "MSSSQL::Dataset#insert" do
     h = @ds.insert_select(:value=>10)
     h[:value].should == 10
     @ds.first(:xid=>h[:xid])[:value].should == 10
+  end
+
+  cspecify "should read blobs", :odbc do
+    blob = Sequel::SQL::Blob.new("01234")
+    @db[:test4].insert(:name => 'max varbinary test', :value => blob)
+    b = @db[:test4].where(:name => 'max varbinary test').get(:value)
+    b.should be_kind_of(Sequel::SQL::Blob)
   end
 
   cspecify "should allow large text and binary values", :odbc do

--- a/spec/adapters/mssql_timestamp_spec.rb
+++ b/spec/adapters/mssql_timestamp_spec.rb
@@ -1,0 +1,63 @@
+SEQUEL_ADAPTER_TEST = :mssql
+
+require File.join(File.dirname(File.expand_path(__FILE__)), 'spec_helper.rb')
+
+def DB.sqls
+  (@sqls ||= [])
+end
+logger = Logger.new($stdout)  #Object.new
+def logger.method_missing(m, msg)
+  DB.sqls << msg
+end
+DB.loggers = [logger]
+
+
+describe "MSSSQL read schema" do
+  before do
+    @db = DB
+    @db.create_table! :items do
+      primary_key :id
+      String :name, :size => 20
+      Integer :intval
+      column :value, 'varbinary(max)'
+      column :lock_version, 'timestamp'
+    end
+    #DB.disconnect
+    #@db = MSSQLTestHelper.connect_db
+    #@ds = @db[:test5]
+  end
+  after do
+    @db.drop_table?(:items)
+  end
+
+  cspecify "timestamp should not be updated", :odbc do
+    @c = Class.new(Sequel::Model(:items))
+    @c.plugin :sql_optimistic_locking
+    blob = Sequel::SQL::Blob.new("01234")
+    @o = @c.create(name: 'max varbinary test', value: blob)
+    @o = @c.first
+    @ts = @o.lock_version
+    @o.value = Sequel::SQL::Blob.new("43210")
+    @o.save
+    @o.lock_version.should_not eql @ts
+  end
+
+  cspecify "should allow large text and binary values", :odbc do
+    @c = Class.new(Sequel::Model(:items))
+    blob = Sequel::SQL::Blob.new("0" * (65*1024))
+    @o = @c.create(name: 'max varbinary test', value: blob)
+    @o = @c.first
+    @o.value.length.should == blob.length
+    @o.value.should == blob
+  end
+
+  cspecify "timestamp should be filled by server", :odbc do
+    @c = Class.new(Sequel::Model(:items))
+    blob = Sequel::SQL::Blob.new("01234")
+    @o = @c.create(name: 'max varbinary test', value: blob)
+    @o = @c.first
+    @o.lock_version.should_not eql nil
+    @o.lock_version.should be_kind_of(Sequel::SQL::Blob)
+  end
+
+end


### PR DESCRIPTION
I tried to start support for MS SQL timestamp/rowversion column type.
A few issues I ran into:
- fetching binary columns does not work; they end up as strings (this is probably the cause for all problems I had!)
- the test for varbinary(max) fails

I added a few tests that should not fail. I couldn't find a way to make them pass. I am hoping for some help here.

I started with a new kind of optimistic locking. You can ignore that for now.

Sorry for any mistakes. This is my first pull request, so I probably broke some rules there.
