### PR TITLE
Use copy constructors instead of overriding dup/clone

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1165,12 +1165,7 @@ module Sequel
       # are frozen.
       def initialize_clone(other)
         super
-        if other.frozen?
-          @values.freeze
-          @changed_columns.freeze if @changed_columns
-          @errors.freeze if @errors
-          @this.freeze if @this
-        end
+        freeze if other.frozen?
       end
 
       # Returns value of the column's attribute.


### PR DESCRIPTION
This modifies Sequel::Model to use Ruby's "copy constructors" to do the work of duplicating/freezing internal data structures instead of overriding `#dup` and `#clone` directly and then `instance_eval`ing the result.

This makes duplicating and cloning more consistent with how Ruby's core/stdlib behaves, and makes the behavior easier to extend in subclasses, as `self` in the bodies of the methods is the duplicate instead of the original.
