### PR TITLE
Added (trivial) support for the openedge.jar JDBC driver

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -162,6 +162,9 @@ module Sequel
         db.extend(Sequel::JDBC::SqlAnywhere::DatabaseMethods)
         db.dataset_class = Sequel::JDBC::SqlAnywhere::Dataset
         drv
+      end,
+      :datadirect=>proc do |db|
+        Java::com.ddtek.jdbc.openedge.OpenEdgeDriver
       end
     }
     


### PR DESCRIPTION
For now, we don't extend the DB object or anything. We only return the driver name, so that we can run when the classloading is a bit messed up (which can be the case e.g. when running from `jruby-complete-*.jar`).

In the future, we could extend this to support the different database methods etc. if needed. For now, just being able to run straight SQL is "good enough" for me.
