### PR TITLE
Adds extension for Dataset#replace_select_with_alias to replace column selections with aliases

### DIFF
--- a/lib/sequel/extensions/replace_select_with_alias.rb
+++ b/lib/sequel/extensions/replace_select_with_alias.rb
@@ -1,0 +1,54 @@
+# The replace_select_with_alias extension adds Sequel::Dataset#replace_select_with_alias
+# for replacing existing selected columns from a dataset with aliases for the
+# same column names. It preservers the order in which columns are selected.
+#
+# You can load this extension into specific datasets:
+#
+#   ds = DB[:table]
+#   ds = ds.extension(:replace_select_with_alias)
+#
+# Or you can load it into all of a database's datasets, which
+# is probably the desired behavior if you are using this extension:
+#
+#   DB.extension(:replace_select_with_alias)
+
+module Sequel
+  module ReplaceSelectWithAlias
+    # Returns a copy of the dataset with the select statements
+    # for the given aliased columns replacing the original selects.
+    # If no aliases are given, it will return the existing selection.
+    # If no columns are currently selected, it will select *.
+    #
+    #   DB[:items].select(:a, :b).replace_select_with_alias(Sequel.as("1", :a)) # SELECT '1' AS a, b FROM items
+    #   DB[:items].replace_select_with_alias(Sequel.as("1", :a)) # SELECT * FROM items
+    #   DB[:items].select(:a).replace_select_with_alias(Sequel.as("1", :b)) # SELECT a FROM items
+    #   DB[:items].select(:a, :b).replace_select_with_alias { |o| Sequel.as("1", o.a) }.sql.should == "SELECT '1' AS a, b FROM items"
+    def replace_select_with_alias(*columns, &block)
+      virtual_row_columns(columns, block)
+      aliased_columns = _aliased_columns(columns)
+      return self if !@opts[:select] || (@opts[:select] & aliased_columns.keys).empty?
+
+      select(*_replace_aliases(@opts[:select], aliased_columns))
+    end
+
+    def _aliased_columns(columns)
+      columns.reduce({}) do |aliased_columns, column|
+        case column.alias
+        when nil
+        when Sequel::SQL::Identifier
+          aliased_columns[column.alias.value.to_sym] = column
+        else
+          aliased_columns[column.alias] = column
+        end
+
+        aliased_columns
+      end
+    end
+
+    def _replace_aliases(selects, aliased_columns)
+      selects.map { |select| aliased_columns[select] || select }
+    end
+  end
+
+  Dataset.register_extension(:replace_select_with_alias, ReplaceSelectWithAlias)
+end

--- a/spec/extensions/replace_select_with_alias_spec.rb
+++ b/spec/extensions/replace_select_with_alias_spec.rb
@@ -1,0 +1,28 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
+
+describe "Dataset#replace_select_with_alias" do
+  before do
+    @d = Sequel.mock.from(:test).extension(:replace_select_with_alias)
+    @d.columns :a, :b
+  end
+
+  specify "should do nothing if aliased columns are not present" do
+    @d.select(:a).replace_select_with_alias(Sequel.as("5", :b)).sql.should == "SELECT a FROM test"
+  end
+
+  specify "should select all if no select are present" do
+    @d.replace_select_with_alias(Sequel.as("1", :a)).sql.should == 'SELECT * FROM test'
+  end
+
+  specify "should replace the currently selected columns with matching alias" do
+    @d.select(:a, :b).replace_select_with_alias(Sequel.as("1", :a), Sequel.as("2", :b)).sql.should == "SELECT '1' AS a, '2' AS b FROM test"
+  end
+
+  specify "should leave unaliased columns untouched" do
+    @d.select(:a, :b).replace_select_with_alias(Sequel.as("1", :a)).sql.should == "SELECT '1' AS a, b FROM test"
+  end
+
+  specify "should accept a block that yields a virtual row" do
+    @d.select(:a, :b).replace_select_with_alias { |o| Sequel.as("1", o.a) }.sql.should == "SELECT '1' AS a, b FROM test"
+  end
+end


### PR DESCRIPTION
This method is useful when building up a dataset over disjoint steps when `SELECT` statements for certain columns will need to be replaced with aliases before the dataset is finally retrieved. The method allows objects that want to transform a dataset via alias to not care about what columns the dataset already contains.
