### PR TITLE
Adding FoundationDB SQL Layer adapter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ begin
   spec_with_cov.call("spec_plugin", Dir["spec/extensions/*_spec.rb"].sort_by{rand}, "Run extension/plugin specs"){|t| t.rcov_opts.concat(%w'--exclude "lib/sequel/([a-z_]+\.rb|adapters|connection_pool|database|dataset|model)"')}
   spec_with_cov.call("spec_integration", Dir["spec/integration/*_test.rb"], "Run integration tests")
 
-  %w'postgres sqlite mysql informix oracle firebird mssql db2 sqlanywhere'.each do |adapter|
+  %w'postgres sqlite mysql informix oracle fdbsql firebird mssql db2 sqlanywhere'.each do |adapter|
     spec_with_cov.call("spec_#{adapter}", ["spec/adapters/#{adapter}_spec.rb"] + Dir["spec/integration/*_test.rb"], "Run #{adapter} specs"){|t| t.rcov_opts.concat(%w'--exclude "lib/sequel/([a-z_]+\.rb|connection_pool|database|dataset|model|extensions|plugins)"')}
   end
 

--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -206,6 +206,18 @@ Connection string examples:
   do:postgres://user:password@host/database
   do:mysql://user:password@host/database
 
+=== fdbsql
+
+Requires: pg
+
+The following additional options are supported:
+
+:connect_timeout :: Set the number of seconds to wait for a connection (default 20).
+:notice_receiver :: A proc that be called with the PGresult objects that have notice or warning messages.
+                    The default notice receiver just prints the messages to stderr, but this can be used
+                    to handle notice/warning messages differently.
+:sslmode :: Set to 'disable', 'allow', 'prefer', 'require' to choose how to treat SSL.
+
 === firebird 
 
 Requires: fb (using code at http://github.com/wishdev/fb)
@@ -239,8 +251,9 @@ Requires: java
 Houses Sequel's JDBC support when running on JRuby.
 Support for individual database types is done using sub adapters.
 There are currently subadapters for PostgreSQL, MySQL, SQLite, H2, HSQLDB, Derby,
-Oracle, MSSQL, JTDS, AS400, Progress, Firebird, Informix, and DB2.  For PostgreSQL, MySQL, SQLite, H2, HSQLDB, Derby,
-and JTDS, this can use the jdbc-* gem, for the others you need to have the .jar in your CLASSPATH
+Oracle, MSSQL, JTDS, AS400, Progress, Fdbsql, Firebird, Informix, and DB2.
+For PostgreSQL, MySQL, SQLite, H2, HSQLDB, Derby, and JTDS,
+this can use the jdbc-* gem, for the others you need to have the .jar in your CLASSPATH
 or load the Java class manually before calling Sequel.connect.
 
 You just use the JDBC connection string directly, which can be specified
@@ -274,6 +287,7 @@ Example connection strings:
   jdbc:jdbcprogress:T:hostname:port:database
   jdbc:cubrid:hostname:port:database:::
   jdbc:sqlanywhere://localhost?DBN=Test;UID=user;PWD=password
+  jdbc:fdbsql://localhost:15432/user?user=user&password=password
 
 You can also use JNDI connection strings:
 

--- a/lib/sequel/adapters/fdbsql.rb
+++ b/lib/sequel/adapters/fdbsql.rb
@@ -1,0 +1,366 @@
+require 'pg'
+
+Sequel.require 'adapters/utils/pg_types'
+Sequel.require 'adapters/shared/fdbsql'
+
+module Sequel
+
+  def_adapter_method(:fdbsql)
+
+  module Fdbsql
+    CONVERTED_EXCEPTIONS << PGError
+
+    # Database class for the FoundationDB SQL Layer used with Sequel and the
+    # pg driver
+    class Database < Sequel::Database
+      include Sequel::Fdbsql::DatabaseMethods
+
+      set_adapter_scheme :fdbsql
+
+      # Connects to the database. In addition to the standard database options,
+      # :connect_timeout is a connection timeout in seconds,
+      # :sslmode sets whether to use ssl, and
+      # :notice_receiver handles server notices in a proc.
+      def connect(server)
+        opts = server_opts(server)
+        Connection.new(self, opts)
+      end
+
+      # Execute the given SQL with the given args on an available connection.
+      def execute(sql, opts = {}, &block)
+        res = nil
+        synchronize(opts[:server]) do |conn|
+          res = check_database_errors do
+            if sql.is_a?(Symbol)
+              execute_prepared_statement(conn, sql, opts, &block)
+            else
+              log_yield(sql) do
+                conn.query(sql, opts[:arguments])
+              end
+            end
+          end
+          yield res if block_given?
+          res.cmd_tuples
+        end
+      end
+
+      private
+
+      def begin_transaction(conn, opts=OPTS)
+        super
+        conn.in_transaction = true
+      end
+
+      def database_exception_sqlstate(exception, opts)
+        if exception.respond_to?(:result) && (result = exception.result)
+          result.error_field(::PGresult::PG_DIAG_SQLSTATE)
+        end
+      end
+
+      def execute_prepared_statement(conn, name, opts=OPTS, &block)
+        statement = prepared_statement(name)
+        sql = statement.prepared_sql
+        ps_name = name.to_s
+        if args = opts[:arguments]
+          args = args.map{|arg| bound_variable_arg(arg, conn)}
+        end
+        begin
+          # create prepared statement if it doesn't exist, or has new sql
+          unless conn.prepared_statements[ps_name] == sql
+            conn.execute("DEALLOCATE #{ps_name}") if conn.prepared_statements.include?(ps_name)
+            log_yield("PREPARE #{ps_name} AS #{sql}"){conn.prepare(ps_name, sql)}
+            conn.prepared_statements[ps_name] = sql
+          end
+
+          log_sql = "EXECUTE #{ps_name}"
+          if statement.log_sql
+            log_sql << " ("
+            log_sql << sql
+            log_sql << ")"
+          end
+          log_yield(sql, args) do
+            conn.execute_prepared_statement(ps_name, args)
+          end
+        rescue PGError => e
+          if (database_exception_sqlstate(e, opts) == STALE_STATEMENT_SQLSTATE)
+            conn.prepared_statements[ps_name] = nil
+            retry
+          end
+        end
+      end
+
+      def remove_transaction(conn, committed)
+        conn.in_transaction = false
+      ensure
+        super
+      end
+
+    end
+
+    # Dataset class for the FoundationDB SQL Layer that uses the pg driver.
+    class Dataset < Sequel::Dataset
+      include Sequel::Fdbsql::DatasetMethods
+
+      Database::DatasetClass = self
+
+      # Allow use of bind arguments for FDBSQL using the pg driver.
+      module BindArgumentMethods
+
+        include Sequel::Dataset::UnnumberedArgumentMapper
+        include DatasetMethods::PreparedStatementMethods
+
+        private
+
+        # Execute the given SQL with the stored bind arguments.
+        def execute(sql, opts=OPTS, &block)
+          super(sql, {:arguments=>bind_arguments}.merge(opts), &block)
+        end
+
+        # Same as execute, explicit due to intricacies of alias and super.
+        def execute_dui(sql, opts=OPTS, &block)
+          super(sql, {:arguments=>bind_arguments}.merge(opts), &block)
+        end
+      end
+
+      # Allow use of server side prepared statements for FDBSQL using the
+      # pg driver.
+      module PreparedStatementMethods
+        include BindArgumentMethods
+
+        # Raise a more obvious error if you attempt to call a unnamed prepared statement.
+        def call(*)
+          raise Error, "Cannot call prepared statement without a name" if prepared_statement_name.nil?
+          super
+        end
+
+        private
+
+        # Execute the stored prepared statement name and the stored bind
+        # arguments instead of the SQL given.
+        def execute(sql, opts=OPTS, &block)
+          super(prepared_statement_name, opts, &block)
+        end
+
+        # Same as execute, explicit due to intricacies of alias and super.
+        def execute_dui(sql, opts=OPTS, &block)
+          super(prepared_statement_name, opts, &block)
+        end
+      end
+
+
+      # Execute the given type of statement with the hash of values.
+      def call(type, bind_vars=OPTS, *values, &block)
+        ps = to_prepared_statement(type, values)
+        ps.extend(BindArgumentMethods)
+        ps.call(bind_vars, &block)
+      end
+
+      # Yield all rows returned by executing the given SQL and converting
+      # the types.
+      def fetch_rows(sql)
+        execute(sql) do |res|
+          columns = set_columns(res)
+          yield_hash_rows(res, columns) {|h| yield h}
+        end
+      end
+
+      # Prepare the given type of statement with the given name, and store
+      # it in the database to be called later.
+      def prepare(type, name=nil, *values)
+        ps = to_prepared_statement(type, values)
+        ps.extend(PreparedStatementMethods)
+        if name
+          ps.prepared_statement_name = name
+          db.set_prepared_statement(name, ps)
+        end
+        ps
+      end
+
+      private
+
+      def set_columns(res)
+        cols = []
+        procs = db.conversion_procs
+        res.nfields.times do |fieldnum|
+          cols << [fieldnum, procs[res.ftype(fieldnum)], output_identifier(res.fname(fieldnum))]
+        end
+        @columns = cols.map{|c| c[2]}
+        cols
+      end
+
+      # For each row in the result set, yield a hash with column name symbol
+      # keys and typecasted values.
+      def yield_hash_rows(res, cols)
+        res.ntuples.times do |recnum|
+          converted_rec = {}
+          cols.each do |fieldnum, type_proc, fieldsym|
+            value = res.getvalue(recnum, fieldnum)
+            converted_rec[fieldsym] = (value && type_proc) ? type_proc.call(value) : value
+          end
+          yield converted_rec
+        end
+      end
+
+    end
+
+    # Connection specific methods for Fdbsql with pg
+    class Connection
+      CONNECTION_OK = -1
+
+      # Regular expression for error messages that note that the connection is closed.
+      DISCONNECT_ERROR_RE = /\A(?:could not receive data from server|no connection to the server|connection not open|connection is closed)/
+
+      # These sql states are used to indicate that fdbvql should automatically
+      # retry the statement if it's not in a transaction
+      RETRY_SQLSTATES = %w'40002'.freeze.each{|s| s.freeze}
+
+      # Whether or not this connection is in a transaction.
+      attr_accessor :in_transaction
+
+      # Hash of prepared statements for this connection.  Keys are
+      # string names of the server side prepared statement, and values
+      # are SQL strings.
+      attr_accessor :prepared_statements
+
+      # Create a new connection to the FoundationDB SQL Layer. See Database#connect.
+      def initialize(db, opts)
+        @db = db
+        @config = opts
+        @connection_hash = {
+          :host => @config[:host] || 'localhost',
+          :port => @config[:port] || 15432,
+          :dbname => @config[:database],
+          :user => @config[:user],
+          :password => @config[:password],
+          :hostaddr => @config[:hostaddr],
+          :connect_timeout => @config[:connect_timeout] || 20,
+          :sslmode => @config[:sslmode]
+        }.delete_if { |key, value| value.nil? or (value.respond_to?(:empty?) and value.empty?)}
+        @prepared_statements = {}
+        connect
+      end
+
+      # Close the connection.
+      def close
+        # Just like postgres, ignore any errors here
+        begin
+          @connection.close
+        rescue PGError, IOError
+        end
+      end
+
+      # Execute the given SQL with this connection.  If a block is given,
+      # yield the results, otherwise, return the number of changed rows.
+      def execute(sql, args=nil)
+        q = query(sql, args)
+        block_given? ? yield(q) : q.cmd_tuples
+      end
+
+      # Execute the prepared statement of the given name, binding the given
+      # args.
+      def execute_prepared_statement(name, args)
+        check_disconnect_errors do
+          retry_on_not_committed do
+            @connection.exec_prepared(name, args)
+          end
+        end
+      end
+
+      # Prepare a statement for later use.
+      def prepare(name, sql)
+        check_disconnect_errors do
+          retry_on_not_committed do
+            @connection.prepare(name, sql)
+          end
+        end
+      end
+
+      # Execute the given query and return the results.
+      def query(sql, args=nil)
+        args = args.map{|v| @db.bound_variable_arg(v, self)} if args
+        check_disconnect_errors do
+          retry_on_not_committed do
+            @connection.query(sql, args)
+          end
+        end
+      end
+
+      private
+
+      def check_version
+        ver = execute('SELECT VERSION()') do |res|
+          version = res.first['_SQL_COL_1']
+          m = version.match('^.* (\d+)\.(\d+)\.(\d+)')
+          if m.nil?
+            raise "No match when checking FDB SQL Layer version: #{version}"
+          end
+          m
+        end
+
+        # Combine into single number, two digits per part: 1.9.3 => 10903
+        @sql_layer_version = (100 * ver[1].to_i + ver[2].to_i) * 100 + ver[3].to_i
+        if @sql_layer_version < 20000
+          raise Sequel::DatabaseError.new("Unsupported FDB SQL Layer version: #{ver[1]}.#{ver[2]}.#{ver[3]}")
+        end
+      end
+
+      def connect
+        @connection = PG::Connection.new(@connection_hash)
+        if (@config[:notice_receiver])
+          @connection.set_notice_receiver(@config[:notice_receiver])
+        else
+          # Swallow warnings
+          @connection.set_notice_receiver { |proc| }
+        end
+        check_version
+      end
+
+      # Raise a Sequel::DatabaseDisconnectError if a PGError is raised and
+      # the connection status cannot be determined or it is not OK.
+      def check_disconnect_errors
+        begin
+          yield
+        rescue PGError => e
+          disconnect = false
+          begin
+            s = status
+          rescue PGError
+            disconnect = true
+          end
+          status_ok = (s == CONNECTION_OK)
+          disconnect ||= !status_ok
+          disconnect ||= e.message =~ DISCONNECT_ERROR_RE
+          disconnect ? raise(Sequel.convert_exception_class(e, Sequel::DatabaseDisconnectError)) : raise
+        rescue IOError, Errno::EPIPE, Errno::ECONNRESET => e
+          disconnect = true
+          raise(Sequel.convert_exception_class(e, Sequel::DatabaseDisconnectError))
+        end
+      end
+
+      def database_exception_sqlstate(exception, opts)
+        if exception.respond_to?(:result) && (result = exception.result)
+          result.error_field(::PGresult::PG_DIAG_SQLSTATE)
+        end
+      end
+
+      def retry_on_not_committed
+        retries = NUMBER_OF_NOT_COMMITTED_RETRIES
+        begin
+          yield
+        rescue PG::TRIntegrityConstraintViolation => e
+          if (!in_transaction and RETRY_SQLSTATES.include? database_exception_sqlstate(e, :classes=>CONVERTED_EXCEPTIONS))
+            retry if (retries -= 1) > 0
+          end
+          raise
+        end
+      end
+
+      def status
+        CONNECTION_OK
+      end
+
+    end
+
+    Dataset.register_extension(:date_arithmetic, Sequel::Fdbsql::DateArithmeticDatasetMethods)
+  end
+end

--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -242,24 +242,7 @@ module Sequel
         return call_sproc(sql, opts, &block) if opts[:sproc]
         return execute_prepared_statement(sql, opts, &block) if [Symbol, Dataset].any?{|c| sql.is_a?(c)}
         synchronize(opts[:server]) do |conn|
-          statement(conn) do |stmt|
-            if block
-              if size = fetch_size
-                stmt.setFetchSize(size)
-              end
-              yield log_yield(sql){stmt.executeQuery(sql)}
-            else
-              case opts[:type]
-              when :ddl
-                log_yield(sql){stmt.execute(sql)}
-              when :insert
-                log_yield(sql){execute_statement_insert(stmt, sql)}
-                last_insert_id(conn, opts.merge(:stmt=>stmt))
-              else
-                log_yield(sql){stmt.executeUpdate(sql)}
-              end
-            end
-          end
+          execute_on_connection(conn, sql, opts, &block)
         end
       end
       alias execute_dui execute
@@ -397,8 +380,7 @@ module Sequel
       # statement, use that statement instead of creating another.
       # Otherwise, prepare a new statement for the connection, bind the
       # variables, and execute it.
-      def execute_prepared_statement(name, opts=OPTS)
-        args = opts[:arguments]
+      def execute_prepared_statement(name, opts=OPTS, &block)
         if name.is_a?(Dataset)
           ps = name
           name = ps.prepared_statement_name
@@ -407,43 +389,48 @@ module Sequel
         end
         sql = ps.prepared_sql
         synchronize(opts[:server]) do |conn|
-          if name and cps = cps_sync(conn){|cpsh| cpsh[name]} and cps[0] == sql
-            cps = cps[1]
+          execute_prepared_statement_on_connection(conn, ps, name, sql, opts, &block)
+        end
+      end
+
+      def execute_prepared_statement_on_connection(conn, ps, name, sql, opts)
+        args = opts[:arguments]
+        if name and cps = cps_sync(conn){|cpsh| cpsh[name]} and cps[0] == sql
+          cps = cps[1]
+        else
+          log_yield("CLOSE #{name}"){cps[1].close} if cps
+          cps = log_yield("PREPARE#{" #{name}:" if name} #{sql}"){prepare_jdbc_statement(conn, sql, opts)}
+          if size = fetch_size
+            cps.setFetchSize(size)
+          end
+          cps_sync(conn){|cpsh| cpsh[name] = [sql, cps]} if name
+        end
+        i = 0
+        args.each{|arg| set_ps_arg(cps, arg, i+=1)}
+        msg = "EXECUTE#{" #{name}" if name}"
+        if ps.log_sql
+          msg << " ("
+          msg << sql
+          msg << ")"
+        end
+        begin
+          if block_given?
+            yield log_yield(msg, args){cps.executeQuery}
           else
-            log_yield("CLOSE #{name}"){cps[1].close} if cps
-            cps = log_yield("PREPARE#{" #{name}:" if name} #{sql}"){prepare_jdbc_statement(conn, sql, opts)}
-            if size = fetch_size
-              cps.setFetchSize(size)
-            end
-            cps_sync(conn){|cpsh| cpsh[name] = [sql, cps]} if name
-          end
-          i = 0
-          args.each{|arg| set_ps_arg(cps, arg, i+=1)}
-          msg = "EXECUTE#{" #{name}" if name}"
-          if ps.log_sql
-            msg << " ("
-            msg << sql
-            msg << ")"
-          end
-          begin
-            if block_given?
-              yield log_yield(msg, args){cps.executeQuery}
+            case opts[:type]
+            when :ddl
+              log_yield(msg, args){cps.execute}
+            when :insert
+              log_yield(msg, args){execute_prepared_statement_insert(cps)}
+              last_insert_id(conn, opts.merge(:prepared=>true, :stmt=>cps))
             else
-              case opts[:type]
-              when :ddl
-                log_yield(msg, args){cps.execute}
-              when :insert
-                log_yield(msg, args){execute_prepared_statement_insert(cps)}
-                last_insert_id(conn, opts.merge(:prepared=>true, :stmt=>cps))
-              else
-                log_yield(msg, args){cps.executeUpdate}
-              end
+              log_yield(msg, args){cps.executeUpdate}
             end
-          rescue NativeException, JavaSQL::SQLException => e
-            raise_error(e)
-          ensure
-            cps.close unless name
           end
+        rescue NativeException, JavaSQL::SQLException => e
+          raise_error(e)
+        ensure
+          cps.close unless name
         end
       end
 
@@ -455,6 +442,27 @@ module Sequel
       # Execute the insert SQL using the statement
       def execute_statement_insert(stmt, sql)
         stmt.executeUpdate(sql)
+      end
+
+      def execute_on_connection(conn, sql, opts, &block)
+        statement(conn) do |stmt|
+          if block
+            if size = fetch_size
+              stmt.setFetchSize(size)
+            end
+            yield log_yield(sql){stmt.executeQuery(sql)}
+          else
+            case opts[:type]
+            when :ddl
+              log_yield(sql){stmt.execute(sql)}
+            when :insert
+              log_yield(sql){execute_statement_insert(stmt, sql)}
+              last_insert_id(conn, opts.merge(:stmt=>stmt))
+            else
+              log_yield(sql){stmt.executeUpdate(sql)}
+            end
+          end
+        end
       end
 
       # The default fetch size to use for statements.  Nil by default, so that the

--- a/lib/sequel/adapters/jdbc/fdbsql.rb
+++ b/lib/sequel/adapters/jdbc/fdbsql.rb
@@ -1,0 +1,119 @@
+Sequel::JDBC.load_driver('com.foundationdb.sql.jdbc.Driver')
+Sequel.require 'adapters/shared/fdbsql'
+
+module Sequel
+  Fdbsql::CONVERTED_EXCEPTIONS << NativeException
+
+  module JDBC
+    Sequel.synchronize do
+      DATABASE_SETUP[:fdbsql] = proc do |db|
+        db.extend(Sequel::JDBC::Fdbsql::DatabaseMethods)
+        db.dataset_class = Sequel::JDBC::Fdbsql::Dataset
+        com.foundationdb.sql.jdbc.Driver
+      end
+    end
+
+    # Adapter, Database, and Dataset support for accessing the FoundationDB SQL Layer
+    # via JDBC
+    module Fdbsql
+      # Methods to add to Database instances that access Fdbsql via
+      # JDBC.
+      module DatabaseMethods
+        extend Sequel::Database::ResetIdentifierMangling
+        include Sequel::Fdbsql::DatabaseMethods
+
+        # Add the primary_keys and primary_key_sequences instance variables,
+        # so we can get the correct return values for inserted rows.
+        def self.extended(db)
+          super
+          db.send(:adapter_initialize)
+        end
+
+        # Execute the given SQL with the given args on an available connection.
+        def execute(sql, opts=OPTS, &block)
+          return call_sproc(sql, opts, &block) if opts[:sproc]
+          return execute_prepared_statement(sql, opts, &block) if [Symbol, Dataset].any?{|c| sql.is_a?(c)}
+          synchronize(opts[:server]) do |conn|
+            retry_on_not_committed(conn) do
+              statement(conn) do |stmt|
+                execute_on_connection(conn, sql, opts, &block)
+              end
+            end
+          end
+        end
+
+        private
+
+        DISCONNECT_ERROR_RE = /\A(?:This connection has been closed|An I\/O error occurred while sending to the backend)/
+        def disconnect_error?(exception, opts)
+          super || exception.message =~ DISCONNECT_ERROR_RE
+        end
+
+        def database_exception_sqlstate(exception, opts)
+          if exception.respond_to?(:sql_state)
+            exception.sql_state
+          end
+        end
+
+        def execute_prepared_statement(name, opts=OPTS, &block)
+          if name.is_a?(Dataset)
+            ps = name
+            name = ps.prepared_statement_name
+          else
+            ps = prepared_statement(name)
+          end
+          sql = ps.prepared_sql
+          synchronize(opts[:server]) do |conn|
+            retry_on_not_committed(conn) do
+              begin
+                execute_prepared_statement_on_connection(conn, ps, name, sql, opts, &block)
+              rescue Sequel::DatabaseError => e
+                if (e.wrapped_exception && database_exception_sqlstate(e.wrapped_exception, opts) == STALE_STATEMENT_SQLSTATE)
+                  cps_sync(conn){|cpsh| cpsh[name] = nil}
+                  retry
+                else
+                  raise
+                end
+              end
+            end
+          end
+        end
+
+        def retry_on_not_committed(conn)
+          retries = Sequel::Fdbsql::NUMBER_OF_NOT_COMMITTED_RETRIES
+          begin
+            yield
+          rescue Sequel::Fdbsql::NotCommittedError => e
+            if (conn.auto_commit and (retries -= 1) > 0)
+              retry
+            else
+              raise
+            end
+          end
+        end
+
+      end
+
+      # Methods to add to Dataset instances that access the FoundationDB SQL Layer via
+      # JDBC.
+      class Dataset < JDBC::Dataset
+        include Sequel::Fdbsql::DatasetMethods
+
+        # Add the shared Fdbsql prepared statement methods
+        def prepare(type, name=nil, *values)
+          ps = to_prepared_statement(type, values)
+          ps.extend(JDBC::Dataset::PreparedStatementMethods)
+          ps.extend(::Sequel::Fdbsql::DatasetMethods::PreparedStatementMethods)
+          if name
+            ps.prepared_statement_name = name
+            db.set_prepared_statement(name, ps)
+          end
+          ps
+        end
+      end
+
+      Dataset.register_extension(:date_arithmetic, Sequel::Fdbsql::DateArithmeticDatasetMethods)
+    end
+
+  end
+end

--- a/lib/sequel/adapters/shared/fdbsql.rb
+++ b/lib/sequel/adapters/shared/fdbsql.rb
@@ -1,0 +1,622 @@
+Sequel.require 'extensions/date_arithmetic'
+Sequel.require 'adapters/utils/pg_types'
+
+module Sequel
+
+  # Top level module for holding all FoundationDB SQL Layer related modules and
+  # classes for Sequel.
+  module Fdbsql
+
+    # Array of exceptions that need to be converted.  JDBC
+    # uses NativeExceptions, the native adapter uses PGError.
+    CONVERTED_EXCEPTIONS  = []
+
+    # When the connection is in autocommit mode, and the server returns a retryable
+    # error, the adapter will retry. At most it will retry this many times
+    NUMBER_OF_NOT_COMMITTED_RETRIES = 10
+
+    # Error raised when Sequel determines a Fdbsql exclusion constraint has been violated.
+    class ExclusionConstraintViolation < Sequel::ConstraintViolation; end
+    # Base class for all retryable errors
+    class RetryError < Sequel::DatabaseError; end
+    # Error thrown when the FoundationDB SQL Layer returns a NotCommitted status
+    class NotCommittedError < RetryError; end
+
+    # Methods shared by Database instances that connect to
+    # the FoundationDB SQL Layer
+    module DatabaseMethods
+
+      # A hash of conversion procs, keyed by type integer (oid) and
+      # having callable values for the conversion proc for that type.
+      attr_reader :conversion_procs
+
+      # Convert given argument so that it can be used directly by pg.  Currently, pg doesn't
+      # handle fractional seconds in Time/DateTime or blobs with "\0", and it won't ever
+      # handle Sequel::SQLTime values correctly.  Only public for use by the adapter, shouldn't
+      # be used by external code.
+      def bound_variable_arg(arg, conn)
+        case arg
+        # TODO TDD it:
+        when Sequel::SQL::Blob
+          # the 1 means treat this as a binary blob
+          {:value => arg, :format => 1}
+        when Sequel::SQLTime
+          # the literal methods put quotes around things, but this is a bound variable, so we can't use those
+          arg.strftime(BOUND_VARIABLE_SQLTIME_FORMAT)
+        when DateTime, Time
+          # the literal methods put quotes around things, but this is a bound variable, so we can't use those
+          from_application_timestamp(arg).strftime(BOUND_VARIABLE_TIMESTAMP_FORMAT)
+        else
+           arg
+        end
+      end
+
+      # Fdbsql uses the :fdbsql database type.
+      def database_type
+        :fdbsql
+      end
+
+      # like PostgreSQL fdbsql uses SERIAL psuedo-type instead of AUTOINCREMENT for
+      # managing incrementing primary keys.
+      def serial_primary_key_options
+        {:primary_key => true, :serial => true, :type=>Integer}
+      end
+
+      # indexes are namespaced per table
+      def global_index_namespace?
+        false
+      end
+
+      # Return primary key for the given table.
+      def primary_key(table_name, opts=OPTS)
+        quoted_table = quote_schema_table(table_name)
+        Sequel.synchronize{return @primary_keys[quoted_table] if @primary_keys.has_key?(quoted_table)}
+        out_identifier, in_identifier = identifier_convertors(opts)
+        schema, table = schema_or_current_and_table(table_name, opts)
+        dataset = metadata_dataset.
+          select(:kc__column_name).
+          from(Sequel.as(:information_schema__key_column_usage, 'kc')).
+          join(Sequel.as(:information_schema__table_constraints, 'tc'),
+               [:table_name, :table_schema, :constraint_name]).
+          where(kc__table_name: in_identifier.call(table),
+                kc__table_schema: schema,
+                tc__constraint_type: 'PRIMARY KEY')
+        value = dataset.map do |row|
+          out_identifier.call(row.delete(:column_name))
+        end
+        value = case value.size
+                  when 0 then nil
+                  when 1 then value.first
+                  else value
+                end
+        Sequel.synchronize{@primary_keys[quoted_table] = value}
+      end
+
+      # the sql layer supports CREATE TABLE IF NOT EXISTS syntax,
+      def supports_create_table_if_not_exists?
+        true
+      end
+
+      # Fdbsql supports deferrable fk constraints
+      def supports_deferrable_foreign_key_constraints?
+        true
+      end
+
+      # the sql layer supports DROP TABLE IF EXISTS
+      def supports_drop_table_if_exists?
+        true
+      end
+
+      # Array of symbols specifying table names in the current database.
+      # The dataset used is yielded to the block if one is provided,
+      # otherwise, an array of symbols of table names is returned.
+      #
+      # Options:
+      # :qualify :: Return the tables as Sequel::SQL::QualifiedIdentifier instances,
+      #             using the schema the table is located in as the qualifier.
+      # :schema :: The schema to search
+      # :server :: The server to use
+      def tables(opts=OPTS, &block)
+        tables_or_views('TABLE', opts, &block)
+      end
+
+      # Array of symbols specifying view names in the current database.
+      #
+      # Options:
+      # :qualify :: Return the views as Sequel::SQL::QualifiedIdentifier instances,
+      #             using the schema the view is located in as the qualifier.
+      # :schema :: The schema to search
+      # :server :: The server to use
+      def views(opts=OPTS, &block)
+        tables_or_views('VIEW', opts, &block)
+      end
+
+      # Return full foreign key information, including
+      # Postgres returns hash like:
+      # {"b_e_fkey"=> {:name=>:b_e_fkey, :columns=>[:e], :on_update=>:no_action, :on_delete=>:no_action, :deferrable=>false, :table=>:a, :key=>[:c]}}
+      def foreign_key_list(table, opts=OPTS)
+        out_identifier, in_identifier = identifier_convertors(opts)
+        schema, table = schema_or_current_and_table(table, opts)
+        sql_table = in_identifier.call(table)
+        columns_dataset = metadata_dataset.
+          select(:tc__table_name___table_name,
+                 :tc__table_schema___table_schema,
+                 :tc__is_deferrable___deferrable,
+                 :kc__column_name___column_name,
+                 :kc__constraint_schema___schema,
+                 :kc__constraint_name___name,
+                 :rc__update_rule___on_update,
+                 :rc__delete_rule___on_delete).
+          from(Sequel.as(:information_schema__table_constraints, 'tc')).
+          join(Sequel.as(:information_schema__key_column_usage, 'kc'),
+               [:constraint_schema, :constraint_name]).
+          join(Sequel.as(:information_schema__referential_constraints, 'rc'),
+               [:constraint_name, :constraint_schema]).
+          where(tc__table_name: sql_table,
+                tc__table_schema: schema,
+                tc__constraint_type: 'FOREIGN KEY')
+
+        keys_dataset = metadata_dataset.
+          select(:rc__constraint_schema___schema,
+                 :rc__constraint_name___name,
+                 :kc__table_name___key_table,
+                 :kc__column_name___key_column).
+          from(Sequel.as(:information_schema__table_constraints, 'tc')).
+          join(Sequel.as(:information_schema__referential_constraints, 'rc'),
+               [:constraint_schema, :constraint_name]).
+          join(Sequel.as(:information_schema__key_column_usage, 'kc'),
+               kc__constraint_schema: :rc__unique_constraint_schema,
+               kc__constraint_name: :rc__unique_constraint_name).
+          where(tc__table_name: sql_table,
+                tc__table_schema: schema,
+                tc__constraint_type: 'FOREIGN KEY')
+        foreign_keys = {}
+        columns_dataset.each do |row|
+          foreign_key = foreign_keys.fetch(row[:name]) do |key|
+            foreign_keys[row[:name]] = row
+            row[:name] = out_identifier.call(row[:name])
+            row[:columns] = []
+            row[:key] = []
+            row
+          end
+          foreign_key[:columns] << out_identifier.call(row[:column_name])
+        end
+        keys_dataset.each do |row|
+          foreign_key = foreign_keys[row[:name]]
+          foreign_key[:table] = out_identifier.call(row[:key_table])
+          foreign_key[:key] << out_identifier.call(row[:key_column])
+        end
+        foreign_keys.values
+      end
+
+      # Return indexes for the table
+      # postgres returns:
+      # {:blah_blah_index=>{:columns=>[:n], :unique=>true, :deferrable=>nil},
+      #  :items_n_a_index=>{:columns=>[:n, :a], :unique=>false, :deferrable=>nil}}
+      def indexes(table, opts=OPTS)
+        out_identifier, in_identifier = identifier_convertors(opts)
+        schema, table = schema_or_current_and_table(table, opts)
+        dataset = metadata_dataset.
+          select(:is__is_unique,
+                 Sequel.as({:is__is_unique => 'YES'}, 'unique'),
+                 :is__index_name,
+                 :ic__column_name).
+          from(Sequel.as(:information_schema__indexes, 'is')).
+          join(Sequel.as(:information_schema__index_columns, 'ic'),
+               ic__index_table_schema: :is__table_schema,
+               ic__index_table_name: :is__table_name,
+               ic__index_name: :is__index_name).
+          where(is__table_schema: schema,
+                is__table_name: in_identifier.call(table)).
+          exclude(is__index_type: 'PRIMARY')
+        indexes = {}
+        dataset.each do |row|
+          index = indexes.fetch(out_identifier.call(row[:index_name])) do |key|
+            h = { :unique => row[:unique], :columns => [] }
+            indexes[key] = h
+            h
+          end
+          index[:columns] << out_identifier.call(row[:column_name])
+        end
+        indexes
+      end
+
+      private
+
+      # the literal methods put quotes around things, but when we bind a variable there shouldn't be quotes around it
+      # it should just be the timestamp, so we need whole new formats here.
+      BOUND_VARIABLE_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S".freeze
+      BOUND_VARIABLE_SQLTIME_FORMAT = "%H:%M:%S".freeze
+
+      def adapter_initialize
+        @primary_keys = {}
+        # Postgres supports named types in the db, if we want to support anything that's not built in, this
+        # will have to be changed to not be a constant
+        @conversion_procs = Sequel::Postgres::PG_TYPES.dup
+        @conversion_procs[16] = Proc.new {|s| s == 'true'}
+        @conversion_procs[1184] = @conversion_procs[1114] = method(:to_application_timestamp)
+        @conversion_procs.freeze
+      end
+
+      def alter_table_op_sql(table, op)
+        quoted_name = quote_identifier(op[:name]) if op[:name]
+        case op[:op]
+        when :set_column_type
+          "ALTER COLUMN #{quoted_name} SET DATA TYPE #{type_literal(op)}"
+        when :set_column_null
+          "ALTER COLUMN #{quoted_name} #{op[:null] ? '' : 'NOT'} NULL"
+        else
+          super
+        end
+      end
+
+      # Convert exceptions raised from the block into DatabaseErrors.
+      def check_database_errors
+        begin
+          yield
+        rescue => e
+          raise_error(e, :classes=>CONVERTED_EXCEPTIONS)
+        end
+      end
+
+      def column_schema_normalize_default(default, type)
+        # the default value returned by schema parsing is not escaped or quoted
+        # in any way, it's just the value of the string
+        # the base implementation assumes it would come back "'my ''default'' value'"
+        # fdbsql returns "my 'default' value" (Not including double quotes for either)
+        return default
+      end
+
+      # FDBSQL requires parens around the SELECT, and the WITH DATA syntax.
+      def create_table_as_sql(name, sql, options)
+        "#{create_table_prefix_sql(name, options)} AS (#{sql}) WITH DATA"
+      end
+
+      def database_error_classes
+        CONVERTED_EXCEPTIONS
+      end
+
+      STALE_STATEMENT_SQLSTATE = '0A50A'.freeze
+      NOT_NULL_CONSTRAINT_SQLSTATES = %w'23502'.freeze.each{|s| s.freeze}
+      FOREIGN_KEY_CONSTRAINT_SQLSTATES = %w'23503 23504'.freeze.each{|s| s.freeze}
+      UNIQUE_CONSTRAINT_SQLSTATES = %w'23501'.freeze.each{|s| s.freeze}
+      NOT_COMMITTED_SQLSTATES = %w'40002'.freeze.each{|s| s.freeze}
+
+      # Given the SQLState, return the appropriate DatabaseError subclass.
+      def database_specific_error_class_from_sqlstate(sqlstate)
+        # There is also a CheckConstraintViolation in Sequel, but the sql layer doesn't support check constraints
+        case sqlstate
+        when *NOT_NULL_CONSTRAINT_SQLSTATES
+          NotNullConstraintViolation
+        when *FOREIGN_KEY_CONSTRAINT_SQLSTATES
+          ForeignKeyConstraintViolation
+        when *UNIQUE_CONSTRAINT_SQLSTATES
+          UniqueConstraintViolation
+        when *NOT_COMMITTED_SQLSTATES
+          NotCommittedError
+        end
+      end
+
+      # This is a fallback used by the base class if the sqlstate fails to figure out
+      # what error type it is.
+      DATABASE_ERROR_REGEXPS = [
+        # Add this check first, since otherwise it's possible for users to control
+        # which exception class is generated.
+        [/invalid input syntax/, DatabaseError],
+        # the rest of these are backups in case the sqlstate fails
+        [/[dD]uplicate key violates unique constraint/, UniqueConstraintViolation],
+        [/due (?:to|for) foreign key constraint/, ForeignKeyConstraintViolation],
+        [/NULL value not permitted/, NotNullConstraintViolation],
+      ].freeze
+
+      def database_error_regexps
+        DATABASE_ERROR_REGEXPS
+      end
+
+      def identifier_convertors(opts=OPTS)
+        [output_identifier_meth(opts[:dataset]), input_identifier_meth(opts[:dataset])]
+      end
+
+      # Like PostgreSQL fdbsql folds unquoted identifiers to lowercase, so it shouldn't need to upcase identifiers on input.
+      def identifier_input_method_default
+        nil
+      end
+
+      # Like PostgreSQL fdbsql folds unquoted identifiers to lowercase, so it shouldn't need to upcase identifiers on output.
+      def identifier_output_method_default
+        nil
+      end
+
+      # If the given type is DECIMAL with scale 0, say that it's an integer
+      def normalize_decimal_to_integer(type, scale)
+        if (type == 'DECIMAL' and scale == 0)
+          'integer'
+        else
+          type
+        end
+      end
+
+      # Remove the cached entries for primary keys and sequences when a table is
+      # changed.
+      def remove_cached_schema(table)
+        tab = quote_schema_table(table)
+        Sequel.synchronize do
+          @primary_keys.delete(tab)
+        end
+        super
+      end
+
+      def schema_or_current_and_table(table, opts=OPTS)
+        schema, table = schema_and_table(table)
+        schema = opts.fetch(:schema, schema || Sequel.lit('CURRENT_SCHEMA'))
+        [schema, table]
+      end
+
+      # returns an array of column information with each column being of the form:
+      # [:column_name, {:db_type=>"integer", :default=>nil, :allow_null=>false, :primary_key=>true, :type=>:integer}]
+      def schema_parse_table(table, opts = {})
+        out_identifier, in_identifier = identifier_convertors(opts)
+        schema, table = schema_or_current_and_table(table, opts)
+        dataset = metadata_dataset.
+          select(:c__column_name,
+                 Sequel.as({:c__is_nullable => 'YES'}, 'allow_null'),
+                 :c__column_default___default,
+                 :c__data_type___db_type,
+                 :c__character_maximum_length___max_length,
+                 :c__numeric_scale,
+                 Sequel.as({:tc__constraint_type => 'PRIMARY KEY'}, 'primary_key')).
+          from(Sequel.as(:information_schema__key_column_usage, 'kc')).
+          join(Sequel.as(:information_schema__table_constraints, 'tc'),
+               tc__constraint_type: 'PRIMARY KEY',
+               tc__table_name: :kc__table_name,
+               tc__table_schema: :kc__table_schema,
+               tc__constraint_name: :kc__constraint_name).
+          right_outer_join(Sequel.as(:information_schema__columns, 'c'),
+                           [:table_name, :table_schema, :column_name]).
+          where(c__table_name: in_identifier.call(table),
+                c__table_schema: schema)
+        dataset.map do |row|
+          row[:default] = nil if blank_object?(row[:default])
+          row[:type] = schema_column_type(normalize_decimal_to_integer(row[:db_type], row[:numeric_scale]))
+          [out_identifier.call(row.delete(:column_name)), row]
+        end
+      end
+
+      def tables_or_views(type, opts, &block)
+        schema = opts[:schema] || Sequel.lit('CURRENT_SCHEMA')
+        m = output_identifier_meth
+        dataset = metadata_dataset.server(opts[:server]).select(:table_name).
+          from(Sequel.qualify('information_schema','tables')).
+          where(table_schema: schema,
+                table_type: type)
+        if block_given?
+          yield(dataset)
+        elsif opts[:qualify]
+          dataset.select_append(:table_schema).map{|r| Sequel.qualify(m.call(r[:table_schema]), m.call(r[:table_name])) }
+        else
+          dataset.map{|r| m.call(r[:table_name])}
+        end
+      end
+
+      # Handle bigserial type if :serial option is present
+      def type_literal_generic_bignum(column)
+        column[:serial] ? :bigserial : super
+      end
+
+      # Handle serial type if :serial option is present
+      def type_literal_generic_integer(column)
+        column[:serial] ? :serial : super
+      end
+
+    end
+
+    # Instance methods for datasets that connect to the FoundationDB SQL Layer.
+    module DatasetMethods
+
+      Dataset.def_sql_method(self, :delete, %w'with delete from using where returning')
+      Dataset.def_sql_method(self, :insert, %w'with insert into columns values returning')
+      Dataset.def_sql_method(self, :update, %w'with update table set from where returning')
+
+      # Shared methods for prepared statements used with the FoundationDB SQL Layer
+      module PreparedStatementMethods
+
+        def prepared_sql
+          return @prepared_sql if @prepared_sql
+          @opts[:returning] = insert_pk if @prepared_type == :insert
+          super
+          @prepared_sql
+        end
+
+        # Override insert action to use RETURNING if the server supports it.
+        def run
+          if @prepared_type == :insert
+            fetch_rows(prepared_sql){|r| return r.values.first}
+          else
+            super
+          end
+        end
+      end
+
+      # Emulate the bitwise operators.
+      def complex_expression_sql_append(sql, op, args)
+        case op
+        when :&, :|, :^, :<<, :>>, :'B~'
+          complex_expression_emulate_append(sql, op, args)
+        # REGEXP_OPERATORS = [:~, :'!~', :'~*', :'!~*']
+        when :'~'
+          function_sql_append(sql, SQL::Function.new(:REGEX, args.at(0), args.at(1)))
+        when :'!~'
+          sql << Sequel::Dataset::NOT_SPACE
+          function_sql_append(sql, SQL::Function.new(:REGEX, args.at(0), args.at(1)))
+        when :'~*'
+          function_sql_append(sql, SQL::Function.new(:IREGEX, args.at(0), args.at(1)))
+        when :'!~*'
+          sql << Sequel::Dataset::NOT_SPACE
+          function_sql_append(sql, SQL::Function.new(:IREGEX, args.at(0), args.at(1)))
+        else
+          super
+        end
+      end
+
+      # Insert given values into the database.
+      def insert(*values)
+        if @opts[:returning]
+          # Already know which columns to return, let the standard code handle it
+          super
+        elsif @opts[:sql] || @opts[:disable_insert_returning]
+          # Raw SQL used or RETURNING disabled, just use the default behavior
+          # and return nil since sequence is not known.
+          super
+          nil
+        else
+          # Force the use of RETURNING with the primary key value,
+          # unless it has been disabled.
+          returning(*insert_pk).insert(*values){|r| return r.values.first}
+        end
+      end
+
+      # Insert a record returning the record inserted.  Always returns nil without
+      # inserting a query if disable_insert_returning is used.
+      def insert_select(*values)
+        unless @opts[:disable_insert_returning]
+          ds = opts[:returning] ? self : returning
+          ds.insert(*values){|r| return r}
+        end
+      end
+
+      # The SQL to use for an insert_select, adds a RETURNING clause to the insert
+      # unless the RETURNING clause is already present.
+      def insert_select_sql(*values)
+        ds = opts[:returning] ? self : returning
+        ds.insert_sql(*values)
+      end
+
+      # FDBSQL has functions to support regular expression pattern matching.
+      def supports_regexp?
+        true
+      end
+
+      # Returning is always supported.
+      def supports_returning?(type)
+        true
+      end
+
+      # FDBSQL truncates all seconds
+      def supports_timestamp_usecs?
+        false
+      end
+
+      # FDBSQL supports quoted function names
+      def supports_quoted_function_names?
+        true
+      end
+
+      private
+
+      # Append the SQL fragment for the DateAdd expression to the SQL query.
+      def date_add_sql_append(sql, da)
+        h = da.interval
+        expr = da.expr
+        interval = ""
+        each_valid_interval_unit(h, DEF_DURATION_UNITS) do |value, sql_unit|
+          interval << "#{value} #{sql_unit} "
+        end
+        if interval.empty?
+          return literal_append(sql, Sequel.cast(expr, Time))
+        else
+          return complex_expression_sql_append(sql, :+, [Sequel.cast(expr, Time), Sequel.cast(interval, :interval)])
+        end
+      end
+
+      # Use USING to specify additional tables in a delete query
+      def delete_using_sql(sql)
+        join_from_sql(:USING, sql)
+      end
+
+      # Return the primary key to use for RETURNING in an INSERT statement
+      def insert_pk
+        if (f = opts[:from]) && !f.empty?
+          case t = f.first
+          when Symbol, String, SQL::Identifier, SQL::QualifiedIdentifier
+            if pk = db.primary_key(t)
+              pk
+            end
+          end
+        end
+      end
+
+      # For multiple table support, PostgreSQL requires at least
+      # two from tables, with joins allowed.
+      def join_from_sql(type, sql)
+        if(from = @opts[:from][1..-1]).empty?
+          raise(Error, 'Need multiple FROM tables if updating/deleting a dataset with JOINs') if @opts[:join]
+        else
+          sql << SPACE << type.to_s << SPACE
+          source_list_append(sql, from)
+          select_join_sql(sql)
+        end
+      end
+
+      # FDBSQL uses a preceding x for hex escaping strings
+      def literal_blob_append(sql, v)
+        if v.empty?
+          sql << "''"
+        else
+          sql << "x'#{v.unpack('H*').first}'"
+        end
+      end
+
+      # fdbsql does not support FOR UPDATE, because it's unnecessary with the transaction model
+      def select_lock_sql(sql)
+        @opts[:lock] == :update ? sql : super
+      end
+
+      # Use FROM to specify additional tables in an update query
+      def update_from_sql(sql)
+        join_from_sql(:FROM, sql)
+      end
+
+    end
+
+    # Methods to support date arithmetic with the FoundationDB SQL Layer.
+    module DateArithmeticDatasetMethods
+      include Sequel::SQL::DateAdd::DatasetMethods
+
+      # chop off the s at the end of each of the units
+      FDBSQL_DURATION_UNITS = DURATION_UNITS.zip(DURATION_UNITS.map{|s| s.to_s.chop.freeze}).freeze
+
+      # Append the SQL fragment for the DateAdd expression to the SQL query.
+      def date_add_sql_append(sql, da)
+        h = da.interval
+        expr = da.expr
+        if db.database_type == :fdbsql
+          expr = Sequel.cast(expr, Time)
+          each_valid_interval_unit(h, FDBSQL_DURATION_UNITS) do |value, sql_unit|
+            expr = Sequel.+(expr, Sequel.lit(["INTERVAL ", " "], value, Sequel.lit(sql_unit)))
+          end
+          literal_append(sql, expr)
+        else
+          super
+        end
+      end
+
+      private
+
+      # Yield the value in the interval for each of the units
+      # present in the interval, along with the SQL fragment
+      # representing the unit name.  Returns false if any
+      # values were yielded, true otherwise
+      def each_valid_interval_unit(interval, units)
+        cast = true
+        units.each do |unit, sql_unit|
+          if (value = interval[unit]) && value != 0
+            cast = false
+            yield value, sql_unit
+          end
+        end
+        cast
+      end
+    end
+
+  end
+end

--- a/lib/sequel/database/connecting.rb
+++ b/lib/sequel/database/connecting.rb
@@ -6,7 +6,7 @@ module Sequel
     # ---------------------
 
     # Array of supported database adapters
-    ADAPTERS = %w'ado amalgalite cubrid db2 dbi do firebird ibmdb informix jdbc mock mysql mysql2 odbc openbase oracle postgres sqlanywhere sqlite swift tinytds'.collect{|x| x.to_sym}
+    ADAPTERS = %w'ado amalgalite cubrid db2 dbi do fdbsql firebird ibmdb informix jdbc mock mysql mysql2 odbc openbase oracle postgres sqlanywhere sqlite swift tinytds'.collect{|x| x.to_sym}
 
     @single_threaded = false
 

--- a/spec/adapters/fdbsql_spec.rb
+++ b/spec/adapters/fdbsql_spec.rb
@@ -1,0 +1,756 @@
+SEQUEL_ADAPTER_TEST = :fdbsql
+
+require File.join(File.dirname(File.expand_path(__FILE__)), 'spec_helper.rb')
+
+def DB.sqls
+  (@sqls ||= [])
+end
+logger = Object.new
+def logger.method_missing(m, msg)
+  DB.sqls << msg
+end
+DB.loggers << logger
+
+if (DB.adapter_scheme == :jdbc)
+  require 'java'
+  require 'sequel/adapters/jdbc'
+end
+
+describe 'Fdbsql' do
+  describe 'Database' do
+    before(:all) do
+      @db = DB
+    end
+
+    describe 'automatic NotCommitted retry' do
+      before do
+        @db.drop_table?(:some_table)
+        @db.create_table(:some_table) {text :name; primary_key :id}
+        @db2 = Sequel.connect(@db.url)
+      end
+      after do
+        @db2.disconnect
+        @db.drop_table?(:some_table)
+      end
+      specify 'within a transaction' do
+        proc do
+          @db.transaction do
+            @db[:some_table].insert(name: 'a')
+            @db2.drop_table(:some_table)
+          end
+        end.should raise_error(Sequel::Fdbsql::NotCommittedError)
+      end
+    end
+
+    # JDBC knows whether it's in autocommit mode or not
+    # just look at the connection
+    if (DB.adapter_scheme == :fdbsql)
+      describe 'PG connection.in_transaction' do
+        before(:all) do
+          raise 'too many servers' if @db.servers.count > 1
+          @db.drop_table?(:some_table)
+          @db.create_table(:some_table) {text :name; primary_key :id}
+          @conn = @db.pool.hold(@db.servers.first) {|conn| conn}
+        end
+        after(:all) do
+          @db.drop_table?(:some_table)
+        end
+
+        specify 'is unset by default' do
+          @conn.in_transaction.should be_false
+        end
+        specify 'is set in a transaction' do
+          @db.transaction do
+            @conn.in_transaction.should be_true
+          end
+        end
+        specify 'is unset after a commit' do
+          @db.transaction do
+            @db[:some_table].insert(name: 'a')
+            @conn.in_transaction.should be_true
+          end
+          @conn.in_transaction.should be_false
+        end
+        specify 'is unset after a rollback' do
+          @db.transaction do
+            raise Sequel::Rollback.new
+          end
+          @conn.in_transaction.should be_false
+        end
+      end
+
+      describe 'PG connecting' do
+        specify '#fdbsql' do
+          db2 = Sequel.fdbsql(DB.uri)
+        end
+
+        describe 'opts' do
+          before do
+            @fake_conn = double('connection class')
+            stub_const('PG::Connection', @fake_conn)
+          end
+
+          def fake_conn(args)
+            fake_conn_instance = double("fake connection")
+            fake_conn_instance.stub(:set_notice_receiver)
+            fake_conn_instance.stub(:query).with('SELECT VERSION()', nil).
+              and_return(double(cmd_tuples: 1, first: {'_SQL_COL_1' => 'FoundationDB 2.0.0'}))
+            @fake_conn.should_receive(:new).with(args).once.and_return(fake_conn_instance)
+            fake_conn_instance.should_receive(:close).once
+          end
+
+          [['database', {:database => 'mydb'}, {:dbname => 'mydb'}],
+           ['host', {:host => 'somewhere.com'}, {:host => 'somewhere.com'}],
+           ['host', {:host => nil}, {:host => 'localhost'}],
+           ['password', {:password => 'mypw'}, {:password => 'mypw'}],
+           ['user', {:user => 'uxt'}, {:user => 'uxt'}],
+           ['username', {:username => 'uxt'}, {:user => 'uxt'}],
+           ['hostaddr', {:hostaddr => '192.168.1.35'}, {:hostaddr => '192.168.1.35'}],
+           ['port', {:port => 3487}, {:port => 3487}],
+           ['default port', {}, {:port => 15432}],
+           ['connect_timeout', {:connect_timeout => 4890}, {:connect_timeout => 4890}],
+           ['default connect_timeout', {}, {:connect_timeout => 20}],
+           ['sslmode', {:sslmode => 'require'}, {:sslmode => 'require'}], # (disable|allow|prefer|require)
+          ].each do |opts|
+            specify opts[0] do
+              fake_conn(include(opts[2]))
+              default = {:adapter => 'fdbsql', :database => 'the database', :host => 'localhost'}
+              Sequel.connect(default.merge(opts[1])) do |db|
+                db.run('SELECT VERSION()')
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe 'schema_parsing' do
+      after do
+        @db.drop_table?(:test)
+      end
+
+      specify 'without primary key' do
+        @db.create_table(:test) do
+          text :name
+          int :value
+        end
+        schema = DB.schema(:test, reload: true)
+        schema.count.should eq 2
+        schema[0][0].should eq :name
+        schema[1][0].should eq :value
+        schema.each {|col| col[1][:primary_key].should be_false}
+      end
+
+      specify 'with one primary key' do
+        @db.create_table(:test) do
+          text :name
+          primary_key :id
+        end
+        schema = DB.schema(:test, reload: true)
+        schema.count.should eq 2
+        id_col = schema[0]
+        name_col = schema[1]
+        name_col[0].should eq :name
+        id_col[0].should eq :id
+        name_col[1][:primary_key].should be_false
+        id_col[1][:primary_key].should be_true
+      end
+
+      specify 'with multiple primary keys' do
+        @db.create_table(:test) do
+          Integer :id
+          Integer :id2
+          primary_key [:id, :id2]
+        end
+        schema = DB.schema(:test, reload: true)
+        schema.count.should eq 2
+        id_col = schema[0]
+        id2_col = schema[1]
+        id_col[0].should eq :id
+        id2_col[0].should eq :id2
+        id_col[1][:primary_key].should be_true
+        id2_col[1][:primary_key].should be_true
+      end
+
+      specify 'with other constraints' do
+        @db.create_table(:test) do
+          primary_key :id
+          Integer :unique, unique: true
+        end
+        schema = DB.schema(:test, reload: true)
+        schema.count.should eq 2
+        id_col = schema[0]
+        unique_col = schema[1]
+        id_col[0].should eq :id
+        unique_col[0].should eq :unique
+        id_col[1][:primary_key].should be_true
+        unique_col[1][:primary_key].should be_false
+      end
+      after do
+        @db.drop_table?(:other_table)
+      end
+      specify 'with other tables' do
+        @db.create_table(:test) do
+          Integer :id
+          text :name
+        end
+        @db.create_table(:other_table) do
+          primary_key :id
+          varchar :name, unique: true
+        end
+        schema = DB.schema(:test, reload: true)
+        schema.count.should eq 2
+        schema.each {|col| col[1][:primary_key].should be_false}
+      end
+
+      describe 'with explicit schema' do
+        before do
+          @db.create_table(:test) do
+            primary_key :id
+          end
+          @schema = @db['SELECT CURRENT_SCHEMA'].first.values.first
+          @second_schema = @schema + "--2"
+          @db.create_table(Sequel.qualify(@second_schema,:test)) do
+            primary_key :id2
+            Integer :id
+          end
+        end
+        after do
+          @db.drop_table?(Sequel.qualify(@second_schema,:test))
+          @db.drop_table?(:test)
+        end
+
+        specify 'gets info for correct table' do
+          schema = DB.schema(:test, reload: true, schema: @second_schema)
+          schema.count.should eq 2
+          id2_col = schema[0]
+          id_col = schema[1]
+          id_col[0].should eq :id
+          id2_col[0].should eq :id2
+          id_col[1][:primary_key].should be_false
+          id2_col[1][:primary_key].should be_true
+        end
+      end
+    end
+
+    describe 'primary_key' do
+      after do
+        @db.drop_table?(:test)
+        @db.drop_table?(:other_table)
+      end
+
+      specify 'without primary key' do
+        @db.create_table(:test) do
+          text :name
+          int :value
+        end
+        DB.primary_key(:test).should eq nil
+      end
+
+      specify 'with one primary key' do
+        @db.create_table(:test) do
+          text :name
+          primary_key :id
+        end
+        DB.primary_key(:test).should eq :id
+      end
+
+      specify 'with multiple primary keys' do
+        @db.create_table(:test) do
+          Integer :id
+          Integer :id2
+          primary_key [:id, :id2]
+        end
+        primary_key = DB.primary_key(:test)
+        primary_key.should match_array([:id, :id2])
+      end
+
+      specify 'with other constraints' do
+        @db.create_table(:test) do
+          primary_key :id
+          Integer :unique, unique: true
+        end
+        DB.primary_key(:test).should eq :id
+      end
+
+      specify 'with other tables' do
+        @db.create_table(:test) do
+          Integer :id
+          text :name
+        end
+        @db.create_table(:other_table) do
+          primary_key :id
+          varchar :name, unique: true
+        end
+        DB.primary_key(:other_table).should eq :id
+      end
+
+      specify 'responds to alter table' do
+        @db.create_table(:test) do
+          Integer :id
+          text :name
+        end
+        @db.alter_table(:test) do
+          add_primary_key :quid
+        end
+        DB.primary_key(:test).should eq :quid
+      end
+
+      describe 'with explicit schema' do
+        before do
+          @db.create_table(:test) do
+            primary_key :id
+          end
+          @schema = @db['SELECT CURRENT_SCHEMA'].first.values.first
+          @second_schema = @schema + "--2"
+          @db.create_table(Sequel.qualify(@second_schema,:test)) do
+            primary_key :id2
+          end
+        end
+        after do
+          @db.drop_table?(Sequel.qualify(@second_schema,:test))
+          @db.drop_table?(:test)
+        end
+
+        specify 'gets correct primary key' do
+          DB.primary_key(:test, schema: @second_schema).should eq :id2
+        end
+      end
+    end
+
+    describe '#tables' do
+      before do
+        @schema = @db['SELECT CURRENT_SCHEMA'].first.values.first
+        @second_schema = @schema + "--2"
+        @db.create_table(:test) do
+          primary_key :id
+        end
+        @db.create_table(Sequel.qualify(@second_schema,:test2)) do
+          primary_key :id
+        end
+      end
+      after do
+        @db.drop_table?(Sequel.qualify(@second_schema,:test2))
+        @db.drop_table?(:test)
+      end
+      specify 'on explicit schema' do
+        tables = @db.tables(schema: @second_schema)
+        tables.should include(:test2)
+        tables.should_not include(:test)
+      end
+      specify 'qualified' do
+        tables = @db.tables(qualify: true)
+        tables.should include(Sequel::SQL::QualifiedIdentifier.new(@schema.to_sym, :test))
+        tables.should_not include(:test)
+      end
+    end
+
+    describe '#views' do
+      def drop_things
+        @db.drop_view(Sequel.qualify(@second_schema,:test_view2), if_exists: true)
+        @db.drop_table?(Sequel.qualify(@second_schema,:test_table))
+        @db.drop_view(:test_view, if_exists: true)
+        @db.drop_table?(:test_table)
+      end
+      before do
+        @schema = @db['SELECT CURRENT_SCHEMA'].single_value
+        @second_schema = @schema + "--2"
+        drop_things
+        @db.create_table(:test_table){Integer :a}
+        @db.create_view :test_view, @db[:test_table]
+        @db.create_table(Sequel.qualify(@second_schema,:test_table)) do
+          Integer :b
+        end
+        @db.create_view(Sequel.qualify(@second_schema, :test_view2),
+                        @db[Sequel.qualify(@second_schema, :test_table)])
+      end
+      after do
+        drop_things
+      end
+      specify 'on explicit schema' do
+        views = @db.views(schema: @second_schema)
+        views.should include(:test_view2)
+        views.should_not include(:test_view)
+      end
+      specify 'qualified' do
+        views = @db.views(qualify: true)
+        views.should include(Sequel::SQL::QualifiedIdentifier.new(@schema.to_sym, :test_view))
+        views.should_not include(:test)
+      end
+    end
+
+    describe 'prepared statements' do
+      def create_table
+        @db.create_table!(:test) {Integer :a; Text :b}
+        @db[:test].insert(1, 'blueberries')
+        @db[:test].insert(2, 'trucks')
+        @db[:test].insert(3, 'foxes')
+      end
+      def drop_table
+        @db.drop_table?(:test)
+      end
+      before do
+        create_table
+      end
+      after do
+        drop_table
+      end
+
+      it 're-prepares on stale statement' do
+        @db[:test].filter(:a=>:$n).prepare(:all, :select_a).call(:n=>2).to_a.should == [{:a => 2, :b => 'trucks'}]
+        drop_table
+        create_table
+        @db[:test].filter(:a=>:$n).prepare(:all, :select_a).call(:n=>2).to_a.should == [{:a => 2, :b => 'trucks'}]
+      end
+
+      it 'can call already prepared' do
+        @db[:test].filter(:a=>:$n).prepare(:all, :select_a).call(:n=>2).to_a.should == [{:a => 2, :b => 'trucks'}]
+        drop_table
+        create_table
+        @db.call(:select_a, :n=>2).to_a.should == [{:a => 2, :b => 'trucks'}]
+      end
+    end
+
+    describe 'Database schema modifiers' do
+      # this test was copied from sequel's integration/schema_test because that one drops a serial primary key which is not
+      # currently supported in fdbsql
+      specify "should be able to specify constraint names for column constraints" do
+        @db.create_table!(:items2){Integer :id, :primary_key=>true, :primary_key_constraint_name=>:foo_pk}
+        @db.create_table!(:items){foreign_key :id, :items2, :unique=>true, :foreign_key_constraint_name => :foo_fk, :unique_constraint_name => :foo_uk, :null=>false}
+        @db.alter_table(:items){drop_constraint :foo_fk, :type=>:foreign_key; drop_constraint :foo_uk, :type=>:unique}
+        @db.alter_table(:items2){drop_constraint :foo_pk, :type=>:primary_key}
+      end
+    end
+  end
+
+  describe 'Dataset' do
+    before(:all) do
+      @db = DB
+    end
+
+    describe 'provides_accurate_rows_matched' do
+      before do
+        DB.create_table!(:test) {Integer :a}
+        DB[:test].insert(1)
+        DB[:test].insert(2)
+        DB[:test].insert(3)
+        DB[:test].insert(4)
+        DB[:test].insert(5)
+      end
+
+      after do
+        DB.drop_table?(:test)
+      end
+
+      specify '#delete' do
+        DB[:test].where(a: 8..10).delete.should eq 0
+        DB[:test].where(a: 5).delete.should eq 1
+        DB[:test].where(a: 1..3).delete.should eq 3
+      end
+
+      specify '#update' do
+        DB[:test].where(a: 8..10).update(a: Sequel.+(:a, 10)).should eq 0
+        DB[:test].where(a: 5).update(a: Sequel.+(:a, 1000)).should eq 1
+        DB[:test].where(a: 1..3).update(a: Sequel.+(:a, 100)).should eq 3
+      end
+
+    end
+
+    describe 'intersect and except ALL' do
+      before do
+        DB.create_table!(:test) {Integer :a; Integer :b}
+        DB[:test].insert(1, 10)
+        DB[:test].insert(2, 10)
+        DB[:test].insert(8, 15)
+        DB[:test].insert(2, 10)
+        DB[:test].insert(2, 10)
+        DB[:test].insert(1, 10)
+
+        DB.create_table!(:test2) {Integer :a; Integer :b}
+        DB[:test2].insert(1, 10)
+        DB[:test2].insert(2, 10)
+        DB[:test2].insert(2, 12)
+        DB[:test2].insert(3, 10)
+        DB[:test2].insert(1, 10)
+      end
+
+      after do
+        DB.drop_table?(:test)
+        DB.drop_table?(:test2)
+      end
+
+      specify 'intersect all' do
+        @db[:test].intersect(@db[:test2], all: true).map{|r| [r[:a],r[:b]]}.to_a.should match_array [[1, 10], [1,10], [2, 10]]
+      end
+
+      specify 'except all' do
+        @db[:test].except(@db[:test2], all: true).map{|r| [r[:a],r[:b]]}.to_a.should match_array [[8, 15], [2,10], [2, 10]]
+      end
+    end
+
+    describe 'is' do
+      before do
+        DB.create_table!(:test) {Integer :a; Boolean :b}
+        DB[:test].insert(1, nil)
+        DB[:test].insert(2, true)
+        DB[:test].insert(3, false)
+      end
+      after do
+        DB.drop_table?(:test)
+      end
+
+      specify 'true' do
+        DB[:test].select(:a).where(Sequel::SQL::ComplexExpression.new(:IS, :b, true)).map{|r| r[:a]}.should match_array [2]
+      end
+
+      specify 'not true' do
+        DB[:test].select(:a).where(Sequel::SQL::ComplexExpression.new(:'IS NOT', :b, true)).map{|r| r[:a]}.should match_array [1, 3]
+      end
+    end
+
+    describe 'insert empty values' do
+      before do
+        DB.create_table!(:test) {primary_key :a}
+      end
+      after do
+        DB.drop_table?(:test)
+      end
+
+      specify 'inserts defaults and returns pk' do
+        DB[:test].insert().should eq 1 # 1 should be the pk
+      end
+    end
+
+    describe 'function names' do
+      before do
+        DB.create_table!(:test) {Text :a; Text :b}
+        DB[:test].insert('1', '')
+        DB[:test].insert('2', 'trucks')
+        DB[:test].insert('3', 'foxes')
+      end
+      after do
+        DB.drop_table?(:test)
+      end
+
+      specify 'evaluate' do
+        DB[:test].select(Sequel.function(:now)).count == 1
+        DB[:test].select(Sequel.as(Sequel.function(:concat, :a, :b), :c)).map{|r| r[:c]}.should match_array ['1','2trucks','3foxes']
+      end
+
+      specify 'get quoted' do
+        DB[:test].select(Sequel.function(:now).quoted).sql.should =~ /"now"\(\)/
+        DB[:test].select(Sequel.as(Sequel.function(:concat, :a, :b).quoted, :c)).sql.should =~ /"concat"\("a", "b"\)/
+      end
+    end
+  end
+
+  # jdbc and pg have different connection objects
+  if (DB.adapter_scheme == :fdbsql)
+    describe 'PG Connection' do
+      before do
+        @fake_conn = double('connection class')
+        stub_const('PG::Connection', @fake_conn)
+      end
+
+      def fake_conn
+        fake_conn_instance = double("fake connection")
+        fake_conn_instance.stub(:set_notice_receiver)
+        fake_conn_instance.stub(:query).with('SELECT VERSION()', nil).ordered.and_return([{'_SQL_COL_1' => 'FoundationDB 2.0.0'}])
+        yield fake_conn_instance
+        @fake_conn.stub(:new).and_return(fake_conn_instance)
+      end
+
+      describe 'Automatic retry on NotCommitted' do
+
+        describe 'outside a transaction' do
+          specify 'retries a finite number of times' do
+            result = double('result')
+            e = PG::TRIntegrityConstraintViolation.new
+            e.stub(:result).and_return(result)
+            result.stub(:error_field).with(::PGresult::PG_DIAG_SQLSTATE).and_return("40002")
+            fake_conn {|conn| conn.stub(:query).with('SELECT 3', nil).ordered.and_raise(e)}
+            conn = Sequel::Fdbsql::Connection.new(nil, {})
+            proc do
+              conn.query('SELECT 3')
+            end.should raise_error(PG::TRIntegrityConstraintViolation)
+          end
+
+          specify 'retries more than 5 times' do
+            result = double('result')
+            e = PG::TRIntegrityConstraintViolation.new
+            e.stub(:result).and_return(result)
+            result.stub(:error_field).with(::PGresult::PG_DIAG_SQLSTATE).and_return("40002")
+            time = 0
+            fake_conn do |conn|
+              conn.stub(:query).with('SELECT 3', nil).ordered do
+                raise e if (time += 1) < 5
+                3
+              end
+            end
+            conn = Sequel::Fdbsql::Connection.new(nil, {})
+            conn.query('SELECT 3')
+          end
+        end
+        describe 'inside a transaction' do
+          specify 'does not retry' do
+            result = double('result')
+            e = PG::TRIntegrityConstraintViolation.new
+            e.stub(:result).and_return(result)
+            result.stub(:error_field).with(::PGresult::PG_DIAG_SQLSTATE).and_return("40002")
+            fake_conn {|conn| conn.stub(:query).with('SELECT 3', nil).once.ordered.and_raise(e)}
+            conn = Sequel::Fdbsql::Connection.new(nil, {})
+            conn.in_transaction = true
+            proc do
+              conn.query('SELECT 3')
+            end.should raise_error(PG::TRIntegrityConstraintViolation)
+          end
+        end
+      end
+
+      describe 'checks sql layer version' do
+        ['1.9.5', '0.9.6', '1.8.6', '1.9.6', '1.9.7', '1.10.0'].each do |version|
+          it "throws error for #{version}" do
+            fake_conn {|conn| conn.stub(:query).with('SELECT VERSION()', nil).and_return([{'_SQL_COL_1' => "FoundationDB #{version}"}])}
+            proc do
+              conn = Sequel::Fdbsql::Connection.new(nil, {})
+            end.should raise_error(Sequel::DatabaseError, /Unsupported.*version.*#{version}/)
+          end
+        end
+        ['2.0.0', '2.9.5', '3.0.0'].each do |version|
+          it "does not throw error for #{version}" do
+            fake_conn {|conn| conn.stub(:query).with('SELECT 3', nil).and_return([{'_SQL_COL_1' => "FoundationDB #{version}"}])}
+            conn = Sequel::Fdbsql::Connection.new(nil, {})
+          end
+        end
+      end
+
+      describe 'receiver' do
+        specify "should set notice receiver when connecting" do
+          receiver = proc {|x| puts x}
+
+          fake_conn do |conn|
+            conn.should_receive(:set_notice_receiver).once.with(receiver)
+            # because we give it a block for our default receiver
+            conn.should_not_receive(:set_notice_receiver).with(no_args())
+          end
+
+          conn = Sequel::Fdbsql::Connection.new(nil, notice_receiver: receiver)
+        end
+      end
+    end
+  elsif (DB.adapter_scheme == :jdbc)
+    describe 'JDBC' do
+      before do
+        @fake_conn = double('fake connection')
+        @fake_conn.stub(:close)
+        DB.stub(:connect).and_return(@fake_conn)
+        # clears all the existing real connection
+        DB.disconnect
+      end
+      after do
+        DB.disconnect
+      end
+
+      def fake_stmt
+        fake_stmt = double("fake statement")
+        @fake_conn.stub(:createStatement).and_return(fake_stmt)
+#        fake_stmt.stub(:executeQuery).with('SELECT VERSION()', nil).ordered.and_return([{'_SQL_COL_1' => 'FoundationDB 1.9.6'}])
+        yield fake_stmt
+        fake_stmt.stub(:close)
+      end
+      describe 'automatic retry on NotCommitted' do
+        describe 'outside a transaction' do
+          before do
+            @fake_conn.stub(:auto_commit).and_return(true)
+          end
+
+          specify 'retries a finite number of times' do
+            e = NativeException.new
+            e.stub(:sql_state).and_return("40002")
+            fake_stmt {|stmt| stmt.stub(:execute).with('SELECT 3').at_most(10).times.ordered.and_raise(e) }
+            proc do
+              DB << 'SELECT 3'
+            end.should raise_error(Sequel::Fdbsql::NotCommittedError)
+          end
+          specify 'retries at least 5 times' do
+            e = NativeException.new
+            e.stub(:sql_state).and_return("40002")
+            time = 0
+            fake_stmt do |stmt|
+              stmt.stub(:execute).with('SELECT 3').ordered do
+                raise e if (time += 1) < 5
+                3
+              end
+            end
+            DB << 'SELECT 3'
+            time.should eq 5
+          end
+
+          specify 'retries a prepared statement' do
+            e = NativeException.new
+            e.stub(:sql_state).and_return("40002")
+            ps = double('fake prepared statement')
+            @fake_conn.stub(:prepareStatement).with('SELECT $n').and_return(ps)
+            ps.stub(:setLong).with(0, 3).at_least(:once)
+            rs = double('faux resultset')
+            rs.stub(:close)
+            md = double('fake metadat')
+            rs.stub(:getMetaData).and_return(md)
+            md.stub(:getColumnCount).and_return(0)
+            rs.stub(:next).and_return(false)
+            time = 0
+            ps.stub(:executeQuery) do
+              raise e if (time += 1) < 5
+              rs
+            end
+            ds = DB["SELECT $n"]
+            ds.prepare(:select, :select_n)
+            DB.call(:select_n, n: 3)
+            time.should eq 5
+          end
+        end
+
+        describe 'inside a transaction' do
+          before do
+            @fake_conn.stub(:auto_commit).and_return(false)
+          end
+
+          specify 'does not retry' do
+            e = NativeException.new
+            e.stub(:sql_state).and_return("40002")
+            fake_stmt do |stmt|
+              stmt.stub(:execute).with('BEGIN').once.ordered
+              stmt.stub(:execute).with('SELECT 3').once.ordered.and_raise(e)
+              stmt.stub(:execute).with('ROLLBACK').once.ordered
+            end
+            proc do
+              DB.transaction do
+                DB << 'SELECT 3'
+              end
+            end.should raise_error(Sequel::Fdbsql::NotCommittedError)
+          end
+
+          specify 'does not retry prepared statement' do
+            e = NativeException.new
+            e.stub(:sql_state).and_return("40002")
+            ps = double('fake prepared statement')
+            fake_stmt do |stmt|
+              stmt.stub(:execute).with('BEGIN').once
+              stmt.stub(:execute).with('ROLLBACK').once
+            end
+            @fake_conn.stub(:prepareStatement).with('SELECT $n').and_return(ps)
+            ps.stub(:setLong).with(0, 3).at_least(:once)
+            ps.stub(:executeQuery).once.and_raise(e)
+            proc do
+              DB.transaction do
+                ds = DB["SELECT $n"]
+                ds.prepare(:select, :select_n)
+                DB.call(:select_n, n: 3)
+              end
+            end.should raise_error(Sequel::Fdbsql::NotCommittedError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/database_test.rb
+++ b/spec/integration/database_test.rb
@@ -53,7 +53,7 @@ describe Sequel::Database do
       proc{@db[:test].update(:a=>'1', :b=>'2')}.should raise_error(Sequel::UniqueConstraintViolation)
     end
 
-    cspecify "should raise Sequel::CheckConstraintViolation when a check constraint is violated", :mysql, [:db2], [proc{|db| db.sqlite_version < 30802}, :sqlite] do
+    cspecify "should raise Sequel::CheckConstraintViolation when a check constraint is violated", :mysql, [:db2], [proc{|db| db.sqlite_version < 30802}, :sqlite], :fdbsql do
       @db.create_table!(:test){String :a; check Sequel.~(:a=>'1')}
       proc{@db[:test].insert('1')}.should raise_error(Sequel::CheckConstraintViolation)
       @db[:test].insert('2')

--- a/spec/integration/plugin_test.rb
+++ b/spec/integration/plugin_test.rb
@@ -277,7 +277,7 @@ describe "Many Through Many Plugin" do
     c.exclude(:albums=>self_join(Album).filter(:albums__id=>[@album1.id, @album3.id])).all.map{|a| a.name}.sort.should == %w'4'
   end
 
-  specify "should handle typical case with 3 join tables" do
+  cspecify "should handle typical case with 3 join tables", :fdbsql do
     Artist.many_through_many :related_artists, [[:albums_artists, :artist_id, :album_id], [:albums, :id, :id], [:albums_artists, :album_id, :artist_id]], :class=>Artist, :distinct=>true
     Artist[@artist1.id].related_artists.map{|x| x.name}.sort.should == %w'1 2 4'
     Artist[@artist2.id].related_artists.map{|x| x.name}.sort.should == %w'1 2 3'
@@ -334,7 +334,7 @@ describe "Many Through Many Plugin" do
     c.exclude(:related_artists=>c.filter(:artists__id=>@artist1.id)).all.map{|a| a.name}.sort.should == %w'3'
   end
 
-  specify "should handle extreme case with 5 join tables" do
+  cspecify "should handle extreme case with 5 join tables", :fdbsql do
     Artist.many_through_many :related_albums, [[:albums_artists, :artist_id, :album_id], [:albums, :id, :id], [:albums_artists, :album_id, :artist_id], [:artists, :id, :id], [:albums_artists, :artist_id, :album_id]], :class=>Album, :distinct=>true
     @db[:albums_artists].delete
     @album1.add_artist(@artist1)
@@ -1890,182 +1890,185 @@ describe "Caching plugins" do
   end
 end
 
-describe "Sequel::Plugins::ConstraintValidations" do
-  before(:all) do
-    @db = DB
-    @db.extension(:constraint_validations)
-    @db.create_constraint_validations_table
-    @ds = @db[:cv_test]
-    @regexp = regexp = @db.dataset.supports_regexp?
-    @validation_opts = {}
-    opts_proc = proc{@validation_opts}
-    @validate_block = proc do |opts|
-      opts = opts_proc.call
-      presence :pre, opts.merge(:name=>:p)
-      exact_length 5, :exactlen, opts.merge(:name=>:el)
-      min_length 5, :minlen, opts.merge(:name=>:minl)
-      max_length 5, :maxlen, opts.merge(:name=>:maxl)
-      length_range 3..5, :lenrange, opts.merge(:name=>:lr)
-      if regexp
-        format(/^foo\d+/, :form, opts.merge(:name=>:f))
-      end
-      like 'foo%', :lik, opts.merge(:name=>:l)
-      ilike 'foo%', :ilik, opts.merge(:name=>:il)
-      includes %w'abc def', :inc, opts.merge(:name=>:i)
-      unique :uniq, opts.merge(:name=>:u)
-      max_length 6, :minlen, opts.merge(:name=>:maxl2)
-    end
-    @valid_row = {:pre=>'a', :exactlen=>'12345', :minlen=>'12345', :maxlen=>'12345', :lenrange=>'1234', :lik=>'fooabc', :ilik=>'FooABC', :inc=>'abc', :uniq=>'u'}
-    @violations = [
-      [:pre, [nil, '', ' ']],
-      [:exactlen, [nil, '', '1234', '123456']],
-      [:minlen, [nil, '', '1234']],
-      [:maxlen, [nil, '123456']],
-      [:lenrange, [nil, '', '12', '123456']],
-      [:lik, [nil, '', 'fo', 'fotabc', 'FOOABC']],
-      [:ilik, [nil, '', 'fo', 'fotabc']],
-      [:inc, [nil, '', 'ab', 'abcd']],
-    ]
-
-    if @regexp
-      @valid_row[:form] = 'foo1'
-      @violations << [:form, [nil, '', 'foo', 'fooa']]
-    end
-  end
-  after(:all) do
-    @db.drop_constraint_validations_table
-  end
-
-  shared_examples_for "constraint validations" do
-    cspecify "should set up constraints that work even outside the model", :mysql do 
-      proc{@ds.insert(@valid_row)}.should_not raise_error
-
-      # Test for unique constraint
-      proc{@ds.insert(@valid_row)}.should raise_error(Sequel::DatabaseError)
-
-      @ds.delete
-      @violations.each do |col, vals|
-        try = @valid_row.dup
-        vals += ['1234567'] if col == :minlen
-        vals.each do |val|
-          next if val.nil? && @validation_opts[:allow_nil]
-          try[col] = val
-          proc{@ds.insert(try)}.should raise_error(Sequel::DatabaseError)
-        end
-      end
-
-      # Test for dropping of constraint
-      @db.alter_table(:cv_test){validate{drop :maxl2}}
-      proc{@ds.insert(@valid_row.merge(:minlen=>'1234567'))}.should_not raise_error
-    end
-
-    it "should set up automatic validations inside the model" do 
-      c = Class.new(Sequel::Model(@ds))
-      c.plugin :constraint_validations
-      c.dataset.delete
-      proc{c.create(@valid_row)}.should_not raise_error
-
-      # Test for unique validation 
-      c.new(@valid_row).should_not be_valid
-
-      c.dataset.delete
-      @violations.each do |col, vals|
-        try = @valid_row.dup
-        vals.each do |val|
-          next if val.nil? && @validation_opts[:allow_nil]
-          try[col] = val
-          c.new(try).should_not be_valid
-        end
-      end
-      c.db.constraint_validations = nil
-    end
-  end
-
-  describe "via create_table" do
+# fdbsql does not support check constraint, so the before blocks here won't work
+unless (DB.database_type == :fdbsql)
+  describe "Sequel::Plugins::ConstraintValidations" do
     before(:all) do
-      @table_block = proc do
-        regexp = @regexp
-        validate_block = @validate_block
-        @db.create_table!(:cv_test) do
-          primary_key :id
-          String :pre
-          String :exactlen
-          String :minlen
-          String :maxlen
-          String :lenrange
-          if regexp
-            String :form
-          end
-          String :lik
-          String :ilik
-          String :inc
-          String :uniq, :null=>false
-          validate(&validate_block)
+      @db = DB
+      @db.extension(:constraint_validations)
+      @db.create_constraint_validations_table
+      @ds = @db[:cv_test]
+      @regexp = regexp = @db.dataset.supports_regexp?
+      @validation_opts = {}
+      opts_proc = proc{@validation_opts}
+      @validate_block = proc do |opts|
+        opts = opts_proc.call
+        presence :pre, opts.merge(:name=>:p)
+        exact_length 5, :exactlen, opts.merge(:name=>:el)
+        min_length 5, :minlen, opts.merge(:name=>:minl)
+        max_length 5, :maxlen, opts.merge(:name=>:maxl)
+        length_range 3..5, :lenrange, opts.merge(:name=>:lr)
+        if regexp
+          format(/^foo\d+/, :form, opts.merge(:name=>:f))
         end
+        like 'foo%', :lik, opts.merge(:name=>:l)
+        ilike 'foo%', :ilik, opts.merge(:name=>:il)
+        includes %w'abc def', :inc, opts.merge(:name=>:i)
+        unique :uniq, opts.merge(:name=>:u)
+        max_length 6, :minlen, opts.merge(:name=>:maxl2)
+      end
+      @valid_row = {:pre=>'a', :exactlen=>'12345', :minlen=>'12345', :maxlen=>'12345', :lenrange=>'1234', :lik=>'fooabc', :ilik=>'FooABC', :inc=>'abc', :uniq=>'u'}
+      @violations = [
+                     [:pre, [nil, '', ' ']],
+                     [:exactlen, [nil, '', '1234', '123456']],
+                     [:minlen, [nil, '', '1234']],
+                     [:maxlen, [nil, '123456']],
+                     [:lenrange, [nil, '', '12', '123456']],
+                     [:lik, [nil, '', 'fo', 'fotabc', 'FOOABC']],
+                     [:ilik, [nil, '', 'fo', 'fotabc']],
+                     [:inc, [nil, '', 'ab', 'abcd']],
+                    ]
+
+      if @regexp
+        @valid_row[:form] = 'foo1'
+        @violations << [:form, [nil, '', 'foo', 'fooa']]
       end
     end
     after(:all) do
-      @db.drop_table?(:cv_test)
-      @db.drop_constraint_validations_for(:table=>:cv_test)
+      @db.drop_constraint_validations_table
     end
 
-    describe "with :allow_nil=>true" do
-      before(:all) do
-        @validation_opts = {:allow_nil=>true}
-        @table_block.call
-      end
-      it_should_behave_like "constraint validations"
-    end
-    describe "with :allow_nil=>false" do
-      before(:all) do
-        @table_block.call
-      end
-      it_should_behave_like "constraint validations"
-    end
-  end
+    shared_examples_for "constraint validations" do
+      cspecify "should set up constraints that work even outside the model", :mysql do 
+        proc{@ds.insert(@valid_row)}.should_not raise_error
 
-  describe "via alter_table" do
-    before(:all) do
-      @table_block = proc do
-        regexp = @regexp
-        validate_block = @validate_block
-        @db.create_table!(:cv_test) do
-          primary_key :id
-          String :lik
-          String :ilik
-          String :inc
-          String :uniq, :null=>false
-        end
-        @db.alter_table(:cv_test) do
-          add_column :pre, String
-          add_column :exactlen, String
-          add_column :minlen, String
-          add_column :maxlen, String
-          add_column :lenrange, String
-          if regexp
-            add_column :form, String
+        # Test for unique constraint
+        proc{@ds.insert(@valid_row)}.should raise_error(Sequel::DatabaseError)
+
+        @ds.delete
+        @violations.each do |col, vals|
+          try = @valid_row.dup
+          vals += ['1234567'] if col == :minlen
+          vals.each do |val|
+            next if val.nil? && @validation_opts[:allow_nil]
+            try[col] = val
+            proc{@ds.insert(try)}.should raise_error(Sequel::DatabaseError)
           end
-          validate(&validate_block)
         end
+
+        # Test for dropping of constraint
+        @db.alter_table(:cv_test){validate{drop :maxl2}}
+        proc{@ds.insert(@valid_row.merge(:minlen=>'1234567'))}.should_not raise_error
       end
-    end
-    after(:all) do
-      @db.drop_table?(:cv_test)
-      @db.drop_constraint_validations_for(:table=>:cv_test)
+
+      it "should set up automatic validations inside the model" do 
+        c = Class.new(Sequel::Model(@ds))
+        c.plugin :constraint_validations
+        c.dataset.delete
+        proc{c.create(@valid_row)}.should_not raise_error
+
+        # Test for unique validation 
+        c.new(@valid_row).should_not be_valid
+
+        c.dataset.delete
+        @violations.each do |col, vals|
+          try = @valid_row.dup
+          vals.each do |val|
+            next if val.nil? && @validation_opts[:allow_nil]
+            try[col] = val
+            c.new(try).should_not be_valid
+          end
+        end
+        c.db.constraint_validations = nil
+      end
     end
 
-    describe "with :allow_nil=>true" do
+    describe "via create_table" do
       before(:all) do
-        @validation_opts = {:allow_nil=>true}
-        @table_block.call
+        @table_block = proc do
+          regexp = @regexp
+          validate_block = @validate_block
+          @db.create_table!(:cv_test) do
+            primary_key :id
+            String :pre
+            String :exactlen
+            String :minlen
+            String :maxlen
+            String :lenrange
+            if regexp
+              String :form
+            end
+            String :lik
+            String :ilik
+            String :inc
+            String :uniq, :null=>false
+            validate(&validate_block)
+          end
+        end
       end
-      it_should_behave_like "constraint validations"
+      after(:all) do
+        @db.drop_table?(:cv_test)
+        @db.drop_constraint_validations_for(:table=>:cv_test)
+      end
+
+      describe "with :allow_nil=>true" do
+        before(:all) do
+          @validation_opts = {:allow_nil=>true}
+          @table_block.call
+        end
+        it_should_behave_like "constraint validations"
+      end
+      describe "with :allow_nil=>false" do
+        before(:all) do
+          @table_block.call
+        end
+        it_should_behave_like "constraint validations"
+      end
     end
-    describe "with :allow_nil=>false" do
+
+    describe "via alter_table" do
       before(:all) do
-        @table_block.call
+        @table_block = proc do
+          regexp = @regexp
+          validate_block = @validate_block
+          @db.create_table!(:cv_test) do
+            primary_key :id
+            String :lik
+            String :ilik
+            String :inc
+            String :uniq, :null=>false
+          end
+          @db.alter_table(:cv_test) do
+            add_column :pre, String
+            add_column :exactlen, String
+            add_column :minlen, String
+            add_column :maxlen, String
+            add_column :lenrange, String
+            if regexp
+              add_column :form, String
+            end
+            validate(&validate_block)
+          end
+        end
       end
-      it_should_behave_like "constraint validations"
+      after(:all) do
+        @db.drop_table?(:cv_test)
+        @db.drop_constraint_validations_for(:table=>:cv_test)
+      end
+
+      describe "with :allow_nil=>true" do
+        before(:all) do
+          @validation_opts = {:allow_nil=>true}
+          @table_block.call
+        end
+        it_should_behave_like "constraint validations"
+      end
+      describe "with :allow_nil=>false" do
+        before(:all) do
+          @table_block.call
+        end
+        it_should_behave_like "constraint validations"
+      end
     end
   end
 end

--- a/spec/integration/schema_test.rb
+++ b/spec/integration/schema_test.rb
@@ -364,7 +364,7 @@ describe "Database schema modifiers" do
     end
   end
 
-  specify "should create temporary tables without raising an exception" do
+  cspecify "should create temporary tables without raising an exception", :fdbsql do
     @db.create_table!(:items_temp, :temp=>true){Integer :number}
   end
 
@@ -420,7 +420,7 @@ describe "Database schema modifiers" do
     @ds.insert([10])
   end
 
-  specify "should be able to specify constraint names for column constraints" do
+  cspecify "should be able to specify constraint names for column constraints", :fdbsql do
     @db.create_table!(:items2){primary_key :id, :primary_key_constraint_name=>:foo_pk}
     @db.create_table!(:items){foreign_key :id, :items2, :unique=>true, :foreign_key_constraint_name => :foo_fk, :unique_constraint_name => :foo_uk, :null=>false}
     @db.alter_table(:items){drop_constraint :foo_fk, :type=>:foreign_key; drop_constraint :foo_uk, :type=>:unique}
@@ -681,7 +681,7 @@ describe "Database schema modifiers" do
     @db.schema(:items, :reload=>true).map{|x| x.first}.should == [:id]
   end
 
-  cspecify "should work correctly with many operations in a single alter_table call", [:jdbc, :db2], [:db2] do
+  cspecify "should work correctly with many operations in a single alter_table call", [:jdbc, :db2], [:db2], :fdbsql do
     @db.create_table!(:items) do
       primary_key :id
       String :name2


### PR DESCRIPTION
This PR adds support for the Foundation DB SQL Layer. The new adapter works both with jdbc and on its own.

As far as the integration tests are concerned all that are not ignored in this PR are passing. Occasionally one or two tests will fail because the transaction takes too long, rerunning fixes it. It requires the latest SQL Layer (v2.0.0).
