### PR TITLE
Add the #validates_confirmation helper

### DIFF
--- a/doc/validations.rdoc
+++ b/doc/validations.rdoc
@@ -230,6 +230,18 @@ These methods check that the specified attributes can be valid integers or valid
     end
   end
 
+=== +validates_confirmation+
+
++validates_confirmation+ checks that the specified attributes match their confirmations. It assumes that the confirmation is in +<attribute>_confirmation+, so you will need to define the accessor if you haven't already.
+
+  class User < Sequel::Model
+    attr_accessor :password_confirmation
+
+    def validate
+      validates_confirmation :password
+    end
+  end
+
 === +validates_type+
 
 +validates_type+ checks that the specified attributes are instances of the class specified in the first argument.  The class can be specified as the class itself, or as a string or symbol with the class name, or as a an array of classes.

--- a/spec/extensions/validation_helpers_spec.rb
+++ b/spec/extensions/validation_helpers_spec.rb
@@ -531,4 +531,16 @@ describe "Sequel::Plugins::ValidationHelpers" do
     m.should_not be_valid
     DB.sqls.should == []
   end
+
+  it "should support validates_confirmation" do
+    @c.set_validations{validates_confirmation :value}
+    @c.send(:attr_accessor, :value_confirmation)
+    @m.value = "foo"
+    @m.value_confirmation = "foo"
+    @m.should be_valid
+
+    @m.value_confirmation = "bar"
+    @m.should_not be_valid
+    @m.errors.should == {:value_confirmation => ["doesn't match value"]}
+  end
 end 


### PR DESCRIPTION
I am now experimenting with doing validations in service objects, so I really like that Sequel provides instance-level validation helpers. I was just missing `#validates_confirmation`.

I'm aware that users have to declare the confirmation column manually, but I think it's not a problem. What do you think?