### PR TITLE
Fix UniqueConstraintViolation for composite primary keys on sqlite

### DIFF
--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -332,7 +332,7 @@ module Sequel
       end
 
       DATABASE_ERROR_REGEXPS = {
-        /is not unique\z/ => UniqueConstraintViolation,
+        /(is|are) not unique\z/ => UniqueConstraintViolation,
         /foreign key constraint failed\z/ => ForeignKeyConstraintViolation,
         /\A(SQLITE ERROR 19 \(CONSTRAINT\) : )?constraint failed\z/ => ConstraintViolation,
         /may not be NULL\z/ => NotNullConstraintViolation,

--- a/spec/integration/database_test.rb
+++ b/spec/integration/database_test.rb
@@ -45,6 +45,14 @@ describe Sequel::Database do
       proc{@db[:test].update(:a=>'1')}.should raise_error(Sequel::UniqueConstraintViolation)
     end
 
+    cspecify "should raise Sequel::UniqueConstraintViolation when a unique constraint is violated for composite primary keys", [:jdbc, :sqlite], [:db2] do
+      @db.create_table!(:test){String :a; String :b; primary_key [:a, :b]}
+      @db[:test].insert(:a=>'1', :b=>'2')
+      proc{@db[:test].insert(:a=>'1', :b=>'2')}.should raise_error(Sequel::UniqueConstraintViolation)
+      @db[:test].insert(:a=>'3', :b=>'4')
+      proc{@db[:test].update(:a=>'1', :b=>'2')}.should raise_error(Sequel::UniqueConstraintViolation)
+    end
+
     cspecify "should raise Sequel::CheckConstraintViolation when a check constraint is violated", :mysql, :sqlite, [:db2] do
       @db.create_table!(:test){String :a; check Sequel.~(:a=>'1')}
       proc{@db[:test].insert('1')}.should raise_error(Sequel::CheckConstraintViolation)


### PR DESCRIPTION
A unique constraint violation on a table with a composite primary key will currently raise `Sequel::DatabaseError: SQLite3::ConstraintException` instead of `Sequel::UniqueConstraintViolation`. The error message is slightly different (because english), so doesn't match the current regexp. Easy fix. Not sure if the guards are correct in the spec, I just copied/pasted from the one above, so please can you double check that.
