### PR TITLE
Have Dataset#empty? ignore order.

### DIFF
--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -146,7 +146,8 @@ module Sequel
     #   DB[:table].empty? # SELECT 1 AS one FROM table LIMIT 1
     #   # => false
     def empty?
-      get(Sequel::SQL::AliasedExpression.new(1, :one)).nil?
+      ds = @opts[:order] ? unordered : self
+      ds.get(Sequel::SQL::AliasedExpression.new(1, :one)).nil?
     end
 
     # If a integer argument is given, it is interpreted as a limit, and then returns all 

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -1952,6 +1952,15 @@ describe "Dataset#empty?" do
     db.from(:test).filter(false).should be_empty
     db.sqls.should == ["SELECT 1 AS one FROM test WHERE 'f' LIMIT 1"]
   end
+
+  specify "should ignore order" do
+    db = Sequel.mock(:fetch=>proc{|sql| {1=>1}})
+    db.from(:test).should_not be_empty
+    without_order = db.sqls
+    db.from(:test).order(:the_order_column).should_not be_empty
+    with_order = db.sqls
+    without_order.should == with_order
+  end
 end
 
 describe "Dataset#first_source_alias" do


### PR DESCRIPTION
This fixes a bug for me where I had called #empty? on a dataset
that I had ordered by a column named by Sequel.as, which did not
exist in the query used for #empty?.
