### PR TITLE
nested_attributes: set up the parent association in new children when possible.

### DIFF
--- a/lib/sequel/plugins/nested_attributes.rb
+++ b/lib/sequel/plugins/nested_attributes.rb
@@ -156,6 +156,13 @@ module Sequel
         # Returns the object created.
         def nested_attributes_create(reflection, attributes)
           obj = reflection.associated_class.new
+          if r = reflection.reciprocal
+            if reflection.reciprocal_array?
+              obj.send(r) << self
+            else
+              obj.associations[r] = self
+            end
+          end
           nested_attributes_set_attributes(reflection, obj, attributes)
           after_validation_hook{validate_associated_object(reflection, obj)}
           if reflection.returns_array?

--- a/spec/extensions/nested_attributes_spec.rb
+++ b/spec/extensions/nested_attributes_spec.rb
@@ -38,6 +38,7 @@ describe "NestedAttributes plugin" do
     @Artist.one_to_one :first_album, :class=>@Album, :key=>:artist_id
     @Album.many_to_one :artist, :class=>@Artist, :reciprocal=>:albums
     @Album.many_to_many :tags, :class=>@Tag, :left_key=>:album_id, :right_key=>:tag_id, :join_table=>:at
+    @Tag.many_to_many :albums, :class=>@Album, :left_key=>:tag_id, :right_key=>:album_id, :join_table=>:at
     @Artist.nested_attributes :albums, :first_album, :destroy=>true, :remove=>true
     @Artist.nested_attributes :concerts, :destroy=>true, :remove=>true
     @Album.nested_attributes :artist, :tags, :destroy=>true, :remove=>true
@@ -119,7 +120,9 @@ describe "NestedAttributes plugin" do
   it "should add new objects to the cached association array as soon as the *_attributes= method is called" do
     a = @Artist.new({:name=>'Ar', :albums_attributes=>[{:name=>'Al', :tags_attributes=>[{:name=>'T'}]}]})
     a.albums.should == [@Album.new(:name=>'Al')]
+    a.albums.first.artist.should == a
     a.albums.first.tags.should == [@Tag.new(:name=>'T')]
+    a.albums.first.tags.first.albums.should == [@Album.new(:name=>'Al')]
   end
   
   it "should support creating new objects with composite primary keys" do


### PR DESCRIPTION
In the nested_attributes plugin, initialize the parent association in a new child when the reciprocal association exists.
