### PR TITLE
Make signature of Sequel::Model.include the same as Module.include

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -473,7 +473,7 @@ module Sequel
 
       # Clear the setter_methods cache when a module is included, as it
       # may contain setter methods.
-      def include(mod)
+      def include(*mods)
         clear_setter_methods_cache
         super
       end

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -733,3 +733,14 @@ describe "Model datasets #with_pk with #with_pk!" do
     DB.sqls.should == ["SELECT * FROM a WHERE (foo) LIMIT 1"]
   end
 end
+
+describe "Model::include" do
+  it "shouldn't change the signature of Module::include" do
+    mod1 = Module.new
+    mod2 = Module.new
+    including_class = Class.new(Sequel::Model(:items)) do
+      include(mod1, mod2)
+    end
+    including_class.included_modules.should include(mod1, mod2)
+  end
+end


### PR DESCRIPTION
In a class that inherits from Sequel::Model, you can't include more than one module at a time like you can if you don't inherit; it raises an `ArgumentError: wrong number of arguments (2 for 1)`.

This is because Sequel::Model overrides include to reset the setter methods cache, but does so with a different method signature than `Module.include`.

This patch includes a two-character fix, and a spec to demonstrate the problem.

Thanks again for all your work on Sequel. It makes my life better every day. :)
