### PR TITLE
Update document to not use core extension

### DIFF
--- a/doc/active_record.rdoc
+++ b/doc/active_record.rdoc
@@ -756,7 +756,7 @@ ActiveRecord Method :: Notes, Workarounds
 +silence+ :: No equivalent.  Because the logger is handled at the <tt>Sequel::Database</tt> level, there is no thread-safe way to turn it off for specific blocks.
 +scopes+ :: No equivalent
 +sti_name+ :: No equivalent.
-+update_counters+ :: <tt>Album.where(:id=>:id).update(:counter_name=>:counter_name + 1, :other_counter=>:other_counter - 1)</tt>
++update_counters+ :: <tt>Album.where(:id=>:id).update(:counter_name=>Sequel.+(:counter_name, 1), :other_counter=>Sequel.-(:other_counter, 1))</tt>
 +uncached+ :: No equivalent
 
 === Instance Methods with Significantly Different Behavior

--- a/doc/model_hooks.rdoc
+++ b/doc/model_hooks.rdoc
@@ -96,7 +96,7 @@ Sequel does not provide a simple way to turn off the running of save/create/upda
 
 However, you should note that there are plenty of ways to modify the database without saving a model object.  One example is by using plain datasets, or one of the model's dataset methods:
 
-  Album.where(:name=>'RF').update(:copies_sold=>:copies_sold + 1)
+  Album.where(:name=>'RF').update(:copies_sold=>Sequel.+(:copies_sold, 1))
   # UPDATE albums SET copies_sold = copies_sold + 1 WHERE name = 'RF'
 
 In this case, the +update+ method is called on the dataset returned by <tt>Album.where</tt>.  Even if there is only a single object with the name RF, this will not call any hooks.  If you want model hooks to be called, you need to make sure to operate on a model object:


### PR DESCRIPTION
I think we don't intend to use core extension in those cases?
Or we could note we need to enable core extension in order to do that way.
