### PR TITLE
Allow default model setting per database specification

### DIFF
--- a/lib/sequel/database/connecting.rb
+++ b/lib/sequel/database/connecting.rb
@@ -159,6 +159,11 @@ module Sequel
       end
     end
 
+    # Returns :default_model_settings specified in database.yml
+    def default_model_settings
+      @opts[:default_model_settings]
+    end
+
     # The database type for this database object, the same as the adapter scheme
     # by default.  Should be overridden in adapters (especially shared adapters)
     # to be the correct type, so that even if two separate Database objects are

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1147,6 +1147,10 @@ module Sequel
         @values = {}
         @new = true
         @modified = true
+        if (defaults = db.default_model_settings)
+          defaults.each { |k,v| instance_variable_set("@#{k}", v) }
+        end
+ 
         initialize_set(values)
         changed_columns.clear 
         yield self if block_given?


### PR DESCRIPTION
This change is to allow per db spec default model setting.

Although the option such as 'use_transactions' can be specified by model, the option goes with each connection definition. Any model that refers to that connection should get the setting without any code.

sample:

```
default: &default
  adapter: informix
  <blah blah>
  default_model_settings:
    use_transactions: false
```
