### PR TITLE
Change single_table_inheritance to use the dataset for the key column table name

### DIFF
--- a/lib/sequel/plugins/single_table_inheritance.rb
+++ b/lib/sequel/plugins/single_table_inheritance.rb
@@ -159,7 +159,7 @@ module Sequel
           key = Array(skm[subclass]).dup
           sti_subclass_added(key)
           rp = dataset.row_proc
-          subclass.set_dataset(sd.filter(SQL::QualifiedIdentifier.new(table_name, sk)=>key), :inherited=>true)
+          subclass.set_dataset(sd.filter(SQL::QualifiedIdentifier.new(sd.first_source_alias, sk)=>key), :inherited=>true)
           subclass.instance_eval do
             dataset.row_proc = rp
             @sti_key = sk


### PR DESCRIPTION
The hybrid_table_inheritance plugin uses the single_table_inheritance plugin.  Just like the class_table_inheritance plugin, hybrid overrides the table_name method to return the lowest table in the inheritance hierarchy.  But, the key column used by single_table_inheritance is on the root table.   The current version of hybrid_table_inheritance changes the result of table_name to the root table then calls the single_table_inheritance inherited method (super) then changes it back as shown here https://github.com/QuinnHarris/sequel-table_inheritance/blob/v0.1.3/lib/sequel/plugins/hybrid_table_inheritance.rb#L265

This request eliminates the need for this kludge.  Note that the table_name method typically used by single_table_inheritance returns dataset.first_source_alias