### PR TITLE
csv_serializer plugin

### DIFF
--- a/.travis.gemfile
+++ b/.travis.gemfile
@@ -15,6 +15,10 @@ if RUBY_VERSION < '1.9.3'
   gem "i18n", '<0.7.0'
 end
 
+if RUBY_VERSION < '1.9.0'
+  gem "fastercsv"
+end
+
 # MRI/Rubinius Adapter Dependencies
 platforms :ruby do
   gem "sqlite3"

--- a/lib/sequel/plugins/csv_serializer.rb
+++ b/lib/sequel/plugins/csv_serializer.rb
@@ -1,0 +1,212 @@
+if RUBY_VERSION < "1.9"
+  begin
+    require 'fastercsv'
+  rescue LoadError
+    warn("plugin csv_serializer requires either ruby>=1.9 or fastercsv")
+  end
+else
+  require 'csv'
+end
+
+module Sequel
+  module Plugins
+    # csv_serializer handles serializing entire Sequel::Model objects to CSV,
+    # as well as support for deserializing CSV directly into Sequel::Model
+    # objects.  It requires either the csv standard library from ruby >= 1.9,
+    # or the fastercsv gem.
+    #
+    # Basic Example:
+    #
+    #   album = Album[1]
+    #   album.to_csv(:write_headers=>true)
+    #   # => "id,name,artist_id\n1,RF,2\n"
+    #
+    # You can provide options to control the CSV output:
+    #
+    #   album.to_csv(:only=>:name)
+    #   album.to_csv(:except=>[:id, :artist_id])
+    #   # => "RF\n"
+    #
+    # +to_csv+ also exists as a class and dataset method, both of which return
+    # all objects in the dataset:
+    #
+    #   Album.to_csv
+    #   Album.filter(:artist_id=>1).to_csv
+    #
+    # If you have an existing array of model instance you want to convert to
+    # CSV, you can call the class to_csv method with the :array option:
+    #
+    #   Album.to_csv(:array=>[Album[1], Album[2]])
+    #
+    # In addition to creating CSV, this plugin also enables Sequel::Model
+    # classes to create instances directly from CSV using the from_csv class
+    # method:
+    #
+    #   csv = album.to_csv
+    #   album = Album.from_csv(csv)
+    #
+    # The array_from_csv class method exists to parse arrays of model instances
+    # from CSV:
+    #
+    #   csv = Album.filter(:artist_id=>1).to_csv
+    #   albums = Album.array_from_csv(csv)
+    #
+    # These do not necessarily round trip, since doing so would let users
+    # create model objects with arbitrary values.  By default, from_csv will
+    # call set with the values in the hash.  If you want to specify the allowed
+    # fields, you can use the :headers option.
+    #
+    #   Album.from_csv(album.to_csv, :headers=>%w'id name')
+    #
+    # If you want to update an existing instance, you can use the from_csv
+    # instance method:
+    #
+    #   album.from_csv(csv)
+    #
+    # Usage:
+    #
+    #   # Add CSV output capability to all model subclass instances (called
+    #   # before loading subclasses)
+    #   Sequel::Model.plugin :csv_serializer
+    #
+    #   # Add CSV output capability to Album class instances
+    #   Album.plugin :csv_serializer
+    module CsvSerializer
+      CSV = Object.const_defined?(:CSV) ? ::CSV : ::FasterCSV
+
+      # Set up the column readers to do deserialization and the column writers
+      # to save the value in deserialized_values
+      def self.configure(model, opts = {})
+        model.instance_eval do
+          @csv_serializer_opts = (@csv_serializer_opts || {}).merge(opts)
+        end
+      end
+
+      # Convert the options hash to one that can be passed to CSV.new
+      def self.process_opts(model, opts = {}, columns = model.columns)
+        opts = (model.csv_serializer_opts || {}).merge(opts)
+        headers = if opts[:only].is_a?(Array)
+                    opts.delete(:only)
+                  elsif opts[:only].is_a?(Symbol)
+                    [opts.delete(:only)]
+                  elsif opts[:headers].is_a?(Array)
+                    opts[:headers]
+                  else
+                    columns
+                  end
+        headers += Array(opts.delete(:include))
+        headers -= Array(opts.delete(:except))
+        opts = opts.merge(:headers=>headers)
+        Array(opts.delete(:except)).each { |header| headers.delete(header) }
+        opts
+      end
+
+      module ClassMethods
+        # The default opts to use when serializing model objects to CSV
+        attr_reader :csv_serializer_opts
+
+        # Attempt to parse a single instance from the given CSV string
+        def from_csv(csv, opts = {})
+          values_hash = hash_from_csv(csv, opts)
+          instance = new
+          instance.set(values_hash)
+          instance
+        end
+
+        # Attempt to parse a single line of CSV into a hash which can be
+        # converted to a Sequel::Model instance
+        def hash_from_csv(csv, opts = {})
+          opts = CsvSerializer.process_opts(self, opts)
+
+          types = {}
+          db_schema.each_pair { |k, v| types[k] = v[:type] }
+
+          values_hash = {}
+          CSV.parse_line(csv, opts).to_hash.each_pair do |k, v|
+            next if v.nil? || k.nil?
+
+            value = if types[k]
+                      db.send(:column_schema_default_to_ruby_value, v, types[k])
+                    else
+                      v
+                    end
+
+            values_hash[k] = value
+          end
+          values_hash
+        end
+
+        # Attempt to parse an array of instances from the given CSV string
+        def array_from_csv(csv, opts = {})
+          opts = CsvSerializer.process_opts(self, opts)
+
+          instances = []
+          CSV.parse(csv, opts) do |row|
+            instance = new
+            row.to_hash.each_pair do |k, v|
+              instance.send(:"#{k}=", v)
+            end
+            instances << instance
+          end
+          instances
+        end
+
+        Plugins.inherited_instance_variables(
+          self, :@csv_serializer_opts => lambda do |csv_serializer_opts|
+            opts = {}
+            csv_serializer_opts.each do |k, v|
+              opts[k] = (v.is_a?(Array) || v.is_a?(Hash)) ? v.dup : v
+            end
+            opts
+          end)
+
+        Plugins.def_dataset_methods(self, :to_csv)
+      end # module ClassMethods
+
+      module InstanceMethods
+        # Parse the provided CSV
+        def from_csv(csv, opts = {})
+          values_hash = self.class.hash_from_csv(csv, opts)
+          set(values_hash)
+        end
+
+        # Return a string in CSV format.  Accepts the same options as CSV.new,
+        # as well as the following options:
+        #
+        # :except :: Symbol or Array of Symbols of columns not to include in
+        #            the CSV output.
+        # :only :: Symbol or Array of Symbols of columns to include in the CSV
+        #          output, ignoring all other columns
+        # :include :: Symbol or Array of Symbols specifying non-column
+        #             attributes to include in the CSV output.
+        def to_csv(opts = {})
+          opts = CsvSerializer.process_opts(model, opts)
+
+          CSV.generate(opts) do |csv|
+            csv << opts[:headers].map { |k| send(k) }
+          end
+        end
+      end # module InstanceMethods
+
+      module DatasetMethods
+        # Return a CSV string representing an array of all objects in this
+        # dataset.  Takes the same options as the instance method, and passes
+        # them to every instance.  Accepts the same options as CSV.new, as well
+        # as the following options:
+        #
+        # :array :: An array of instances.  If this is not provided, calls #all
+        #           on the receiver to get the array.
+        def to_csv(opts = {})
+          opts = CsvSerializer.process_opts(model, opts, columns)
+          items = opts.delete(:array) || self
+
+          CSV.generate(opts) do |csv|
+            items.each do |object|
+              csv << opts[:headers].map { |header| object[header] }
+            end
+          end
+        end
+      end # module DatasetMethods
+    end # module CsvSerializer
+  end # module Plugins
+end # module Sequel

--- a/spec/extensions/csv_serializer_spec.rb
+++ b/spec/extensions/csv_serializer_spec.rb
@@ -1,0 +1,176 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
+
+describe "Sequel::Plugins::CsvSerializer" do
+  before do
+    class ::Artist < Sequel::Model
+      unrestrict_primary_key
+      plugin :csv_serializer
+      columns :id, :name
+      def_column_accessor :id, :name
+      @db_schema = {:id=>{:type=>:integer}}
+      one_to_many :albums
+    end
+    class ::Album < Sequel::Model
+      unrestrict_primary_key
+      attr_accessor :blah
+      plugin :csv_serializer
+      columns :id, :name, :artist_id
+      def_column_accessor :id, :name, :artist_id
+      @db_schema = {:id=>{:type=>:integer}, :artist_id=>{:type=>:integer}}
+      many_to_one :artist
+    end
+    @artist = Artist.load(:id=>2, :name=>'YJM')
+    @artist.associations[:albums] = []
+    @album = Album.load(:id=>1, :name=>'RF')
+    @album.artist = @artist
+    @album.blah = 'Blah'
+  end
+  after do
+    Object.send(:remove_const, :Artist)
+    Object.send(:remove_const, :Album)
+  end
+
+  it "should round trip successfully" do
+    Artist.from_csv(@artist.to_csv).should == @artist
+    Album.from_csv(@album.to_csv).should == @album
+  end
+
+  it "should handle ruby objects in values" do
+    class ::Artist
+      def name=(v)
+        super(Date.parse(v))
+      end
+    end
+    Artist.from_csv(Artist.load(:name=>Date.today).to_csv).
+      should == Artist.load(:name=>Date.today)
+  end
+
+  it "should handle the :only option" do
+    Artist.from_csv(@artist.to_csv(:only=>:name), :only=>:name).
+      should == Artist.load(:name=>@artist.name)
+    Album.from_csv(@album.to_csv(:only=>[:id, :name]), :only=>[:id, :name]).
+      should == Album.load(:id=>@album.id, :name=>@album.name)
+  end
+
+  it "should handle the :except option" do
+    Artist.from_csv(@artist.to_csv(:except=>:id), :except=>:id).
+      should == Artist.load(:name=>@artist.name)
+    Album.from_csv(@album.to_csv(:except=>[:id, :artist_id]),
+                   :except=>[:id, :artist_id]).
+      should == Album.load(:name=>@album.name)
+  end
+
+  it "should handle the :include option for arbitrary attributes" do
+    Album.from_csv(@album.to_csv(:include=>:blah), :include=>:blah).
+      blah.should == @album.blah
+  end
+
+  it "should handle multiple inclusions using an array for the :include option" do
+    a = Album.from_csv(@album.to_csv(:include=>[:blah]), :include=>:blah)
+    a.blah.should == @album.blah
+  end
+
+  it "should support #from_csv to set column values" do
+    @artist.from_csv('AS', :only=>:name)
+    @artist.name.should == 'AS'
+    @artist.id.should == 2
+
+    @artist.from_csv('1', :only=>:id)
+    @artist.name.should == 'AS'
+    @artist.id.should == 1
+  end
+
+  it "should support #from_csv to support specific :fields" do
+    @album.from_csv('AS,2', :headers=>['name'])
+    @album.name.should == 'AS'
+    @album.artist_id.should == 2
+
+    @album.from_csv('2,AS', :headers=>[nil, 'name'])
+    @album.name.should == 'AS'
+    @album.artist_id.should == 2
+  end
+
+  it "should support a to_csv class and dataset method" do
+    Album.dataset._fetch = {:id=>1, :name=>'RF', :artist_id=>2}
+    Artist.dataset._fetch = {:id=>2, :name=>'YJM'}
+    Album.array_from_csv(Album.to_csv).should == [@album]
+    Album.array_from_csv(Album.dataset.to_csv(:only=>:name), :only=>:name).
+      should == [Album.load(:name=>@album.name)]
+  end
+
+  it "should have dataset to_csv method respect :array option" do
+    a = Album.new(:id=>1, :name=>'RF', :artist_id=>3)
+    Album.array_from_csv(Album.to_csv(:array=>[a])).should == [a]
+  end
+
+  it "should propagate class default options to instance to_csv output" do
+    class ::Album2 < Sequel::Model
+      attr_accessor :blah
+      plugin :csv_serializer, :except => :id
+      columns :id, :name, :artist_id
+      many_to_one :artist
+    end
+    @album2 = Album2.load(:id=>2, :name=>'JK')
+    @album2.artist = @artist
+    @album2.blah = 'Gak'
+
+    csv = Sequel::Plugins::CsvSerializer::CSV
+    csv.parse(@album2.to_csv(:write_headers=>true), :headers=>true).
+      first.to_hash.
+      should == @album2.
+               values.
+               reject { |k, _v| k.to_s == 'id' }.
+               reduce({}) { |h, (k, v)| h[k.to_s] = v.to_s; h }
+    csv.parse(@album2.to_csv(:only=>:name, :write_headers=>true),
+              :headers=>true).
+      first.to_hash.
+      should == @album2.
+               values.
+               reject { |k, _v| k.to_s != 'name' }.
+               reduce({}) { |h, (k, v)| h[k.to_s] = v.to_s; h }
+    csv.parse(@album2.to_csv(:except=>:artist_id, :write_headers=>true),
+              :headers=>true).
+      first.to_hash.
+      should == @album2.
+               values.
+               reject { |k, _v| k.to_s == 'artist_id' }.
+               reduce({}) { |h, (k, v)| h[k.to_s] = v.to_s; h }
+  end
+
+  it "should store the default options in csv_serializer_opts" do
+    Album.csv_serializer_opts.should == {}
+    c = Class.new(Album)
+    c.plugin :csv_serializer, :naked=>false
+    c.csv_serializer_opts.should == {:naked=>false}
+  end
+
+  it "should work correctly when subclassing" do
+    ::Artist2 = Class.new(Artist)
+    Artist2.plugin :csv_serializer, :only=>:name
+    ::Artist3 = Class.new(Artist2)
+    Artist3.from_csv(Artist3.load(:id=>2, :name=>'YYY').to_csv).
+      should == Artist3.load(:name=>'YYY')
+    Object.send(:remove_const, :Artist2)
+    Object.send(:remove_const, :Artist3)
+  end
+
+  it "should raise an error if attempting to set a restricted column "\
+     "and :all_columns is not used" do
+    Artist.restrict_primary_key
+    proc{Artist.from_csv(@artist.to_csv)}.should raise_error(Sequel::Error)
+  end
+
+  it "should use a dataset's selected columns" do
+    columns = [:id]
+    ds = Artist.select(*columns).limit(1)
+    ds.instance_variable_set(:@columns, columns)
+    ds._fetch = [:id => 10]
+    ds.to_csv(:write_headers => true).should == "id\n10\n"
+  end
+
+  it "should pass all the examples from the documentation" do
+    @album.to_csv(:write_headers=>true).should == "id,name,artist_id\n1,RF,2\n"
+    @album.to_csv(:only=>:name).should == "RF\n"
+    @album.to_csv(:except=>[:id, :artist_id]).should == "RF\n"
+  end
+end


### PR DESCRIPTION
A plugin for working with CSV in the spirit of `json_serializer` and `xml_serializer`. The API is broadly similar to the existing serialization plugins, but because CSV is not a nested format, no attempt was made to support associations. It will of course properly escape values, accept alternative record separators, and so on, as it uses the standard `csv` library (or, on ruby < 1.9, `fastercsv`).

Past interest in CSV support:
* https://github.com/jeremyevans/sequel/issues/577
* https://groups.google.com/forum/#!searchin/sequel-talk/csv/sequel-talk/qq5OiXkn8LM/GKnFtR2VS84J
* https://groups.google.com/forum/#!searchin/sequel-talk/csv/sequel-talk/pUcaBSRc1_A/yLg21y49DoMJ
* http://stackoverflow.com/questions/24763711/reading-a-csv-file-into-ruby-using-sequel-and-the-sqlite3-gems

`fastercsv` greatly simplified the implementation for ruby 1.8, but isn't used by later rubies (in fact it throws an exception telling you to use the standard library if you try to use it), so I added it only to `.travis.gemfile` and not `sequel.gemspec`, and arranged for it to be conditionally loaded when the plugin is loaded.

Please let me know if there are any ways this plugin can be improved.

Thanks!