### PR TITLE
Pass server name to after_connect block

### DIFF
--- a/lib/sequel/connection_pool.rb
+++ b/lib/sequel/connection_pool.rb
@@ -94,7 +94,7 @@ class Sequel::ConnectionPool
   def make_new(server)
     begin
       conn = @db.connect(server)
-      @after_connect.call(conn) if @after_connect
+      @after_connect.call(conn, server) if @after_connect
     rescue Exception=>exception
       raise Sequel.convert_exception_class(exception, Sequel::DatabaseConnectionError)
     end

--- a/spec/core/connection_pool_spec.rb
+++ b/spec/core/connection_pool_spec.rb
@@ -909,8 +909,8 @@ shared_examples_for "All connection pools classes" do
   
   specify "should have respect an :after_connect proc that is called with each newly created connection" do
     x = nil
-    @class.new(mock_db.call{123}, :after_connect=>proc{|c| x = [c, c]}).hold{}
-    x.should == [123, 123]
+    @class.new(mock_db.call{123}, :after_connect=>proc{|c, s| x = [c, s]}).hold{}
+    x.should == [123, :default]
   end
   
   specify "should raise a DatabaseConnectionError if the connection raises an exception" do


### PR DESCRIPTION
I'm currently checking for the host of the server in a `after_connect` callback to apply different settings to it (eg: set a longer statement timeout for a read-only follower).

This is obviously pretty fragile and doesn't work when multiple databases are running on the same host. So proposing here that Sequel also pass the database name to `after_connect`, like:

``` ruby
Sequel.connect(URL,
  servers: servers,
  after_connect: proc do |conn, server|
    if server == :default
      # ...
```

By keeping the param order I believe this is backwards compatible.
