### PR TITLE
Merge arbitrary options into add_constraint ops hash

### DIFF
--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -326,7 +326,7 @@ module Sequel
       #   add_constraint({:name=>:valid_name, :deferrable=>true}, Sequel.like(:name, 'A%'))
       #   # ADD CONSTRAINT valid_name CHECK (name LIKE 'A%' ESCAPE '\') DEFERRABLE INITIALLY DEFERRED
       def add_constraint(name, *args, &block)
-        opts = name.is_a?(Hash) ? name : {:name=>name}
+        opts = name.is_a?(Hash) ? name : (args.last.is_a?(Hash) ? args.pop : {}).merge(:name=>name)
         @operations << opts.merge(:op=>:add_constraint, :type=>:check, :check=>block || args)
       end
 

--- a/spec/core/schema_generator_spec.rb
+++ b/spec/core/schema_generator_spec.rb
@@ -115,6 +115,7 @@ describe Sequel::Schema::AlterTableGenerator do
       add_index :blah, :type => :hash
       add_index :blah, :where => {:something => true}
       add_constraint :con1, 'fred > 100'
+      add_constraint :con3, 'fred > 300', :opts => true
       drop_constraint :con2
       add_unique_constraint [:aaa, :bbb, :ccc], :name => :con3
       add_primary_key :id
@@ -143,6 +144,7 @@ describe Sequel::Schema::AlterTableGenerator do
       {:op => :add_index, :columns => [:blah], :type => :hash},
       {:op => :add_index, :columns => [:blah], :where => {:something => true}},
       {:op => :add_constraint, :type => :check, :name => :con1, :check => ['fred > 100']},
+      {:op => :add_constraint, :type => :check, :name => :con3, :check => ['fred > 300'], :opts => true},
       {:op => :drop_constraint, :name => :con2},
       {:op => :add_constraint, :type => :unique, :name => :con3, :columns => [:aaa, :bbb, :ccc]},
       {:op => :add_column, :name => :id, :type => Integer, :primary_key=>true, :auto_increment=>true},


### PR DESCRIPTION
Based on comments from Jeremy on sequel-talk, and the behaviour of most
other methods, my intuition is that add_constraint should merge any opts
passed to add_constraint.  However, the existing code wasn't doing that in
the case of a named constraint.  Now it does.