### PR TITLE
Add link to sequel-jsonapi_eager external plugin

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -221,6 +221,7 @@
 <li><a href='http://github.com/gucki/sequel_rails3'>sequel_rails3</a>: Another Rails 3 plugin that allows you to use Sequel instead of ActiveRecord.</li>
 <li><a href='http://github.com/jsvd/sequel_vectorized'>sequel_vectorized</a>: Allows Sequel::Dataset to be exported as an Hash of Arrays and NArrays.</li>
 <li><a href='https://github.com/refile/refile-sequel'>refile-sequel</a>: Provides an extension for using Refile with Sequel.</li>
+<li><a href='https://github.com/janko-m/sequel-jsonapi_eager'>sequel-jsonapi_eager</a>: Helps properly eager load associations when exposing objects in a JSON API.</li>
 </ul>
 
 <h3>External Adapters</h3>


### PR DESCRIPTION
I created a plugin that helps eager loading associations when exposing objects in a JSON API.