### PR TITLE
FIX: PostgreSQL deadlock sqlstate

### DIFF
--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -529,7 +529,8 @@ module Sequel
 
       def database_exception_sqlstate(exception, opts)
         if exception.respond_to?(:result) && (result = exception.result)
-          result.error_field(::PGresult::PG_DIAG_SQLSTATE)
+          sqlstate = result.error_field(::PGresult::PG_DIAG_SQLSTATE)
+          sqlstate == '40P01' ? '40001' : sqlstate
         end
       end
 


### PR DESCRIPTION
In PostgreSQL, when the deadlock error occurs, Sequel::DatabaseError is
raised instead of Sequel::SerializationFailure.
Because the sqlstate of deadlock is '40P01' in PostgreSQL. It is not '40001'.
