### PR TITLE
Interpret integer and floating point dates the same way in SQLite

### DIFF
--- a/lib/sequel/adapters/sqlite.rb
+++ b/lib/sequel/adapters/sqlite.rb
@@ -154,10 +154,8 @@ module Sequel
         case s
         when String
           super
-        when Integer
+        when Integer, Float
           super(Time.at(s).to_s)
-        when Float
-          super(DateTime.jd(s).to_s)
         else
           raise Sequel::Error, "unhandled type when converting to : #{s.inspect} (#{s.class.inspect})"
         end


### PR DESCRIPTION
SQLite documentation claims that floating point values in a date time column should be treated as a Julian date. However, this only matters if you are also using the SQLite date time functions, which does not seem to be part of Sequel.

Furthermore, SQLite has tendency to turn Floats into Integers when the float has a 0 for the decimal part. This is a documented feature of SQLite in their data type documentation: https://www.sqlite.org/datatype3.html

Here is an example:

```ruby
require 'sequel'
Sequel.default_timezone=:utc
s = Sequel.connect 'sqlite://test.sqlite'
s.create_table :test do
  primary_key :id
  Time :foo
end

s[:test].insert(foo: 10682232306.0)
s[:test].insert(foo: 10682232306.1)
s[:test].insert(foo: Time.at(10682232306.0))
puts s[:test].to_a
```
```sh
 ± ruby test.rb 
{:id=>1, :foo=>2308-07-04 22:45:06 UTC}
{:id=>2, :foo=>29242246-07-31 02:24:00 UTC}
{:id=>3, :foo=>2308-07-04 22:45:06 UTC}
```
```sh
 ○ sqlite3 test.sqlite 'SELECT * FROM test;'
-- Loading resources from /Users/mrada/.sqliterc

id          foo        
----------  -----------
1           10682232306
2           10682232306
3           2308-07-04 
```
