### PR TITLE
Fix documentation for using slave shards

### DIFF
--- a/doc/sharding.rdoc
+++ b/doc/sharding.rdoc
@@ -36,7 +36,7 @@ To use a single, read-only slave that handles SELECT queries, the following
 is the simplest configuration:
 
   DB=Sequel.connect('postgres://master_server/database', \
-    :servers=>{:read_only=>{:host=>'slave_server'}})
+    :servers=>{:slave=>{:host=>'slave_server'}})
 
 This will use the slave_server for SELECT queries and master_server for
 other queries.


### PR DESCRIPTION
Not sure of the history, but using the single read-only slave, single master example in the docs, I had to use a key named `slave` instead of `read_only`.

Using sequel 4.10.0, mysql2 0.3.16, ruby 2.1.0 and a threaded connection pool.

I didn't see if this was necessary for the other examples, but I can update those as well if appropriate.

Thanks for the hard work!
