### PR TITLE
List pagination methods in the documentation

### DIFF
--- a/lib/sequel/extensions/pagination.rb
+++ b/lib/sequel/extensions/pagination.rb
@@ -1,6 +1,18 @@
 # The pagination extension adds the Sequel::Dataset#paginate and #each_page methods,
 # which return paginated (limited and offset) datasets with some helpful methods
-# that make creating a paginated display easier.
+# that make creating a paginated display easier:
+#
+# * +#Sequel::Dataset#page_size+
+# * +#Sequel::Dataset#page_count+
+# * +#Sequel::Dataset#page_range+
+# * +#Sequel::Dataset#current_page+
+# * +#Sequel::Dataset#next_page+
+# * +#Sequel::Dataset#prev_page+
+# * +#Sequel::Dataset#first_page?+
+# * +#Sequel::Dataset#last_page?+
+# * +#Sequel::Dataset#pagination_record_count+
+# * +#Sequel::Dataset#current_page_record_count+
+# * +#Sequel::Dataset#current_page_record_range+
 #
 # This extension uses Object#extend at runtime, which can hurt performance.
 #


### PR DESCRIPTION
Hi Jeremy,

I was thinking that it would be useful to list the methods that the pagination extension provides in the documentation. Just so that it's not necessary to open the source code.