### PR TITLE
FIX: PostgreSQL deadlock sqlstate

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -708,9 +708,12 @@ module Sequel
       end
 
       EXCLUSION_CONSTRAINT_SQL_STATE = '23P01'.freeze
+      DEADLOCK_SQL_STATE = '40P01'.freeze
       def database_specific_error_class_from_sqlstate(sqlstate)
         if sqlstate == EXCLUSION_CONSTRAINT_SQL_STATE
           ExclusionConstraintViolation
+        elsif sqlstate == DEADLOCK_SQL_STATE
+          SerializationFailure
         else
           super
         end


### PR DESCRIPTION
In PostgreSQL, when the deadlock error occurs, Sequel::DatabaseError is
raised instead of Sequel::SerializationFailure.
Because the sqlstate of deadlock is '40P01' in PostgreSQL. It is not '40001'.
