### PR TITLE
List :name as option for DB.add_index

### DIFF
--- a/lib/sequel/database/schema_methods.rb
+++ b/lib/sequel/database/schema_methods.rb
@@ -44,6 +44,7 @@ module Sequel
     #
     # Options:
     # :ignore_errors :: Ignore any DatabaseErrors that are raised
+    # :name :: Name to use for index instead of default
     #
     # See <tt>alter_table</tt>.
     def add_index(table, columns, options=OPTS)


### PR DESCRIPTION
Added a line to the add_index documentation to show that :name is an option.

Thanks for Sequel.  It rocks!
