### PR TITLE
Fix problem with named columns in ibm_db driver

### DIFF
--- a/lib/sequel/adapters/ibmdb.rb
+++ b/lib/sequel/adapters/ibmdb.rb
@@ -432,9 +432,9 @@ module Sequel
           stmt.num_fields.times do |i|
             k = stmt.field_name i
             key = output_identifier(k)
-            type = stmt.field_type(k).downcase.to_sym
+            type = stmt.field_type(i).downcase.to_sym
             # decide if it is a smallint from precision
-            type = :boolean  if type == :int && convert && stmt.field_precision(k) < 8
+            type = :boolean  if type == :int && convert && stmt.field_precision(i) < 8
             type = :blob if type == :clob && Sequel::DB2.use_clob_as_blob
             columns << [key, cps[type]]
           end


### PR DESCRIPTION
Hello,

I found that a simple query like DB["select \* from mytable"] would throw this warning:

`sequel/lib/sequel/adapters/ibmdb.rb:151: warning: Column name specified is not valid`

In trying out a few things, it looks like the `field_type` and `field_precision` calls to the IBM_DB driver only work correctly when calling with a column index, but return false when using a column name.  I even tried this with an older 2.5.10 version of the ibm_db driver, and the same problem happened.
