### PR TITLE
Add timezone support to swift adapter when using mysql

### DIFF
--- a/lib/sequel/adapters/swift/mysql.rb
+++ b/lib/sequel/adapters/swift/mysql.rb
@@ -34,7 +34,21 @@ module Sequel
       class Dataset < Swift::Dataset
         include Sequel::MySQL::DatasetMethods
         APOS = Dataset::APOS
-        
+
+        def fetch_rows(sql)
+          super(sql) do |h|
+            converted_h = h.map do |k,v|
+              converted_v = if v.is_a?(DateTime)
+                              Sequel.database_to_application_timestamp(Sequel.send(:convert_input_datetime_no_offset, v, Sequel.database_timezone))
+                            else
+                              v
+                            end
+              [k, converted_v]
+            end
+            yield Hash[converted_h]
+          end
+        end
+
         private
         
         # Use Swift's escape method for quoting.


### PR DESCRIPTION
Hi there,

I've been having some trouble with the mysql2 gem so decided I would give the swift adapter a go as a possible alternative.  The main thing I noticed that didn't seem to be working was timezones for `DateTime` objects (i.e. for `DATETIME` columns in the db).  Regardless of what `database_timezone` and `application_timezone` settings I use, the `DateTime` objects always seem to get the UTC timezone.  I assume that this is only an issue for MySQL, but I haven't tested any other databases that Swift works with.    [this file](https://github.com/shanna/swift/blob/master/test/test_timestamps.rb) from their test cases seems to indicate that they only expect timezones to work with Postgres.

I've had a go at resolving this in the present pull request, but I don't think my solution isn't very good -- perhaps there is a better method that I could override?  Also, I had to use `#send` because `Sequel#convert_input_datetime_no_offset` is a private method.  This seems a bit hacky.

Finally, I haven't written any tests for this change because I wasn't sure where they should go.  It seems that there are no Swift tests at all at the moment -- is that right?

While I have the opportunity I'd also like to add that this is an awesome project!  Thanks for all your work on it.