### PR TITLE
Improve error message of failed database extension

### DIFF
--- a/lib/sequel/database/misc.rb
+++ b/lib/sequel/database/misc.rb
@@ -199,7 +199,7 @@ module Sequel
         if pr = Sequel.synchronize{EXTENSIONS[ext]}
           pr.call(self)
         else
-          raise(Error, "Extension #{ext} does not have specific support handling individual databases")
+          raise(Error, "Extension #{ext} does not have specific support handling individual databases (try `Sequel.extension :#{ext}`)")
         end
       end
       self


### PR DESCRIPTION
When I first got the error, I couldn't quite figure out how to fix the problem. I think this error mostly happens when an extension is required on the wrong level. This error happened to me because I did this:

```rb
DB.extension :pg_json, :pg_json_ops
```