### PR TITLE
Update documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -47,7 +47,10 @@ If you have any comments or suggestions please post to the Google group.
   
   DB = Sequel.sqlite # memory database
   
-  DB.create_table :items do
+  # DB.create_table creates the table if it doesn't exist
+  # DB.create_table! removes the table and creates it (empty)
+  # DB.create_table? creates the table only if it doesn't exist
+  DB.create_table? :items do
     primary_key :id
     String :name
     Float :price


### PR DESCRIPTION
At least with sqlite3, the initial script from the README, can't be executed more than once.
This is occasioned when it opens a database that already contains a table with that name.
Even though this is documented, it is more appropriate to read it here too, the first contact with Sequel.