### PR TITLE
Firebird supports encoding option

### DIFF
--- a/lib/sequel/adapters/firebird.rb
+++ b/lib/sequel/adapters/firebird.rb
@@ -18,7 +18,8 @@ module Sequel
         Fb::Database.new(
           :database => "#{opts[:host]}:#{opts[:database]}",
           :username => opts[:user],
-          :password => opts[:password]).connect
+          :password => opts[:password],
+          :encoding => opts[:encoding]).connect
       end
 
       def disconnect_connection(conn)


### PR DESCRIPTION
Hi,

Since fb gem now supports string encoding in `connect` method, it would be nice to have this option for firebird.

Please let me know if you need any other information.

Regards,
Vieira
