### PR TITLE
Make drop_view(:view_name, :foreign=>true) drop foreign tables on Postgres

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -906,6 +906,11 @@ module Sequel
         "DROP TRIGGER#{' IF EXISTS' if opts[:if_exists]} #{name} ON #{quote_schema_table(table)}#{' CASCADE' if opts[:cascade]}"
       end
 
+      # Support :foreign tables
+      def drop_table_sql(name, options)
+        "DROP#{' FOREIGN' if options[:foreign]} TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_schema_table(name)}#{' CASCADE' if options[:cascade]}"
+      end
+
       # SQL for dropping a view from the database.
       def drop_view_sql(name, opts=OPTS)
         "DROP #{'MATERIALIZED ' if opts[:materialized]}VIEW#{' IF EXISTS' if opts[:if_exists]} #{quote_schema_table(name)}#{' CASCADE' if opts[:cascade]}"

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -277,10 +277,14 @@ describe "A PostgreSQL database" do
     a.should == "WARNING:  foo\n"
   end if DB.adapter_scheme == :postgres && SEQUEL_POSTGRES_USES_PG && DB.server_version >= 90000
 
+  # These only test the SQL created, because a true test using file_fdw or postgres_fdw
+  # requires superuser permissions, and you should not be running the tests as a superuser.
   specify "should support creating foreign tables" do
-    # This only tests the SQL created, because a true test using file_fdw or postgres_fdw
-    # requires superuser permissions, and you should not be running the tests as a superuser.
-    DB.send(:create_table_sql, :t, DB.create_table_generator{Integer :a}, :foreign=>:f, :options=>{:o=>1}).should == 'CREATE FOREIGN TABLE "t" ("a" integer) SERVER "f" OPTIONS (o \'1\')'
+    DB.send(:create_table_sql, :t, DB.send(:create_table_generator){Integer :a}, :foreign=>:f, :options=>{:o=>1}).should == 'CREATE FOREIGN TABLE "t" ("a" integer) SERVER "f" OPTIONS (o \'1\')'
+  end
+
+  specify "should support dropping foreign tables" do
+    DB.send(:drop_table_sql, :t, :foreign=>true).should == 'DROP FOREIGN TABLE "t"'
   end
 end
 


### PR DESCRIPTION
This closes #891
