### PR TITLE
Adds schema parsing support for :byteint, :varbyte, and :byte as a column's :type_name

### DIFF
--- a/lib/sequel/database/query.rb
+++ b/lib/sequel/database/query.rb
@@ -289,7 +289,7 @@ module Sequel
       case db_type
       when /\A(character( varying)?|n?(var)?char|n?text|string|clob)/io
         :string
-      when /\A(int(eger)?|(big|small|tiny)int)/io
+      when /\A(int(eger)?|(big|small|tiny|byte)int)/io
         :integer
       when /\Adate\z/io
         :date
@@ -303,7 +303,7 @@ module Sequel
         :float
       when /\A(?:(?:(?:num(?:ber|eric)?|decimal)(?:\(\d+,\s*(\d+|false|true)\))?))\z/io
         $1 && ['0', 'false'].include?($1) ? :integer : :decimal
-      when /bytea|blob|image|(var)?binary/io
+      when /bytea|blob|image|(var)?(binary|byte)/io
         :blob
       when /\Aenum/io
         :enum

--- a/spec/core/schema_spec.rb
+++ b/spec/core/schema_spec.rb
@@ -1493,6 +1493,7 @@ describe "Schema Parser" do
     @db.schema(:integer).first.last[:type].should == :integer
     @db.schema(:bigint).first.last[:type].should == :integer
     @db.schema(:smallint).first.last[:type].should == :integer
+    @db.schema(:byteint).first.last[:type].should == :integer
     @db.schema(:character).first.last[:type].should == :string
     @db.schema(:"character varying").first.last[:type].should == :string
     @db.schema(:varchar).first.last[:type].should == :string
@@ -1528,6 +1529,8 @@ describe "Schema Parser" do
     @db.schema(:binary).first.last[:type].should == :blob
     @db.schema(:varbinary).first.last[:type].should == :blob
     @db.schema(:enum).first.last[:type].should == :enum
+    @db.schema(:varbyte).first.last[:type].should == :blob
+    @db.schema(:byte).first.last[:type].should == :blob
 
     @db = Sequel.mock(:host=>'postgres')
     @db.extend(sm)


### PR DESCRIPTION
Some columns are returned like: [:YrsExp, {:type=>nil, :db_type=>"BYTEINT", :default=>nil, :allow_null=>true, :primary_key=>false, :column_size=>3, :scale=>nil, :ruby_default=>nil}] 

but we'd prefer to see [:YrsExp, {:type=>:integer, :db_type=>"BYTEINT", :default=>nil, :allow_null=>true, :primary_key=>false, :column_size=>3, :scale=>nil, :ruby_default=>nil}]

Adds support for converting :byteint, :varbyte, and :byte in schema_column_type

:byteint -> :integer
:varbyte, :byte -> :blob

Note: These are types returned by teradata jdbc, http://developer.teradata.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_7.html
