### PR TITLE
For models with composite primary keys, make the Model#primary_key array immutable.

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -542,8 +542,12 @@ module Sequel
       #   end
       def set_primary_key(key)
         clear_setter_methods_cache
-        if key.is_a?(Array) && key.length < 2
-          key = key.first
+        if key.is_a?(Array)
+          if key.length < 2
+            key = key.first
+          else
+            key = key.dup.freeze
+          end
         end
         self.simple_pk = if key && !key.is_a?(Array)
           (@dataset || db).literal(key)

--- a/spec/model/model_spec.rb
+++ b/spec/model/model_spec.rb
@@ -686,6 +686,15 @@ describe "Model.db_schema" do
     @c.db_schema.should == {:x=>{:primary_key=>true}, :y=>{:primary_key=>true}}
     @c.primary_key.should == [:x, :y]
   end
+
+  specify "should set an immutable composite primary key based on the schema" do
+    ds = @dataset
+    d = ds.db
+    def d.schema(table, *opts) [[:x, {:primary_key=>true}], [:y, {:primary_key=>true}]] end
+    @c.dataset = ds
+    @c.primary_key.should == [:x, :y]
+    proc{@c.primary_key.pop}.should raise_error RuntimeError, /can't modify frozen Array/
+  end
   
   specify "should automatically set no primary key based on the schema" do
     ds = @dataset


### PR DESCRIPTION
Modifying this array can lead to bad things, so per IRC conversation, freeze it when it's set.
