### PR TITLE
Allow create_enum to be used in a reversible migration

### DIFF
--- a/lib/sequel/extensions/pg_enum.rb
+++ b/lib/sequel/extensions/pg_enum.rb
@@ -37,6 +37,15 @@
 #   DB[:table_name].get(:column_name)
 #   # ['value1', 'value2']
 #
+# If the migration extension is loaded before this one (the order is important),
+# you can use create_enum in a reversible migration:
+#
+#   Sequel.migration do
+#     change do
+#       create_enum(:type_name, %w'value1 value2 value3')
+#     end
+#   end
+#
 # Finally, typecasting for enums is setup to cast to strings, which
 # allows you to use symbols in your model code.  Similar, you can provide
 # the enum values as symbols when creating enums using create_enum or
@@ -128,6 +137,16 @@ module Sequel
       # Typecast the given value to a string.
       def typecast_value_enum(value)
         value.to_s
+      end
+    end
+  end
+
+  # support reversible create_enum statements if the migration extension is loaded
+  if defined?(MigrationReverser)
+    class MigrationReverser
+      private
+      def create_enum(name, _)
+        @actions << [:drop_enum, name]
       end
     end
   end

--- a/spec/extensions/pg_enum_spec.rb
+++ b/spec/extensions/pg_enum_spec.rb
@@ -1,6 +1,6 @@
 require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
 
-describe "pg_inet extension" do
+describe "pg_enum extension" do
   before do
     @db = Sequel.connect('mock://postgres', :quote_identifiers=>false)
     @db.extend(Module.new do


### PR DESCRIPTION
As discussed on IRC, this PR adds the ability for create_enum in the pg_enum extension to be used in a reversible transaction.

I haven't added the spec yet, if you can let me know how to load the migration extension safely in pg_enum_spec.rb I will happily do that as well (or feel free to finish the job) :)