### PR TITLE
Make regexps adapt to newer error messages in SQLite 3.8

### DIFF
--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -332,10 +332,10 @@ module Sequel
       end
 
       DATABASE_ERROR_REGEXPS = {
-        /(is|are) not unique\z/ => UniqueConstraintViolation,
-        /foreign key constraint failed\z/ => ForeignKeyConstraintViolation,
+        /(is|are) not unique\z|UNIQUE constraint failed: .+\z/ => UniqueConstraintViolation,
+        /foreign key constraint failed\z|FOREIGN KEY constraint failed\z/ => ForeignKeyConstraintViolation,
         /\A(SQLITE ERROR 19 \(CONSTRAINT\) : )?constraint failed\z/ => ConstraintViolation,
-        /may not be NULL\z/ => NotNullConstraintViolation,
+        /may not be NULL\z|NOT NULL constraint failed: .+\z/ => NotNullConstraintViolation,
       }.freeze
       def database_error_regexps
         DATABASE_ERROR_REGEXPS


### PR DESCRIPTION
Hi,

It seems that SQLite 3.8.2+ changed their error message formats for unique, foreign key and not null constraints. 
That makes spec/integration/database_test.rb fail:

```
1) Sequel::Database constraint violations should raise Sequel::UniqueConstraintViolation when a unique constraint is violated
   Failure/Error: Unable to find matching line from backtrace
     expected Sequel::UniqueConstraintViolation, got #<Sequel::DatabaseError: SQLite3::ConstraintException: UNIQUE constraint failed: test.a> with backtrace:
       # ./lib/sequel/adapters/sqlite.rb:181:in `block (2 levels) in _execute'
       # ./lib/sequel/database/logging.rb:33:in `log_yield'
...
```

So I did a small modification to fix it. Hope it can help!
