### PR TITLE
Demodulize default root name in json_serializer

### DIFF
--- a/lib/sequel/plugins/json_serializer.rb
+++ b/lib/sequel/plugins/json_serializer.rb
@@ -290,7 +290,9 @@ module Sequel
           end
 
           if root = opts[:root]
-            root = model.send(:underscore, model.to_s) unless root.is_a?(String)
+            unless root.is_a?(String)
+              root = model.send(:underscore, model.send(:demodulize, model.to_s))
+            end
             h = {root => h}
           end
 
@@ -330,7 +332,7 @@ module Sequel
               opts.delete(:root)
             end
             unless collection_root.is_a?(String)
-              collection_root = model.send(:pluralize, model.send(:underscore, model.to_s))
+              collection_root = model.send(:pluralize, model.send(:underscore, model.send(:demodulize, model.to_s)))
             end
           end
 

--- a/spec/extensions/json_serializer_spec.rb
+++ b/spec/extensions/json_serializer_spec.rb
@@ -206,6 +206,19 @@ describe "Sequel::Plugins::JsonSerializer" do
     @album.to_json(:root=>true, :except => [:name, :artist_id]).to_s.should == '{"album":{"id":1}}'
     @album.to_json(:root=>true, :only => :name).to_s.should == '{"album":{"name":"RF"}}'
   end
+
+  it "should handle the :root option to qualify single records of namespaced models" do
+    module ::Namespace
+      class Album < Sequel::Model
+        plugin :json_serializer, :naked=>true
+      end
+    end
+    Namespace::Album.new({}).to_json(:root=>true).to_s.should == '{"album":{}}'
+    Namespace::Album.dataset._fetch = [{}]
+    Namespace::Album.dataset.to_json(:root=>:collection).to_s.should == '{"albums":[{}]}'
+    Namespace::Album.dataset.to_json(:root=>:both).to_s.should == '{"albums":[{"album":{}}]}'
+    Object.send(:remove_const, :Namespace)
+  end
   
   it "should handle the :root option with a string to qualify single records using the string as the key" do
     @album.to_json(:root=>"foo", :except => [:name, :artist_id]).to_s.should == '{"foo":{"id":1}}'


### PR DESCRIPTION
I'm really loving the extension/plugin architecture of Sequel, thank you for making it that way.

I'm making a Sinatra app that is structured as a gem. So all classes, including Sequel models, are namespaced inside the main namespace. Currently Sequel does the following:

```rb
module Namespace
  class Album < Sequel::Model
  end
end

Namespace::Album.new.to_json(root: true) #=> "{"namespace/album": {}}"
```

I think a natural default key would be simply `"album"`. This goes along with the rest of Sequel where the namespace doesn't affect the name (e.g. table name). I know I could write `root: "album"`, but it gets tedious when you always need to pass it both to instance's and dataset's `to_json`.

I think this shouldn't be a backwards-incompatible change, because:

1. I believe it's a very rare case that someone even has a namespaced Sequel model
2. Users who wanted to get around this problem most probably are already passing `root: "album"`, or adding the root manually outside of the json_serializer extension.