### PR TITLE
Fix the descendants method

### DIFF
--- a/lib/sequel/plugins/tree.rb
+++ b/lib/sequel/plugins/tree.rb
@@ -93,7 +93,7 @@ module Sequel
         #   subchild1.ancestors # => [child1, root]
         def descendants
           nodes = children.dup
-          nodes.each{|child| nodes.concat(child.descendants)}
+          children.each{|child| nodes.concat(child.descendants)}
           nodes 
         end
 


### PR DESCRIPTION
One shall be careful when modifying an array which is being iterated. Even though the iteration always finishes in this particular case, it may generate many duplicate nodes in the result. The fix prevents this.
