### PR TITLE
Remove outdated comment about from_db

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1144,12 +1144,10 @@ module Sequel
       alias to_hash values
 
       # Creates new instance and passes the given values to set.
-      # If a block is given, yield the instance to the block unless
-      # from_db is true.
+      # If a block is given, yield the instance to the block.
       #
       # Arguments:
       # values :: should be a hash to pass to set. 
-      # from_db :: only for backwards compatibility, forget it exists.
       #
       #   Artist.new(:name=>'Bob')
       #


### PR DESCRIPTION
from_db was removed in 258fcad8c435d96483dd6643e1aa7d97943aa496

It will be even easier to "forget it exists" once the code stops reminding us. ;)
