### PR TITLE
Fix error in documentation (two=>to)

### DIFF
--- a/lib/sequel/adapters/mysql2.rb
+++ b/lib/sequel/adapters/mysql2.rb
@@ -61,7 +61,7 @@ module Sequel
         execute(sql, opts){|c| return c.last_id}
       end
 
-      # Return the version of the MySQL server two which we are connecting.
+      # Return the version of the MySQL server to which we are connecting.
       def server_version(server=nil)
         @server_version ||= (synchronize(server){|conn| conn.server_info[:id]} || super)
       end


### PR DESCRIPTION
Documentation had "two" instead of "to".
