### PR TITLE
Give PG array columns ruby_defaults

### DIFF
--- a/lib/sequel/extensions/pg_array.rb
+++ b/lib/sequel/extensions/pg_array.rb
@@ -300,6 +300,19 @@ module Sequel
           end
         end
 
+        def column_schema_default_string_type?(type)
+          ARRAY_TYPES.values.include?(type) || super
+        end
+
+        def column_schema_default_to_ruby_value(default, type)
+          case type
+          when *ARRAY_TYPES.values
+            Creator.new(type).call(default)
+          else
+            super
+          end
+        end
+
         # Given a value to typecast and the type of PGArray subclass:
         # * If given a PGArray with a matching array_type, use it directly.
         # * If given a PGArray with a different array_type, return a PGArray

--- a/spec/extensions/pg_array_spec.rb
+++ b/spec/extensions/pg_array_spec.rb
@@ -397,4 +397,14 @@ describe "pg_array extension" do
              "'{1,2,3}'::integer", :integer_array
             ).should == @m::PGArray.new([1,2,3], :integer)
   end
+
+  it "should reject garbage array defaults" do
+    @db.send(:column_schema_to_ruby_default,
+             "'{1,2,3'::integer", :integer_array
+            ).should == nil
+
+    @db.send(:column_schema_to_ruby_default,
+             "'{foo,bar'::character varying", :varchar_array
+            ).should == nil
+  end
 end

--- a/spec/extensions/pg_array_spec.rb
+++ b/spec/extensions/pg_array_spec.rb
@@ -387,4 +387,14 @@ describe "pg_array extension" do
     @db.schema_type_class(:banana_array).should == Sequel::Postgres::PGArray
     @db.schema_type_class(:integer).should == Integer
   end
+
+  it "should set a ruby_default for array types" do
+    @db.send(:column_schema_to_ruby_default,
+             "'{foo,bar}'::character varying", :varchar_array
+            ).should == @m::PGArray.new(['foo', 'bar'], :varchar)
+
+    @db.send(:column_schema_to_ruby_default,
+             "'{1,2,3}'::integer", :integer_array
+            ).should == @m::PGArray.new([1,2,3], :integer)
+  end
 end


### PR DESCRIPTION
*This is not ready to be merged*

As discussed in #990, this is a first cut at giving PG array columns with defaults a ruby_default in the schema.  This fixes auto_validations and maybe other problems.

I would like some advice on how to proceed.

```
  1) pg_array extension should set a ruby_default for array types
     Failure/Error: ).should == @m::PGArray.new([1,2,3], :integer)
       expected: [1, 2, 3]
            got: ["1", "2", "3"] (using ==)
     # ./spec/extensions/pg_array_spec.rb:398:in `block (2 levels) in <top (required)>'
```

It seems I need the JSONCreator for integers.  Which creator to use only appears to be available in the [big list of register() calls](https://github.com/jeremyevans/sequel/blob/master/lib/sequel/extensions/pg_array.rb#L527) and I can't figure out a way to get at that information.

What should I be doing instead of `Creator.new(type).call(default)`?  Do I need to make PGArray::DatabaseMethods::register store the creator for each array_type in a structure for later use?  Or am I overlooking something?