### PR TITLE
Don't call validate_presence on not null columns with non-ruby defaults.

### DIFF
--- a/lib/sequel/plugins/auto_validations.rb
+++ b/lib/sequel/plugins/auto_validations.rb
@@ -109,7 +109,10 @@ module Sequel
 
         # Parse the database schema and indexes and record the columns to automatically validate.
         def setup_auto_validations
-          not_null_cols, explicit_not_null_cols = db_schema.select{|col, sch| sch[:allow_null] == false}.partition{|col, sch| sch[:ruby_default].nil?}.map{|cs| cs.map{|col, sch| col}}
+          not_null_cols, explicit_not_null_cols =
+                 db_schema.select{|col, sch| sch[:allow_null] == false}
+                   .partition{|col, sch| sch[:default].nil? && sch[:ruby_default].nil?}
+                   .map{|cs| cs.map{|col, sch| col}}
           @auto_validate_not_null_columns = not_null_cols - Array(primary_key)
           explicit_not_null_cols += Array(primary_key)
           @auto_validate_explicit_not_null_columns = explicit_not_null_cols.uniq

--- a/spec/extensions/auto_validations_spec.rb
+++ b/spec/extensions/auto_validations_spec.rb
@@ -11,7 +11,9 @@ describe "Sequel::Plugins::AutoValidations" do
        [:name, {:primary_key=>false, :type=>:string, :allow_null=>false, :max_length=>50}],
        [:num, {:primary_key=>false, :type=>:integer, :allow_null=>true}],
        [:d, {:primary_key=>false, :type=>:date, :allow_null=>false}],
-       [:nnd, {:primary_key=>false, :type=>:string, :allow_null=>false, :ruby_default=>'nnd'}]]
+       [:nnrd, {:primary_key=>false, :type=>:string, :allow_null=>false, :ruby_default=>'nnrd'}],
+       [:nnd, {:primary_key=>false, :type=>:string, :allow_null=>false, :default=>'nnd'}],
+      ]
     end
     def db.supports_index_parsing?() true end
     def db.indexes(t, *)
@@ -20,7 +22,7 @@ describe "Sequel::Plugins::AutoValidations" do
       {:a=>{:columns=>[:name, :num], :unique=>true}, :b=>{:columns=>[:num], :unique=>false}}
     end
     @c = Class.new(Sequel::Model(db[:test]))
-    @c.send(:def_column_accessor, :id, :name, :num, :d, :nnd)
+    @c.send(:def_column_accessor, :id, :name, :num, :d, :nnd, :nnrd)
     @c.raise_on_typecast_failure = false
     @c.plugin :auto_validations
     @m = @c.new
@@ -68,10 +70,12 @@ describe "Sequel::Plugins::AutoValidations" do
   end
 
   it "should automatically validate explicit nil values for columns with not nil defaults" do
-    @m.set(:d=>Date.today, :name=>1, :nnd=>nil)
+    @m.set(:d=>Date.today, :name=>1, :nnd=>nil, :nnrd=>nil)
     @m.id = nil
     @m.valid?.should == false
-    @m.errors.should == {:id=>["is not present"], :nnd=>["is not present"]}
+    @m.errors.should == {
+      :id=>["is not present"], :nnd=>["is not present"], :nnrd=>["is not present"]
+    }
   end
 
   it "should allow skipping validations by type" do


### PR DESCRIPTION
For example, this will have a default, but not a ruby_default (though it probably should, see #989).  auto_validates was only looking for ruby_default.

    column :titles, 'varchar[]', null: false, default: '{}'