### PR TITLE
Reversible triggers and functions

### DIFF
--- a/doc/migration.rdoc
+++ b/doc/migration.rdoc
@@ -71,7 +71,9 @@ it will attempt to create a +down+ block for you, assuming that it knows how to
 reverse the given migration.  The +change+ block can usually correctly reverse
 the following methods:
 
+* +create_function+
 * +create_table+
+* +create_trigger+
 * +add_column+
 * +add_index+
 * +rename_column+

--- a/doc/migration.rdoc
+++ b/doc/migration.rdoc
@@ -72,8 +72,10 @@ reverse the given migration.  The +change+ block can usually correctly reverse
 the following methods:
 
 * +create_function+
+* +create_join_table+
 * +create_table+
 * +create_trigger+
+* +create_view+
 * +add_column+
 * +add_index+
 * +rename_column+

--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -199,12 +199,20 @@ module Sequel
       @actions << [:alter_table, table, MigrationAlterTableReverser.new.reverse(&block)]
     end
 
+    def create_function(name, _, opts=OPTS)
+      @actions << [:drop_function, name]
+    end
+
     def create_join_table(*args)
       @actions << [:drop_join_table, *args]
     end
 
     def create_table(name, opts=OPTS)
       @actions << [:drop_table, name, opts]
+    end
+
+    def create_trigger(table, name, _, opts=OPTS)
+      @actions << [:drop_trigger, table, name]
     end
 
     def create_view(name, _, opts=OPTS)


### PR DESCRIPTION
This change makes `create_trigger` and `create_function` reversible.

Also a separate commit for adding some omitted methods in the list of change-safe methods.