### PR TITLE
Raise error within manual admin disconnection

### DIFF
--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -108,7 +108,7 @@ module Sequel
     # PGconn subclass for connection specific methods used with the
     # pg, postgres, or postgres-pr driver.
     class Adapter < ::PGconn
-      DISCONNECT_ERROR_RE = /\A(?:could not receive data from server|no connection to the server|connection not open)/
+      DISCONNECT_ERROR_RE = /\A(?:could not receive data from server|no connection to the server|connection not open|terminating connection due to administrator command)/
       
       self.translate_results = false if respond_to?(:translate_results=)
       


### PR DESCRIPTION
Raise error Sequel::DatabaseDisconnectError when receiving the message
"terminating connection due to administrator command". This may happen
with a manual restart or any other manual connection reset.
