### PR TITLE
Adding pg_inet_ops extension

### DIFF
--- a/lib/sequel/extensions/pg_inet_ops.rb
+++ b/lib/sequel/extensions/pg_inet_ops.rb
@@ -1,0 +1,149 @@
+# The pg_inet_ops extension adds support to Sequel's DSL to make
+# it easier to call PostgreSQL inet functions and operators.
+#
+# To load the extension:
+#
+#   Sequel.extension :pg_inet_ops
+#
+# The most common usage is passing an expression to Sequel.pg_inet_op:
+#
+#   r = Sequel.pg_inet_op(:inet)
+#
+# If you have also loaded the pg_inet extension, you can use
+# Sequel.pg_inet as well:
+#
+#   r = Sequel.pg_inet(:inet)
+#
+# Also, on most Sequel expression objects, you can call the pg_inet
+# method:
+#
+#   r = Sequel.expr(:ip).pg_inet
+#
+# If you have loaded the {core_extensions extension}[rdoc-ref:doc/core_extensions.rdoc],
+# or you have loaded the core_refinements extension
+# and have activated refinements for the file, you can also use Symbol#pg_inet:
+#
+#   r = :inet.pg_inet
+#
+# This creates a Sequel::Postgres::InetOp object that can be used
+# for easier querying:
+#
+#   r.less_than(:other)                        # inet < other
+#   r.less_than_or_equal(:other)               # inet <= other
+#   r.equals(:other)                           # inet = other
+#   r.greater_than_or_equal(:other)            # inet >= other
+#   r.greater_than(:other)                     # inet > other
+#   r.not_equal(:other)                        # inet <> other
+#   r.contained_by(:other)                     # inet << other
+#   r.contained_by_or_equals(:other)           # inet <<= other
+#   r.contains(:other)                         # inet >> other
+#   r.contains_or_equals(:other)               # inet >>= other
+#   r.contains_or_contained_by(:other)         # inet && other
+#
+#   r.abbrev           # abbrev(inet)
+#   r.broadcast        # broadcast(inet)
+#   r.family           # family(inet)
+#   r.host             # host(inet)
+#   r.hostmask         # hostmask(inet)
+#   r.masklen          # masklen(inet)
+#   r.netmask          # netmask(inet)
+#   r.network          # network(inet)
+#   r.text             # text(inet)
+#
+# See the PostgreSQL network function and operator documentation for more
+# details on what these functions and operators do.
+#
+module Sequel
+  module Postgres
+    # The InetOp class is a simple container for a single object that
+    # defines methods that yield Sequel expression objects representing
+    # PostgreSQL inet operators and functions.
+    #
+    # Most methods in this class are defined via metaprogramming, see
+    # the pg_inet_ops extension documentation for details on the API.
+    class InetOp < Sequel::SQL::Wrapper
+      OPERATORS = {
+        :less_than => ["(".freeze, " < ".freeze, ")".freeze].freeze,
+        :less_than_or_equal => ["(".freeze, " <= ".freeze, ")".freeze].freeze,
+        :equals => ["(".freeze, " = ".freeze, ")".freeze].freeze,
+        :greater_than_or_equal => ["(".freeze, " >= ".freeze, ")".freeze].freeze,
+        :greater_than => ["(".freeze, " > ".freeze, ")".freeze].freeze,
+        :not_equal => ["(".freeze, " <> ".freeze, ")".freeze].freeze,
+        :contained_by => ["(".freeze, " << ".freeze, ")".freeze].freeze,
+        :contained_by_or_equals => ["(".freeze, " <<= ".freeze, ")".freeze].freeze,
+        :contains => ["(".freeze, " >> ".freeze, ")".freeze].freeze,
+        :contains_or_equals => ["(".freeze, " >>= ".freeze, ")".freeze].freeze,
+        :contains_or_contained_by => ["(".freeze, " && ".freeze, ")".freeze].freeze,
+      }
+      FUNCTIONS = %w'abbrev broadcast family host hostmask netmask network text'
+
+      FUNCTIONS.each do |f|
+        class_eval("def #{f}; function(:#{f}) end", __FILE__, __LINE__)
+      end
+      OPERATORS.keys.each do |f|
+        class_eval("def #{f}(v); operator(:#{f}, v) end", __FILE__, __LINE__)
+      end
+
+      # Return the receiver.
+      def pg_inet
+        self
+      end
+
+      private
+
+      # Create a boolen expression for the given type and argument.
+      def operator(type, other)
+        Sequel::SQL::BooleanExpression.new(:NOOP, Sequel::SQL::PlaceholderLiteralString.new(OPERATORS[type], [value, other]))
+      end
+
+      # Return a function called with the receiver.
+      def function(name)
+        Sequel::SQL::Function.new(name, self)
+      end
+    end
+
+    module InetOpMethods
+      # Wrap the receiver in an InetOp so you can easily use the PostgreSQL
+      # inet functions and operators with it.
+      def pg_inet
+        InetOp.new(self)
+      end
+    end
+
+    module SQL::Builders
+      # Return the expression wrapped in the Postgres::InetOp.
+      def pg_inet_op(v)
+        case v
+        when Postgres::InetOp
+          v
+        else
+          Postgres::InetOp.new(v)
+        end
+      end
+    end
+
+    class SQL::GenericExpression
+      include Sequel::Postgres::InetOpMethods
+    end
+
+    class LiteralString
+      include Sequel::Postgres::InetOpMethods
+    end
+  end
+end
+
+# :nocov:
+if Sequel.core_extensions?
+  class Symbol
+    include Sequel::Postgres::InetOpMethods
+  end
+end
+
+if defined?(Sequel::CoreRefinements)
+  module Sequel::CoreRefinements
+    refine Symbol do
+      include Sequel::Postgres::InetOpMethods
+    end
+  end
+end
+# :nocov:

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -3044,6 +3044,59 @@ describe 'PostgreSQL range types' do
     v.each{|k,v1| v1.must_be :==, @ra[k].to_a}
   end
 
+  it 'operations/functions with pg_inet_ops' do
+    Sequel.extension :pg_inet_ops
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').less_than('1.2.3.5')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').less_than('1.2.3.3')).must_equal false
+    @db.get(Sequel.pg_inet_op('1.2.3.4').less_than('1.2.3.4')).must_equal false
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').less_than_or_equal('1.2.3.5')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').less_than_or_equal('1.2.3.3')).must_equal false
+    @db.get(Sequel.pg_inet_op('1.2.3.4').less_than_or_equal('1.2.3.4')).must_equal true
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').equals('1.2.3.4')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').equals('1.2.3.5')).must_equal false
+
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').greater_than_or_equal('1.2.3.5')).must_equal false
+    @db.get(Sequel.pg_inet_op('1.2.3.4').greater_than_or_equal('1.2.3.3')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').greater_than_or_equal('1.2.3.4')).must_equal true
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').greater_than('1.2.3.5')).must_equal false
+    @db.get(Sequel.pg_inet_op('1.2.3.4').greater_than('1.2.3.3')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').greater_than('1.2.3.4')).must_equal false
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').not_equal('1.2.3.3')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').not_equal('1.2.3.4')).must_equal false
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').contained_by('1.2.3.0/24')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').contained_by('1.2.3.4/32')).must_equal false
+    @db.get(Sequel.pg_inet_op('1.2.3.4').contained_by('1.2.2.0/24')).must_equal false
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4').contained_by_or_equals('1.2.3.0/24')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').contained_by_or_equals('1.2.3.4/32')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.4').contained_by_or_equals('1.2.2.0/24')).must_equal false
+
+
+    @db.get(Sequel.pg_inet_op('1.2.3.0/24').contains('1.2.3.4')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.0/24').contains('1.2.2.4')).must_equal false
+
+    @db.get(Sequel.pg_inet_op('1.2.3.0/24').contains_or_equals('1.2.3.4')).must_equal true
+    @db.get(Sequel.pg_inet_op('1.2.3.0/24').contains_or_equals('1.2.2.4')).must_equal false
+    @db.get(Sequel.pg_inet_op('1.2.3.0/24').contains_or_equals('1.2.3.0/24')).must_equal true
+
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').abbrev).must_equal '1.2.3.4/24'
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').broadcast).must_equal IPAddr.new('1.2.3.255/255.255.255.0')
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').family).must_equal 4
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').host).must_equal '1.2.3.4'
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').hostmask).must_equal IPAddr.new('0.0.0.255/255.255.255.255')
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').masklen).must_equal 24
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').netmask).must_equal IPAddr.new('255.255.255.255/255.255.255.255')
+    @db.get(Sequel.pg_inet_op('1.2.3.4/24').network).must_equal IPAddr.new('1.2.3.0/255.255.255.0')
+    @db.get(Sequel.pg_inet_op('1.2.3.4/32').text).must_equal '1.2.3.4/32'
+  end
+
   it 'operations/functions with pg_range_ops' do
     Sequel.extension :pg_range_ops
 

--- a/spec/extensions/pg_inet_ops_spec.rb
+++ b/spec/extensions/pg_inet_ops_spec.rb
@@ -1,0 +1,50 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
+
+Sequel.extension :pg_inet, :pg_inet_ops
+
+describe "Sequel::Postgres::InetOp" do
+  before do
+    @ds = Sequel.connect('mock://postgres', :quote_identifiers=>false).dataset
+    @h = Sequel.pg_inet_op(:h)
+  end
+
+  it "#pg_inet should return self" do
+    @h.pg_inet.must_be_same_as(@h)
+  end
+
+  it "Sequel.pg_inet_op should return argument if already an InetOp" do
+    Sequel.pg_inet_op(@h).must_be_same_as(@h)
+  end
+
+  it "#pg_inet should return a InetOp for literal strings, and expressions" do
+    @ds.literal(Sequel.function(:b, :h).pg_inet.abbrev).must_equal "abbrev(b(h))"
+    @ds.literal(Sequel.lit('h').pg_inet.abbrev).must_equal "abbrev(h)"
+  end
+
+  it "should define methods for all of the PostgreSQL inet operators" do
+    @ds.literal(@h.less_than(@h)).must_equal "(h < h)"
+    @ds.literal(@h.less_than_or_equal(@h)).must_equal "(h <= h)"
+    @ds.literal(@h.equals(@h)).must_equal "(h = h)"
+    @ds.literal(@h.greater_than_or_equal(@h)).must_equal "(h >= h)"
+    @ds.literal(@h.greater_than(@h)).must_equal "(h > h)"
+    @ds.literal(@h.not_equal(@h)).must_equal "(h <> h)"
+    @ds.literal(@h.contained_by(@h)).must_equal "(h << h)"
+    @ds.literal(@h.contained_by_or_equals(@h)).must_equal "(h <<= h)"
+    @ds.literal(@h.contains(@h)).must_equal "(h >> h)"
+    @ds.literal(@h.contains_or_equals(@h)).must_equal "(h >>= h)"
+    @ds.literal(@h.contains_or_contained_by(@h)).must_equal "(h && h)"
+  end
+
+  it "should define methods for all of the PostgreSQL inet functions" do
+    @ds.literal(@h.abbrev).must_equal "abbrev(h)"
+    @ds.literal(@h.broadcast).must_equal "broadcast(h)"
+    @ds.literal(@h.family).must_equal "family(h)"
+    @ds.literal(@h.host).must_equal "host(h)"
+    @ds.literal(@h.hostmask).must_equal "hostmask(h)"
+    @ds.literal(@h.masklen).must_equal "masklen(h)"
+    @ds.literal(@h.netmask).must_equal "netmask(h)"
+    @ds.literal(@h.network).must_equal "network(h)"
+    @ds.literal(@h.text).must_equal "text(h)"
+  end
+
+end


### PR DESCRIPTION
As discussed on IRC.

This isn't finished, as mentioned there are some bizarre spec errors I can't work out, need your help :)

A few points to work out for your thoughts..

* I'm not sure if all the operators and functions I defined are worth having, some of them are just overrides of standard operators (greater_than etc)
* Casting seems to be an issue in the PostgreSQL tests; when using a real column the server works it out, but when passing two strings, they need to be cast to inet and I'm not sure how to achieve this.
* The PostgreSQL tests sometimes return an IPAddr, sometimes a string, I'm not sure if this is consistent? In particular shouldn't the netmask function just return a string perhaps?

Let me know if I can do any more on this, or alternatively feel free to polish it up for inclusion, hope its useful :)