### PR TITLE
Clarify file naming requirements in migration documentation

### DIFF
--- a/doc/migration.rdoc
+++ b/doc/migration.rdoc
@@ -23,6 +23,9 @@ you generally need to run Sequel's migrator with <tt>bin/sequel -m</tt>:
 
   sequel -m path/to/migrations postgres://host/database
 
+Note: The files containing the migrations should be prefixed with a number
+greater than zero, e.g. <tt>001_initial_migration.rb</tt>.
+
 Migrations in Sequel use a very simple DSL via the <tt>Sequel.migration</tt>
 method, and inside the DSL, use the <tt>Sequel::Database</tt> schema
 modification methods such as +create_table+ and +alter_table+.


### PR DESCRIPTION
This is obvious in hindsight, but I was chasing yaks for an hour because I named my file `0_initial_schema.rb`.

It looks like the current version defaults to `0`, in which case a `0` migration would not get picked up.

If you can think of any way to improve this patch, let me know and I'll fix it.
