### PR TITLE
Cast the value passed to Model.[] if the PK column is a blob

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1043,6 +1043,9 @@ module Sequel
         if sql = @fast_pk_lookup_sql
           sql = sql.dup
           ds = dataset
+          if db_schema[primary_key][:type] == :blob
+            pk = SQL::Blob.new(pk)
+          end
           ds.literal_append(sql, pk)
           ds.fetch_rows(sql){|r| return ds.row_proc.call(r)}
           nil


### PR DESCRIPTION
Doing something like this:

    Model["\x89"]

on a Postgres database, with a table which has a `bytea` primary key, will
cause the following error:

    Sequel::DatabaseError:
      PG::CharacterNotInRepertoire: ERROR:  invalid byte sequence for
      encoding "UTF8": 0x89

This comes about because "\x89" produces a string, which `literal_append`
thinks is a text value, and just quotes it as it would for any text field.
Except that it *isn't* text, it's binary data, which needs its own escaping.

The solution I've provided here works, but it probably isn't the most
general-purpose solution.  If there is some sort of column-type-to-SQL::*
mapping somewhere, using that would be better, but I couldn't find one.

I tried putting the checking higher or lower, but it really does have to go
in here.  Two frames up is FixtureDependencies' `model_find_by_pk_S`, and
`Dataset#literal_append` doesn't know what column its dealing with, so *it*
can't do any sort of casting.

I considered modifying FIxtureDependencies instead of this code, too, but
that would essentially put the exact same code further away from the site of
the problem.  To my mind, if Sequel already has the information required to
know to encode the value differently, it should just do it.  The way I've
done it, it also protects anyone calling `Model.[]` directly and passing in
the raw PK value (and anywhere else internally that happen to use `.[]`).

Sorry there's no tests -- I couldn't work out where to add a test without
building essentially a whole new test harness.