### PR TITLE
Fix typo in pg_array documentation

### DIFF
--- a/lib/sequel/extensions/pg_array.rb
+++ b/lib/sequel/extensions/pg_array.rb
@@ -23,7 +23,7 @@
 #
 #   array.pg_array
 #
-# You can also provide a type, though it many cases it isn't necessary:
+# You can also provide a type, though in many cases it isn't necessary:
 #
 #   Sequel.pg_array(array, :varchar) # or :integer, :"double precision", etc.
 #   array.pg_array(:varchar) # or :integer, :"double precision", etc.


### PR DESCRIPTION
Found a small typo in the documentation for pg_array
