### PR TITLE
Use foreign key constraint names in MySQL alter table

### DIFF
--- a/lib/sequel/adapters/shared/mysql.rb
+++ b/lib/sequel/adapters/shared/mysql.rb
@@ -185,7 +185,11 @@ module Sequel
             sql = super
             op[:table] = related
             op[:key] ||= primary_key_from_schema(related)
-            sql << ", ADD FOREIGN KEY (#{quote_identifier(op[:name])})#{column_references_sql(op)}"
+            sql << ", ADD "
+            if constraint_name = op.delete(:foreign_key_constraint_name)
+              sql << "CONSTRAINT #{quote_identifier(constraint_name)} "
+            end
+            sql << "FOREIGN KEY (#{quote_identifier(op[:name])})#{column_references_sql(op)}"
           else
             super
           end

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -520,6 +520,17 @@ describe "A MySQL database" do
     end
   end
 
+  specify "should correctly format ALTER TABLE statements with named foreign keys" do
+    @db.create_table(:items){Integer :id}
+    @db.create_table(:users){primary_key :id}
+    @db.alter_table(:items){add_foreign_key :p_id, :users, :key => :id, :null => false, :on_delete => :cascade, :foreign_key_constraint_name => :pk_items__users }
+    check_sqls do
+      @db.sqls.should == ["CREATE TABLE `items` (`id` integer)",
+        "CREATE TABLE `users` (`id` integer PRIMARY KEY AUTO_INCREMENT)",
+        "ALTER TABLE `items` ADD COLUMN `p_id` integer NOT NULL, ADD CONSTRAINT `pk_items__users` FOREIGN KEY (`p_id`) REFERENCES `users`(`id`) ON DELETE CASCADE"]
+    end
+  end
+
   specify "should have rename_column support keep existing options" do
     @db.create_table(:items){String :id, :null=>false, :default=>'blah'}
     @db.alter_table(:items){rename_column :id, :nid}


### PR DESCRIPTION
When using a MySQL adapter to alter a table to add a foreign key and
receiving a `foreign_key_constraint_name` option, use the value of that
option as the constraint name in the generated SQL.

This value is being respected when creating the table, but not in an `ALTER`.
