### PR TITLE
Add support for PostgreSQL CREATE/DROP EXTENSION

### DIFF
--- a/doc/postgresql.rdoc
+++ b/doc/postgresql.rdoc
@@ -132,9 +132,9 @@ allows you do create an unlogged table by specifying the <tt>:unlogged=>true</tt
   DB.create_table(:table, :unlogged=>true){Integer :i}
   # CREATE UNLOGGED TABLE "table" ("i" integer)
 
-=== Creating/Dropping Schemas, Languages, Functions, and Triggers
+=== Creating/Dropping Schemas, Languages, Functions, Triggers, and Extensions
 
-Sequel has built in support for creating and dropping PostgreSQL schemas, procedural languages, functions, and triggers:
+Sequel has built in support for creating and dropping PostgreSQL schemas, procedural languages, functions, triggers, and extensions:
 
   DB.create_schema(:s)
   # CREATE SCHEMA "s"
@@ -164,6 +164,11 @@ Sequel has built in support for creating and dropping PostgreSQL schemas, proced
   # CREATE TRIGGER trg_updated_at BEFORE INSERT OR UPDATE ON "table" FOR EACH ROW EXECUTE PROCEDURE set_updated_at()
   DB.drop_trigger(:table, :trg_updated_at)
   # DROP TRIGGER trg_updated_at ON "table"
+  
+  DB.create_extension(:hstore)
+  # CREATE EXTENSION hstore
+  DB.drop_extension(:hstore)
+  # DROP EXTENSION hstore
 
 == PostgreSQL-specific DML Support
 

--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -159,6 +159,17 @@ module Sequel
       def commit_prepared_transaction(transaction_id, opts=OPTS)
         run("COMMIT PREPARED #{literal(transaction_id)}", opts)
       end
+      
+      # Creates the extension in the database. Arguments:
+      # * name: The name of the extension to be installed.
+      # * opts: Options hash:
+      #   * :if_not_exists : Do not throw an error if an extension with the same name already exists.
+      #   * :schema : The name of the schema in which to install the extension's objects.
+      #   * :version : The version of the extension to install.
+      #   * :old_version : Must be specified when, and only when, you are attempting to install an extension that replaces an "old style" module.
+      def create_extension(name, opts=OPTS)
+        self << create_extension_sql(name, opts)
+      end
 
       # Creates the function in the database.  Arguments:
       # * name : name of the function to create
@@ -231,6 +242,15 @@ module Sequel
       def do(code, opts=OPTS)
         language = opts[:language]
         run "DO #{"LANGUAGE #{literal(language.to_s)} " if language}#{literal(code)}"
+      end
+      
+      # Drops the extension from the database. Arguments:
+      # * name : The name of an installed extension.
+      # * opts : Options hash:
+      #   * :if_exists : Do not throw an error if the extension does not exist.
+      #   * :cascade : Automatically drop objects that depend on the extension.
+      def drop_extension(name, opts=OPTS)
+        self << drop_extension_sql(name, opts)
       end
 
       # Drops the function from the database. Arguments:
@@ -756,6 +776,11 @@ module Sequel
         end
       end
 
+      # SQL statement to create an extension.
+      def create_extension_sql(name, opts=OPTS)
+        "CREATE EXTENSION #{'IF NOT EXISTS ' if opts[:if_not_exists]}#{name}#{" SCHEMA #{quote_identifier(opts[:schema])}" if opts[:schema]}#{" VERSION #{quote_identifier(opts[:version])}" if opts[:version]}#{" FROM #{opts[:old_version]}" if opts[:old_version]}"
+      end
+
       # SQL statement to create database function.
       def create_function_sql(name, definition, opts=OPTS)
         args = opts[:args]
@@ -841,6 +866,11 @@ module Sequel
       # The errors that the main adapters can raise, depends on the adapter being used
       def database_error_classes
         CONVERTED_EXCEPTIONS
+      end
+      
+      # SQL for dropping an extension from the database.
+      def drop_extension_sql(name, opts=OPTS)
+        "DROP EXTENSION#{' IF EXISTS' if opts[:if_exists]} #{name}#{' CASCADE' if opts[:cascade]}"
       end
 
       # SQL for dropping a function from the database.

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -1434,6 +1434,24 @@ describe "Postgres::Database functions, languages, schemas, and triggers" do
     @d.drop_schema(:sequel, :if_exists=>true, :cascade=>true)
     @d.drop_table?(:test)
   end
+  
+  specify '#create_extension and #drop_extension should create and drop extensions' do
+    @d.send(:create_extension_sql, :hstore).should == 'CREATE EXTENSION hstore'
+    @d.send(:create_extension_sql, :hstore, :if_not_exists => true).should == 'CREATE EXTENSION IF NOT EXISTS hstore'
+    @d.send(:create_extension_sql, :hstore, :schema => :public, :old_version => :unpackaged).should == 'CREATE EXTENSION hstore SCHEMA "public" FROM unpackaged'
+    
+    @d.create_extension(:hstore, :if_not_exists => true)
+    proc { @d.create_extension(:hstore) } .should raise_error(Sequel::DatabaseError)
+    
+    @d.send(:drop_extension_sql, :hstore).should == 'DROP EXTENSION hstore'
+    @d.send(:drop_extension_sql, :hstore, :if_exists => true).should == 'DROP EXTENSION IF EXISTS hstore'
+    @d.send(:drop_extension_sql, :hstore, :cascade => true).should == 'DROP EXTENSION hstore CASCADE'
+    @d.send(:drop_extension_sql, :hstore, :if_exists => true, :cascade => true).should == 'DROP EXTENSION IF EXISTS hstore CASCADE'
+    
+    @d.drop_extension(:hstore, :cascade => true)
+    proc { @d.drop_extension(:hstore) } .should raise_error(Sequel::DatabaseError)
+    @d.drop_extension(:hstore, :if_exists => true)
+  end
 
   specify "#create_function and #drop_function should create and drop functions" do
     proc{@d['SELECT tf()'].all}.should raise_error(Sequel::DatabaseError)


### PR DESCRIPTION
This adds [`CREATE EXTENSION`](http://www.postgresql.org/docs/9.3/static/sql-createextension.html) and [`DROP EXTENSION`](http://www.postgresql.org/docs/9.3/static/sql-dropextension.html) support for the `PostgreSQL` adapter: `#create_extension` and `#drop_extension`

```
DB.create_extension(:hstore, :if_not_exists => true)
# CREATE EXTENSION IF NOT EXISTS hstore

DB.drop_extension(:hstore)
# DROP EXTENSION hstore
```
- [x] Try to include tests for all new features.
- [x] Try to include documentation for all new features.
- [x] Follow the style conventions of the surrounding code.
- [x] Do not submit whitespace changes with code changes. (This actually happened, and I had to go back, search for the specific instances and add back the appropriate amount of trilling whitespace, because at the time, it was the easiest solution)
- [x] All code in pull requests is assummed to be MIT licensed.
