### PR TITLE
JDBC adapter should set username even if no password provided.

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -201,7 +201,12 @@ module Sequel
           get_connection_from_jndi
         else
           args = [uri(opts)]
-          args.concat([opts[:user], opts[:password]]) if opts[:user] && opts[:password]
+          if opts[:user]
+            args.push(opts[:user])
+            if opts[:password]
+              args.push(opts[:password])
+            end
+          end
           begin
             JavaSQL::DriverManager.setLoginTimeout(opts[:login_timeout]) if opts[:login_timeout]
             JavaSQL::DriverManager.getConnection(*args)
@@ -210,9 +215,13 @@ module Sequel
             # If the DriverManager can't get the connection - use the connect
             # method of the driver. (This happens under Tomcat for instance)
             props = java.util.Properties.new
-            if opts && opts[:user] && opts[:password]
-              props.setProperty("user", opts[:user])
-              props.setProperty("password", opts[:password])
+            if opts
+              if opts[:user]
+                props.setProperty("user", opts[:user])
+                if opts[:password]
+                  props.setProperty("password", opts[:password])
+                end
+              end
             end
             opts[:jdbc_properties].each{|k,v| props.setProperty(k.to_s, v)} if opts[:jdbc_properties]
             begin


### PR DESCRIPTION
**Scenario** 
Using JDBC to connect to MySQL under JRuby. The connection uses SSL certificates to authenticate users, thus it requires a username to be passed, but not a password.

**Issue**
The JDBC adapter only sets a username on the connection if a password is also set. 

There's no `jdbc_spec.rb` file, so not sure on the best way to test this change. Thoughts?