### PR TITLE
valid_connection? now rescues gracefully on Timeout::Error

### DIFF
--- a/lib/sequel/core.rb
+++ b/lib/sequel/core.rb
@@ -1,4 +1,4 @@
-%w'bigdecimal date thread time uri'.each{|f| require f}
+%w'bigdecimal date thread time uri timeout'.each{|f| require f}
 
 # Top level module for Sequel
 #

--- a/lib/sequel/database/connecting.rb
+++ b/lib/sequel/database/connecting.rb
@@ -253,7 +253,7 @@ module Sequel
       sql = valid_connection_sql
       begin
         log_connection_execute(conn, sql)
-      rescue Sequel::DatabaseError, *database_error_classes
+      rescue Timeout::Error, Sequel::DatabaseError, *database_error_classes
         false
       else
         true

--- a/spec/core/database_spec.rb
+++ b/spec/core/database_spec.rb
@@ -488,12 +488,22 @@ describe "Database#disconnect_connection" do
 end
 
 describe "Database#valid_connection?" do
+  before do
+    @db = Sequel.mock
+  end
+
   specify "should issue a query to validate the connection" do
-    db = Sequel.mock
-    db.synchronize{|c| db.valid_connection?(c)}.should == true
-    db.synchronize do |c|
+    @db.synchronize{|c| @db.valid_connection?(c)}.should == true
+    @db.synchronize do |c|
       def c.execute(*) raise Sequel::DatabaseError, "error" end
-      db.valid_connection?(c)
+      @db.valid_connection?(c)
+    end.should == false
+  end
+
+  specify "should return false when a connection times out" do
+    @db.synchronize do |c|
+      def c.execute(*) raise Timeout::Error, "error" end
+      @db.valid_connection?(c)
     end.should == false
   end
 end


### PR DESCRIPTION
We use Sequel in production (using the Mysql2 adapter, threaded connection pooling and the connection_validator extension) for several micro services. Our services run for a long time, and we have noticed that if something happens on our network to make MySQL go away, Sequel does not realise that the connection in the pool is bad and keeps attempting to use it for queries.

The connection_validator extension uses valid_connection? as a condition on whether to remove the current connection from the pool and re-establish a new one. However, I've noticed that when the Mysql2 adapter returns a Timeout::Error, Sequel does not rescue this error. Therefore, Sequel returns true for valid_connection? even when the Timeout::Error is being raised by the adapter.

I've written an example spec and a patch to specifically rescue this exception, and from testing with some code that behaves similarly to our micro services, I'm fairly confident this fixes the bug we're seeing in production.

I've tried my best to keep with the style of code already in place, if it needs any tweaks, please let me know.

Thanks,
Dan
