### PR TITLE
Add a destroy callback for the list plugin

### DIFF
--- a/lib/sequel/plugins/list.rb
+++ b/lib/sequel/plugins/list.rb
@@ -96,6 +96,15 @@ module Sequel
           super
         end
 
+        def around_destroy
+          tail = list_dataset.where("? > ?", position_field, position_value)
+          decrement = Sequel::SQL::NumericExpression.new(:-, position_field, 1)
+
+          tail.update(position_field => decrement)
+
+          super
+        end
+
         # Find the last position in the list containing this instance.
         def last_position
           list_dataset.max(position_field).to_i

--- a/spec/extensions/list_spec.rb
+++ b/spec/extensions/list_spec.rb
@@ -106,6 +106,12 @@ describe "List plugin" do
       "SELECT * FROM items WHERE (id = 3) ORDER BY scope_id, position LIMIT 1"]
   end
 
+  it "should refresh positions automatically on deletion" do
+    @o.destroy
+
+    @db.sqls.first.should == "UPDATE items SET position = (position - 1) WHERE (position > 3)"
+  end
+
   it "should have last_position return the last position in the list" do
     @c.dataset._fetch  = {:max=>10}
     @o.last_position.should == 10


### PR DESCRIPTION
When an item is deleted from a list, the positions of the following items need to be decremented to fill in the gap.
