### PR TITLE
Optmistic locking error

### DIFF
--- a/lib/sequel/plugins/optimistic_locking.rb
+++ b/lib/sequel/plugins/optimistic_locking.rb
@@ -18,7 +18,6 @@ module Sequel
     #
     # This plugin relies on the instance_filters plugin.
     module OptimisticLocking
-
       # Exception class raised when trying to update or destroy a stale object.
       class Error < Sequel::NoExistingObject; end
 


### PR DESCRIPTION
Hi,

Just a small change, so that we can differentiate at the type level when this happens due to optimistic locking issue, rather than from the other occurrences of NoExistingObject, as documented on:

https://github.com/jeremyevans/sequel/blob/7acaef623fd64d6938790336b7884d7954f51373/doc/release_notes/3.33.0.txt#L94

and 

https://github.com/jeremyevans/sequel/blob/1ee82f4e694188f780689bdb880d4d0f05dcd57e/spec/integration/model_test.rb#L166

Cheers,
- Daniel
