### PR TITLE
Fix example usage for `update` with increment expression

### DIFF
--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -763,7 +763,7 @@ module Sequel
     #   DB[:table].update(:x=>nil) # UPDATE table SET x = NULL
     #   # => 10
     #
-    #   DB[:table].update(:x=>:x+1, :y=>0) # UPDATE table SET x = (x + 1), y = 0
+    #   DB[:table].update(:x=>Sequel.expr(:x)+1, :y=>0) # UPDATE table SET x = (x + 1), y = 0
     #   # => 10
     def update(values=OPTS, &block)
       sql = update_sql(values)


### PR DESCRIPTION
Tiny fix documentation for `update()`:
When performing an increment update, the symbol has to be wrapped by `Sequel.expr()`, otherwise a `Exception: undefined method '+' for ...` is thrown
