### PR TITLE
Change single and class to use Plugins.inherited_instance_variables

### DIFF
--- a/lib/sequel/plugins/class_table_inheritance.rb
+++ b/lib/sequel/plugins/class_table_inheritance.rb
@@ -153,17 +153,17 @@ module Sequel
         # Specified with the :table_map option to the plugin, and used if
         # the implicit naming is incorrect.
         attr_reader :cti_table_map
-        
+
+        Plugins.inherited_instance_variables(self, :@cti_key=>nil, :@cti_model_map=>nil, :@cti_table_map=>nil)
+
         # Add the appropriate data structures to the subclass.  Does not
         # allow anonymous subclasses to be created, since they would not
         # be mappable to a table.
         def inherited(subclass)
           cc = cti_columns
-          ck = cti_key
           ct = cti_tables.dup
-          ctm = cti_table_map.dup
+          ctm = cti_table_map
           cbm = cti_base_model
-          cmm = cti_model_map
           pk = primary_key
           ds = dataset
           table = nil
@@ -172,12 +172,9 @@ module Sequel
             raise(Error, "cannot create anonymous subclass for model class using class_table_inheritance") if !(n = name) || n.empty?
             table = ctm[n.to_sym] || implicit_table_name
             columns = db.from(table).columns
-            @cti_key = ck 
             @cti_tables = ct + [table]
             @cti_columns = cc.merge(table=>columns)
-            @cti_table_map = ctm
             @cti_base_model = cbm
-            @cti_model_map = cmm
             # Need to set dataset and columns before calling super so that
             # the main column accessor module is included in the class before any
             # plugin accessor modules (such as the lazy attributes accessor module).

--- a/lib/sequel/plugins/single_table_inheritance.rb
+++ b/lib/sequel/plugins/single_table_inheritance.rb
@@ -147,27 +147,19 @@ module Sequel
         # This defaults to a lookup in the key map.
         attr_reader :sti_key_chooser
 
+        Plugins.inherited_instance_variables(self, :@sti_dataset=>nil, :@sti_key=>nil, :@sti_key_map=>nil, :@sti_model_map=>nil, :@sti_key_chooser=>nil)
+
         # Copy the necessary attributes to the subclasses, and filter the
         # subclass's dataset based on the sti_kep_map entry for the class.
         def inherited(subclass)
           super
-          sk = sti_key
-          sd = sti_dataset
-          skm = sti_key_map
-          smm = sti_model_map
-          skc = sti_key_chooser
-          key = Array(skm[subclass]).dup
+          key = Array(sti_key_map[subclass]).dup
           sti_subclass_added(key)
           rp = dataset.row_proc
-          subclass.set_dataset(sd.filter(SQL::QualifiedIdentifier.new(sd.first_source_alias, sk)=>key), :inherited=>true)
+          subclass.set_dataset(sti_dataset.filter(SQL::QualifiedIdentifier.new(sti_dataset.first_source_alias, sti_key)=>key), :inherited=>true)
           subclass.instance_eval do
             dataset.row_proc = rp
-            @sti_key = sk
             @sti_key_array = key
-            @sti_dataset = sd
-            @sti_key_map = skm
-            @sti_model_map = smm
-            @sti_key_chooser = skc
             self.simple_table = nil
           end
         end

--- a/spec/extensions/single_table_inheritance_spec.rb
+++ b/spec/extensions/single_table_inheritance_spec.rb
@@ -207,6 +207,7 @@ describe Sequel::Model, "single table inheritance plugin" do
       StiTest2.dataset.row_proc.call(:kind=>0).should be_a_instance_of(StiTest2)
       StiTest2.dataset.row_proc.call(:kind=>1).should be_a_instance_of(StiTest3)
       StiTest2.dataset.row_proc.call(:kind=>2).should be_a_instance_of(StiTest4)
+      StiTest3.sti_model_map.should == StiTest2.sti_model_map
 
       StiTest2.create.kind.should == 4
       StiTest3.create.kind.should == 5


### PR DESCRIPTION
This is intended to clean up the single and class table inheritance plugins a little bit by using inherited instance variables.  This passes specs and I don't expect it will change behaviour.  This is an aesthetic change so I don't mind if its rejected.