### PR TITLE
Update README to remove sudo instruction

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,7 +34,7 @@ If you have any comments or suggestions please post to the Google group.
 
 == Installation
 
-  sudo gem install sequel
+  gem install sequel
   
 == A Short Example
 


### PR DESCRIPTION
Jeremy, I am a beginner to Ruby and have been doing a few projects with Sequel and it has been great.  I noticed in the README that the instruction for install was to use `sudo`.  It seems like this is out of date.  Similar to https://github.com/sstephenson/rbenv/issues/532, I think removing `sudo` would be a good update.
