### PR TITLE
Increase valid number of digits for intervals

### DIFF
--- a/lib/sequel/extensions/pg_interval.rb
+++ b/lib/sequel/extensions/pg_interval.rb
@@ -67,7 +67,7 @@ module Sequel
       # Creates callable objects that convert strings into ActiveSupport::Duration instances.
       class Parser
         # Regexp that parses the full range of PostgreSQL interval type output.
-        PARSER = /\A([+-]?\d+ years?\s?)?([+-]?\d+ mons?\s?)?([+-]?\d+ days?\s?)?(?:(?:([+-])?(\d\d):(\d\d):(\d\d(\.\d+)?))|([+-]?\d+ hours?\s?)?([+-]?\d+ mins?\s?)?([+-]?\d+(\.\d+)? secs?\s?)?)?\z/o
+        PARSER = /\A([+-]?\d+ years?\s?)?([+-]?\d+ mons?\s?)?([+-]?\d+ days?\s?)?(?:(?:([+-])?(\d{2,10}):(\d\d):(\d\d(\.\d+)?))|([+-]?\d+ hours?\s?)?([+-]?\d+ mins?\s?)?([+-]?\d+(\.\d+)? secs?\s?)?)?\z/o
 
         # Parse the interval input string into an ActiveSupport::Duration instance.
         def call(string)

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -3028,6 +3028,7 @@ describe 'PostgreSQL interval types' do
       ['1 second', '00:00:01', 1, [[:seconds, 1]]],
       ['1 minute', '00:01:00', 60, [[:seconds, 60]]],
       ['1 hour', '01:00:00', 3600, [[:seconds, 3600]]],
+      ['123000 hours', '123000:00:00', 442800000, [[:seconds, 442800000]]],
       ['1 day', '1 day', 86400, [[:days, 1]]],
       ['1 week', '7 days', 86400*7, [[:days, 7]]],
       ['1 month', '1 mon', 86400*30, [[:months, 1]]],


### PR DESCRIPTION
Postgres will store and return more hours than just two digits:

```
will=# select * from deltas order by id desc limit 2;
 id  |   delta
-----+-----------
 336 | 167:30:00
 335 | 167:00:00
(2 rows)

will=# select '1000000000 hours'::interval;
     interval
------------------
 1000000000:00:00
(1 row)
```
