### PR TITLE
Add missing sproc option

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -698,6 +698,7 @@ module Sequel
             sql = @sproc_name
             opts = Hash[opts]
             opts[:args] = @sproc_args
+            opts[:sproc] = true
             opts[:type] = :insert
             super
           end


### PR DESCRIPTION
Hello,

I think there is missing option in StoredProcedureMethods#execute_insert that leads to fail for insert-like procedures when using JDBC adapter. I faced with it on Oracle but add a test for PG (also failed).

Best regards,
Nikita