### PR TITLE
Avoid false positive cache hits when using STI.

### DIFF
--- a/lib/sequel/plugins/caching.rb
+++ b/lib/sequel/plugins/caching.rb
@@ -64,10 +64,15 @@ module Sequel
           cache_get(cache_key(pk))
         end
 
+        # Returns the prefix used to namespace this class in the cache.
+        def cache_key_prefix
+          "#{self}"
+        end
+
         # Return a key string for the given primary key.
         def cache_key(pk)
           raise(Error, 'no primary key for this record') unless pk.is_a?(Array) ? pk.all? : pk
-          "#{self}:#{Array(pk).join(',')}"
+          "#{cache_key_prefix}:#{Array(pk).join(',')}"
         end
         
         Plugins.inherited_instance_variables(self, :@cache_store=>nil, :@cache_ttl=>nil, :@cache_ignore_exceptions=>nil)

--- a/spec/extensions/caching_spec.rb
+++ b/spec/extensions/caching_spec.rb
@@ -249,4 +249,22 @@ describe Sequel::Model, "caching" do
     @c.cache_delete_pk(1).should == nil
     @c.cache_get_pk(1).should == nil
   end
+
+  it "should support overriding the cache key prefix" do
+    c2 = Class.new(@c)
+    c2.define_singleton_method(:cache_key_prefix) {"ceetwo"}
+    c3 = Class.new(c2)
+    @c.cache_key(:id).should_not == c2.cache_key(:id)
+    c2.cache_key(:id).should == c3.cache_key(:id)
+    
+    @c[1]
+    c2.cache_get_pk(1).should == nil
+    m = c2[1]
+    c2.cache_get_pk(1).values.should == @c[1].values
+    c3.cache_get_pk(1).values.should == m.values
+
+    m.name << m.name
+    m.save
+    c2[1].values.should == c3[1].values
+  end
 end

--- a/spec/extensions/single_table_inheritance_spec.rb
+++ b/spec/extensions/single_table_inheritance_spec.rb
@@ -120,6 +120,29 @@ describe Sequel::Model, "single table inheritance plugin" do
     StiTestSub1A.dataset.sql.should == "SELECT * FROM sti_tests WHERE (sti_tests.kind IN ('StiTestSub1A', 'StiTestSub1B'))"
     StiTestSub1B.dataset.sql.should == "SELECT * FROM sti_tests WHERE (sti_tests.kind IN ('StiTestSub1B'))"
   end
+  
+  it "should work correctly with the :caching plugin" do
+    cache_class = Class.new(Hash) do
+      attr_accessor :ttl
+      def set(k, v, ttl); self[k] = v; @ttl = ttl; end
+      def get(k); self[k]; end
+    end
+    cache = cache_class.new
+
+    StiTest.plugin :caching, cache
+    StiTest.define_singleton_method(:cache_key_prefix) { "stitest" }
+    c2 = Class.new StiTest
+    c2.cache_key(:id).should == StiTest.cache_key(:id)
+
+    obj2 = c2.new
+    obj2.values[:x] = 2
+    obj2.save
+    c2[obj2.id]
+    c2.cache_get_pk(obj2.id).values.should == StiTest.cache_get_pk(obj2.id).values
+    obj2.save
+    c2.cache_get_pk(obj2.id).should == nil
+    StiTest.cache_get_pk(obj2.id).should == nil
+  end
 
   describe "with custom options" do
     before do
@@ -249,6 +272,5 @@ describe Sequel::Model, "single table inheritance plugin" do
       StiTest3.create.kind.should == 'stitest3'
       StiTest4.create.kind.should == 'stitest4'
     end
-
   end
 end


### PR DESCRIPTION
I encountered a bug using STI with the caching plugin.  The bad interaction is that STI uses multiple classes to load data from the same table, and the caching plugin uses a prefix based on the name of the model's class, so saving as one class and then attempting a load through another class gives stale data.  A simplified version of my use-case:

``` ruby
Sequel::Model.plugin :caching, TheMemcachedClient
class User < Sequel::Model(:users)
    plugin :single_table_inheritance, :type,
        model_map: {
            'student' => '::User::Student',
            # And other classes.
        }
    class Student < self; end
    # And other classes.
end

student = User[user_id]
student.stale = false
student.save # Cached as a User::Student rather than a User!

# Meanwhile, in another HTTP request, or a different process sharing the
# same cache, or something:
user = User[the_same_user_id] 
user.stale # => true

```

My workaround was to override `User.cache_key(pk)` by means of copy and paste, but this was a little less than ideal.  I added a method to allow a user to explicitly override the prefix only (without duplicating the logic around the PK).  It's fairly unobtrusive (the behavior doesn't change unless the `cache_key_prefix` method is overridden), and it solves the issue.
