### PR TITLE
Changed touch plugin touch_association_value to Time.now instead of CURRENT_TIMESTAMP

### DIFF
--- a/lib/sequel/plugins/touch.rb
+++ b/lib/sequel/plugins/touch.rb
@@ -104,10 +104,9 @@ module Sequel
 
         private
 
-        # The value to use when modifying the touch column for the association datasets.  Uses
-        # the SQL standard CURRENT_TIMESTAMP.
+        # The value to use when modifying the touch column for the association datasets.
         def touch_association_value
-          Sequel::CURRENT_TIMESTAMP
+          Time.now
         end
 
         # Update the updated at field for all associated objects that should be touched.


### PR DESCRIPTION
hello there

`Sequel::CURRENT_TIMESTAMP` was wrong because:
- it doesn't match with `#touch_instance_value` (one would expect these methods to perform in a similar way)
- it breaks Rails timezone settings, forcing the database setting over Rails
- it breaks `Timecop` testing

let me know what you think.

cheers,
Florin.
