### PR TITLE
this small patch makes add_named_conversion_proc also work for enum types

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -706,7 +706,7 @@ module Sequel
       # Convert the hash of named conversion procs into a hash a oid conversion procs. 
       def convert_named_procs_to_procs(named_procs)
         h = {}
-        from(:pg_type).where(:typtype=>'b', :typname=>named_procs.keys.map(&:to_s)).select_map([:oid, :typname]).each do |oid, name|
+        from(:pg_type).where(:typtype=>['b', 'e'], :typname=>named_procs.keys.map(&:to_s)).select_map([:oid, :typname]).each do |oid, name|
           h[oid.to_i] = named_procs[name.untaint.to_sym]
         end
         h

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -1662,6 +1662,18 @@ if DB.adapter_scheme == :postgres
       @db[:foo].insert(Sequel.pg_array(['21 days'], :interval))
       @db[:foo].get(:bar).should == ['syad 12']
     end
+
+    specify "should work with conversion procs on enums" do
+      @db.create_enum(:foo_enum, %w(foo bar))
+      @db.add_named_conversion_proc(:foo_enum){|string| string.reverse}
+      @db.create_table!(:foo){foo_enum :bar}
+      @db[:foo].insert(:bar => 'test string')
+      @db[:foo].get(:bar).should == 'test string'.reverse
+
+      # need to drop teh table here so we can drop the enum as well.
+      @db.drop_table?(:foo)
+      @db.drop_enum(:foo_enum)
+    end
   end
 end
 


### PR DESCRIPTION
This makes adding a named conversion proc work for an enum type column.