### PR TITLE
Change class_table_inheritance to use hybrid_table_inheritance code

### DIFF
--- a/lib/sequel/plugins/class_table_inheritance.rb
+++ b/lib/sequel/plugins/class_table_inheritance.rb
@@ -1,15 +1,24 @@
 module Sequel
   module Plugins
-    # The class_table_inheritance plugin allows you to model inheritance in the
-    # database using a table per model class in the hierarchy, with only columns
-    # unique to that model class (or subclass hierarchy) being stored in the related
-    # table.  For example, with this hierarchy:
+    # = Overview
+    #
+    # The class_table_inheritance pluging allows model subclasses to be stored
+    # in either the same table as the parent model or a different table with a key
+    # referencing the parent table.
+    # This combines the functionality of single and class (multiple) table inheritance.
+    # This plugin uses the single_table_inheritance plugin so it has all of its features.
+    #
+    # = Detail
+    #
+    # For example, with this hierarchy:
     #
     #       Employee
-    #      /        \ 
+    #      /        \
     #   Staff     Manager
+    #     |          |
+    #   Cook      Executive
     #                |
-    #            Executive
+    #               CEO
     #
     # the following database schema may be used (table - columns):
     #
@@ -18,44 +27,56 @@ module Sequel
     # managers :: id, num_staff
     # executives :: id, num_managers
     #
-    # The class_table_inheritance plugin assumes that the main table
-    # (e.g. employees) has a primary key field (usually autoincrementing),
+    # The class_table_inheritance plugin assumes that the root table
+    # (e.g. employees) has a primary key column (usually autoincrementing),
     # and all other tables have a foreign key of the same name that points
-    # to the same key in their superclass's table.  For example:
+    # to the same column in their superclass's table.  In this example,
+    # the employees id column is a primary key and the id column in every
+    # other table is a foreign key referencing the employees id.
     #
-    # employees.id :: primary key, autoincrementing
-    # staff.id :: foreign key referencing employees(id)
-    # managers.id :: foreign key referencing employees(id)
-    # executives.id :: foreign key referencing managers(id)
+    # In this example the staff table stores Cook model objects and the
+    # executives table stores CEO model objects.
     #
-    # When using the class_table_inheritance plugin, subclasses use joined 
+    # When using the class_table_inheritance plugin, subclasses can use joined
     # datasets:
     #
     #   Employee.dataset.sql
-    #   # SELECT employees.id, employees.name, employees.kind
-    #   # FROM employees
+    #   # SELECT * FROM employees
     #
     #   Manager.dataset.sql
-    #   # SELECT employees.id, employees.name, employees.kind, managers.num_staff
+    #   # SELECT employees.id, employees.name, employees.kind,
+    #   #        managers.num_staff
     #   # FROM employees
     #   # JOIN managers ON (managers.id = employees.id)
     #
-    #   Executive.dataset.sql
-    #   # SELECT employees.id, employees.name, employees.kind, managers.num_staff, executives.num_managers
+    #   CEO.dataset.sql
+    #   # SELECT employees.id, employees.name, employees.kind,
+    #   #        managers.num_staff, executives.num_managers
     #   # FROM employees
     #   # JOIN managers ON (managers.id = employees.id)
     #   # JOIN executives ON (executives.id = managers.id)
+    #   # WHERE (employees.kind IN ('CEO'))
     #
-    # This allows Executive.all to return instances with all attributes
+    # This allows CEO.all to return instances with all attributes
     # loaded.  The plugin overrides the deleting, inserting, and updating
     # in the model to work with multiple tables, by handling each table
     # individually.
     #
-    # This plugin allows the use of a :key option when loading to mark
-    # a column holding a class name.  This allows methods on the
-    # superclass to return instances of specific subclasses.
-    # This plugin also requires the lazy_attributes plugin and uses it to
-    # return subclass specific attributes that would not be loaded
+    # = Subclass loading
+    #
+    # When model objects are retrieved for a superclass the result could be
+    # subclass objects needing additional values from other tables.
+    # This plugin can load those additional values immediately with eager
+    # loading or when requested on the model object with lazy loading.
+    #
+    # With eager loading, the additional needed rows will be loaded with the
+    # all or first methods.  Note that eager loading does not work
+    # with the each method because all of the model objects must be loaded to
+    # determine the keys for each subclass table query.  In that case lazy loading can
+    # be used or the each method used on the result of the all method.
+    #
+    # Unless lazy loading is disabled, the lazy_attributes plugin will be
+    # included to return subclass specific values that were not loaded
     # when calling superclass methods (since those wouldn't join
     # to the subclass tables).  For example:
     #
@@ -67,171 +88,245 @@ module Sequel
     # via the superclass, call Model#refresh.
     #
     #   a = Employee.first
-    #   a.values # {:id=>1, name=>'S', :kind=>'Executive'}
+    #   a.values # {:id=>1, name=>'S', :kind=>'CEO'}
     #   a.refresh.values # {:id=>1, name=>'S', :kind=>'Executive', :num_staff=>4, :num_managers=>2}
-    # 
-    # Usage:
     #
-    #   # Set up class table inheritance in the parent class
-    #   # (Not in the subclasses)
+    # The option :subclass_load sets the default subclass loading strategy.
+    # It accepts :eager, :eager_only, :lazy or :lazy_only with a default of :lazy
+    # The _only options will only allow that strategy to be used.
+    # In addition eager or lazy can be called on a dataset to override the default
+    # strategy used assuming an _only option was not set.
+    #
+    # = Usage
+    #
+    #   # Use the default of storing the class name in the sti_key
+    #   # column (:kind in this case)
     #   class Employee < Sequel::Model
-    #     plugin :class_table_inheritance
+    #     plugin :class_table_inheritance, :key=>:kind
     #   end
     #
     #   # Have subclasses inherit from the appropriate class
-    #   class Staff < Employee; end
-    #   class Manager < Employee; end
-    #   class Executive < Manager; end
+    #   class Staff < Employee; end    # uses staff table
+    #   class Cook < Staff; end        # cooks table doesn't exist so uses staff table
+    #   class Manager < Employee; end  # uses managers table
+    #   class Executive < Manager; end # uses executives table
+    #   class CEO < Executive; end     # ceos table doesn't exist so uses executives table
     #
-    #   # You can also set options when loading the plugin:
-    #   # :kind :: column to hold the class name
-    #   # :table_map :: map of class name symbols to table name symbols
-    #   # :model_map :: map of column values to class name symbols
-    #   Employee.plugin :class_table_inheritance, :key=>:kind, :table_map=>{:Staff=>:staff},
-    #     :model_map=>{1=>:Employee, 2=>:Manager, 3=>:Executive, 4=>:Staff}
+    #   # Some examples of using these options:
+    #
+    #   # Specifying the tables with a :table_map hash
+    #   Employee.plugin :class_table_inheritance,
+    #     :table_map=>{:Employee  => :employees,
+    #                  :Staff     => :staff,
+    #                  :Cook      => :staff,
+    #                  :Manager   => :managers,
+    #                  :Executive => :executives,
+    #                  :CEO       => :executives }
+    #
+    #   # Using integers to store the class type, with a :model_map hash
+    #   # and an sti_key of :type
+    #   Employee.plugin :class_table_inheritance, :type,
+    #     :model_map=>{1=>:Staff, 2=>:Cook, 3=>:Manager, 4=>:Executive, 5=>:CEO}
+    #
+    #   # Using non-class name strings
+    #   Employee.plugin :class_table_inheritance, :key=>:type,
+    #     :model_map=>{'staff'=>:Staff, 'cook staff'=>:Cook, 'supervisor'=>:Manager}
+    #
+    #   # By default the plugin sets the respective column value
+    #   # when a new instance is created.
+    #   Cook.create.type == 'cook staff'
+    #   Manager.create.type == 'supervisor'
+    #
+    #   # You can customize this behavior with the :key_chooser option.
+    #   # This is most useful when using a non-bijective mapping.
+    #   Employee.plugin :class_table_inheritance, :key=>:type,
+    #     :model_map=>{'cook staff'=>:Cook, 'supervisor'=>:Manager},
+    #     :key_chooser=>proc{|instance| instance.model.sti_key_map[instance.model.to_s].first || 'stranger' }
+    #
+    #   # Using custom procs, with :model_map taking column values
+    #   # and yielding either a class, string, symbol, or nil,
+    #   # and :key_map taking a class object and returning the column
+    #   # value to use
+    #   Employee.plugin :single_table_inheritance, :key=>:type,
+    #     :model_map=>proc{|v| v.reverse},
+    #     :key_map=>proc{|klass| klass.name.reverse}
+    #
+    #   # You can use the same class for multiple values.
+    #   # This is mainly useful when the sti_key column contains multiple values
+    #   # which are different but do not require different code.
+    #   Employee.plugin :single_table_inheritance, :key=>:type,
+    #     :model_map=>{'staff' => "Staff",
+    #                  'manager' => "Manager",
+    #                  'overpayed staff' => "Staff",
+    #                  'underpayed staff' => "Staff"}
+    #
+    # One minor issue to note is that if you specify the <tt>:key_map</tt>
+    # option as a hash, instead of having it inferred from the <tt>:model_map</tt>,
+    # you should only use class name strings as keys, you should not use symbols
+    # as keys.
     module ClassTableInheritance
-      # The class_table_inheritance plugin requires the lazy_attributes plugin
-      # to handle lazily-loaded attributes for subclass instances returned
-      # by superclass methods.
-      def self.apply(model, opts=OPTS)
-        model.plugin :lazy_attributes
+      # The class_table_inheritance plugin requires the single_table_inheritance
+      # plugin and the lazy_attributes plugin to handle lazily-loaded attributes
+      # for subclass instances returned by superclass methods.
+      def self.apply(model, opts = OPTS)
+        model.plugin :single_table_inheritance, nil
+        model.plugin :lazy_attributes unless opts[:subclass_load] == :eager_only
       end
-      
-      # Initialize the per-model data structures and set the dataset's row_proc
-      # to check for the :key option column for the type of class when loading objects.
-      # Options:
-      # :key :: The column symbol holding the name of the model class this
-      #         is an instance of.  Necessary if you want to call model methods
-      #         using the superclass, but have them return subclass instances.
-      # :table_map :: Hash with class name symbol keys and table name symbol
-      #               values.  Necessary if the implicit table name for the model class
-      #               does not match the database table name
-      # :model_map :: Hash with keys being values of the cti_key column, and values
-      #               being class name strings or symbols.  Used if you don't want to
-      #               store class names in the database.  If you use this option, you
-      #               are responsible for setting the values of the cti_key column
-      #               manually (usually in a before_create hook).
-      def self.configure(model, opts=OPTS)
+
+      # Initialize the plugin using the following options:
+      # :key :: Column symbol that holds the key that identifies the class to use.
+      #         Necessary if you want to call model methods on a superclass
+      #         that return subclass instances
+      # :model_map :: Hash or proc mapping the key column values to model class names.
+      # :key_map :: Hash or proc mapping model class names to key column values.
+      #             Each value or return is an array of possible key column values.
+      # :key_chooser :: proc returning key for the provided model instance
+      # :table_map :: Hash with class name symbols keys mapping to table name symbol values
+      #               Overrides implicit table names
+      # :subclass_load :: Subclass loading strategy,
+      #                   options are :eager, :eager_only, :lazy or :lazy_only.
+      #                   Defaults to :lazy.
+      def self.configure(model, opts = OPTS)
+        SingleTableInheritance.configure model, opts[:key], opts
+
         model.instance_eval do
-          @cti_base_model = self
-          @cti_key = opts[:key] 
+          @cti_subclass_load = opts[:subclass_load]
+          @cti_subclass_datasets = {}
+          @cti_models = [self]
           @cti_tables = [table_name]
-          @cti_columns = {table_name=>columns}
+          @cti_instance_dataset = @instance_dataset
+          @cti_table_columns = columns
           @cti_table_map = opts[:table_map] || {}
-          @cti_model_map = opts[:model_map]
-          set_dataset_cti_row_proc
-          set_dataset(dataset.select(*columns.map{|c| Sequel.qualify(table_name, Sequel.identifier(c))}))
         end
       end
 
       module ClassMethods
+        # An array of each model in the inheritance hierarchy that uses an
+        # backed by a new table.
+        attr_reader :cti_models
+
         # The parent/root/base model for this class table inheritance hierarchy.
-        # This is the only model in the hierarchy that load the
+        # This is the only model in the hierarchy that loads the
         # class_table_inheritance plugin.
-        attr_reader :cti_base_model
-        
-        # Hash with table name symbol keys and arrays of column symbol values,
+        # Only needed to be compatible with class_table_inheritance plugin
+        def cti_base_model
+          @cti_models.first
+        end
+
+        # Last model in the inheritance hierarchy to use a new table
+        def cti_table_model
+          @cti_models.last
+        end
+
+        # A hash with subclass models keys and datasets to load that subclass
+        # assuming the current model has already been loaded.
+        # Used for eager loading
+        attr_reader :cti_subclass_datasets
+
+        # Eager loading option
+        attr_reader :cti_subclass_load
+
+        # An array of column symbols for the backing database table,
         # giving the columns to update in each backing database table.
-        attr_reader :cti_columns
-        
-        # The column containing the class name as a string.  Used to
-        # return instances of subclasses when calling the superclass's
-        # load method.
-        attr_reader :cti_key
-        
-        # A hash with keys being values of the cti_key column, and values
-        # being class name strings or symbols.  Used if you don't want to
-        # store class names in the database.
-        attr_reader :cti_model_map
-        
+        attr_reader :cti_table_columns
+
+        # The dataset that table instance datasets are based on.
+        # Used for database modifications
+        attr_reader :cti_instance_dataset
+
         # An array of table symbols that back this model.  The first is
         # cti_base_model table symbol, and the last is the current model
         # table symbol.
         attr_reader :cti_tables
-        
+
         # A hash with class name symbol keys and table name symbol values.
         # Specified with the :table_map option to the plugin, and used if
         # the implicit naming is incorrect.
         attr_reader :cti_table_map
 
-        Plugins.inherited_instance_variables(self, :@cti_key=>nil, :@cti_model_map=>nil, :@cti_table_map=>nil)
+        # Hash with table name symbol keys and arrays of column symbol values,
+        # giving the columns to update in each backing database table.
+        # Only needed to be compatible with class_table_inheritance plugin
+        def cti_columns
+          h = {}
+          cti_models.each { |m| h[m.table_name] = m.cti_table_columns }
+          h
+        end
 
-        # Add the appropriate data structures to the subclass.  Does not
-        # allow anonymous subclasses to be created, since they would not
-        # be mappable to a table.
+        # Alias to single_table_inheritance methods to be compatible with
+        # class_table_inheritance plugin
+        def cti_key; sti_key; end
+        def cti_model_map; sti_model_map; end
+
+        Plugins.inherited_instance_variables(self, :@cti_models=>nil, :@cti_tables=>nil, :@cti_table_columns=>nil, :@cti_instance_dataset=>nil, :@cti_subclass_load=>nil, :@cti_table_map=>nil, :@cti_subclass_datasets=>proc{|v| {} })
+
         def inherited(subclass)
-          cc = cti_columns
-          ct = cti_tables.dup
-          ctm = cti_table_map
-          cbm = cti_base_model
-          pk = primary_key
-          ds = dataset
+          ds = sti_dataset
+
+          # Prevent inherited in model/base.rb from setting the dataset
+          subclass.instance_eval { @dataset = nil }
+
+          super
+
+          # Set table if this is a class table inheritance
           table = nil
           columns = nil
-          subclass.instance_eval do
-            raise(Error, "cannot create anonymous subclass for model class using class_table_inheritance") if !(n = name) || n.empty?
-            table = ctm[n.to_sym] || implicit_table_name
-            columns = db.from(table).columns
-            @cti_tables = ct + [table]
-            @cti_columns = cc.merge(table=>columns)
-            @cti_base_model = cbm
-            # Need to set dataset and columns before calling super so that
-            # the main column accessor module is included in the class before any
-            # plugin accessor modules (such as the lazy attributes accessor module).
-            set_dataset(ds.join(table, pk=>pk).select_append(*(columns - [primary_key]).map{|c| Sequel.qualify(table, Sequel.identifier(c))}))
-            set_columns(self.columns)
-          end
-          super
-          subclass.instance_eval do
-            set_dataset_cti_row_proc
-            (columns - [cbm.primary_key]).each{|a| define_lazy_attribute_getter(a, :dataset=>dataset, :table=>table)}
-            cti_tables.reverse.each do |t|
-              db.schema(t).each{|k,v| db_schema[k] = v}
-            end
-          end
-        end
-        
-        # The primary key in the parent/base/root model, which should have a
-        # foreign key with the same name referencing it in each model subclass.
-        def primary_key
-          return super if self == cti_base_model
-          cti_base_model.primary_key
-        end
-        
-        # The table name for the current model class's main table (not used
-        # by any superclasses).
-        def table_name
-          self == cti_base_model ? super : cti_tables.last
-        end
-
-        private
-
-        # If calling set_dataset manually, make sure to set the dataset
-        # row proc to one that handles inheritance correctly.
-        def set_dataset_row_proc(ds)
-          ds.row_proc = @dataset.row_proc if @dataset
-        end
-
-        # Set the row_proc for the model's dataset appropriately
-        # based on the cti key and model map.
-        def set_dataset_cti_row_proc
-          m = method(:constantize)
-          dataset.row_proc = if ck = cti_key
-            if model_map = cti_model_map
-              lambda do |r|
-                mod = if name = model_map[r[ck]]
-                  m.call(name)
-                else
-                  self
-                end
-                mod.call(r)
-              end
+          if (n = subclass.name) && !n.empty?
+            if table = cti_table_map[n.to_sym]
+              columns = db.from(table).columns
             else
-              lambda{|r| (m.call(r[ck]) rescue self).call(r)}
+              table = subclass.implicit_table_name
+              columns = db.from(table).columns rescue nil
+              table = nil if !columns || columns.empty?
             end
-          else
-            self
           end
+          table = nil if table && (table == table_name)
+
+          return unless table
+
+          pk = primary_key
+          subclass.instance_eval do
+            if cti_tables.length == 1
+              ds = ds.select(*self.columns.map{|cc| Sequel.qualify(table_name, Sequel.identifier(cc))})
+            end
+            sel_app = (columns - [pk]).map{|cc| Sequel.qualify(table, Sequel.identifier(cc))}
+            @sti_dataset = ds.join(table, pk=>pk).select_append(*sel_app)
+            set_dataset(@sti_dataset)
+            set_columns(self.columns)
+            dataset.row_proc = lambda{|r| subclass.sti_load(r)}
+
+            unless cti_subclass_load == :lazy_only
+              cti_models.each do |model|
+                sd = model.instance_variable_get(:@cti_subclass_datasets)
+                unless d = sd[cti_table_model]
+                  sd[self] = db.from(table).select(*columns.map{|cc| Sequel.qualify(table, Sequel.identifier(cc))})
+                else
+                  sd[self] = d.join(table, pk=>pk).select_append(*sel_app)
+                end
+              end
+            end
+            unless cti_subclass_load == :eager_only
+              (columns - [pk]).each{|a| define_lazy_attribute_getter(a, :dataset=>dataset, :table=>table)}
+            end
+
+            @cti_models += [self]
+            @cti_tables += [table]
+            @cti_table_columns = columns
+            @cti_instance_dataset = db.from(table)
+
+            cti_tables.reverse.each do |ct|
+              db.schema(ct).each{|sk,v| db_schema[sk] = v}
+            end
+          end
+        end
+
+        # The table name for the current model class's main table.
+        def table_name
+          cti_tables ? cti_tables.last : super
+        end
+
+        def sti_class_from_key(key)
+          sti_class(sti_model_map[key])
         end
       end
 
@@ -240,47 +335,131 @@ module Sequel
         # most recent table and going through all superclasses.
         def delete
           raise Sequel::Error, "can't delete frozen object" if frozen?
-          m = model
-          m.cti_tables.reverse.each do |table|
-            m.db.from(table).filter(m.primary_key=>pk).delete
+          model.cti_models.reverse.each do |m|
+            cti_this(m).delete
           end
           self
         end
-        
+
         private
-        
-        # Set the cti_key column to the name of the model.
+
+        def cti_this(model)
+          use_server(model.cti_instance_dataset.filter(model.primary_key_hash(pk)))
+        end
+
+        # Set the sti_key column based on the sti_key_map.
         def _before_validation
-          if new? && model.cti_key && !model.cti_model_map
-            set_column_value("#{model.cti_key}=", model.name.to_s)
+          if new? && (set = self[model.sti_key])
+            exp = model.sti_key_chooser.call(self)
+            if set != exp
+              set_table = model.sti_class_from_key(set).table_name
+              exp_table = model.sti_class_from_key(exp).table_name
+              set_column_value("#{model.sti_key}=", exp) if set_table != exp_table
+            end
           end
           super
         end
-        
+
         # Insert rows into all backing tables, using the columns
-        # in each table.  
+        # in each table.
         def _insert
-          return super if model == model.cti_base_model
-          iid = @values[primary_key] 
-          m = model
-          m.cti_tables.each do |table|
-            h = {}
-            h[m.primary_key] ||= iid if iid
-            m.cti_columns[table].each{|c| h[c] = @values[c] if @values.include?(c)}
-            nid = m.db.from(table).insert(h)
-            iid ||= nid
+          return super if model.cti_tables.length == 1
+          model.cti_models.each do |m|
+            v = {}
+            m.cti_table_columns.each{|c| v[c] = @values[c] if @values.include?(c)}
+            ds = use_server(m.cti_instance_dataset)
+            if ds.supports_insert_select? && (h = ds.insert_select(v))
+              @values.merge!(h)
+            else
+              nid = ds.insert(v)
+              @values[primary_key] ||= nid
+            end
           end
-          @values[primary_key] = iid
+          db.dataset.supports_insert_select? ? nil : @values[primary_key]
         end
-        
+
         # Update rows in all backing tables, using the columns in each table.
         def _update(columns)
-          pkh = pk_hash
-          m = model
-          m.cti_tables.each do |table|
+          model.cti_models.each do |m|
             h = {}
-            m.cti_columns[table].each{|c| h[c] = columns[c] if columns.include?(c)}
-            m.db.from(table).filter(pkh).update(h) unless h.empty?
+            m.cti_table_columns.each{|c| h[c] = columns[c] if columns.include?(c)}
+            cti_this(m).update(h) unless h.empty?
+          end
+        end
+      end
+
+      module DatasetMethods
+        def single_record
+          post_load_record(super)
+        end
+
+        def with_sql_first(sql)
+          post_load_record(super)
+        end
+
+        # Set dataset to use eager loading
+        def eager
+          raise Error, "eager loading disabled" if model.cti_subclass_load == :lazy_only
+          clone(:eager_load => true)
+        end
+
+        # Set dataset to use lazy loading
+        def lazy
+          raise Error, "lazy loading disabled" if model.cti_subclass_load == :eager_only
+          clone(:eager_load => false)
+        end
+
+        # Return true if eager loading will be used, false/nil for lazy loading
+        def uses_eager_load?
+          return opts[:eager_load] unless opts[:eager_load].nil?
+          [:eager, :eager_only].include?(model.cti_subclass_load)
+        end
+
+        private
+
+        def subclass_dataset(m, keys)
+          ds = model.cti_subclass_datasets[m]
+          ds = ds.filter(m.qualified_primary_key_hash(keys, ds.first_source_alias))
+          ds
+        end
+
+        def post_load_record(r)
+          return r unless r && uses_eager_load?
+          ds = subclass_dataset(r.model.cti_table_model, r.pk)
+          r.values.merge!(ds.limit(1).first)
+          r
+        end
+
+        def post_load(records)
+          super
+          return unless uses_eager_load?
+
+          subclass_datasets = model.cti_subclass_datasets
+
+          table_key_map = Hash.new
+          records.each do |r|
+            model = r.model.cti_table_model
+            next unless subclass_datasets.key?(model)
+            table_key_map[model] = { } unless table_key_map.key?(model)
+            table_key_map[model][r.pk] = r
+          end
+
+          pkc = model.primary_key
+          table_key_map.each do |model, id_map|
+            ds = subclass_dataset(model, id_map.keys)
+            applied_set = {}
+            ds.all do |r|
+              pkv = pkc.is_a?(Array) ? pkc.map{|k| r[k]} : r[pkc]
+              m = id_map[pkv]
+              if applied_set.key?(pkv)
+                # Multiple rows for one row in original query
+                # insert is O(n) but needed if dataset is ordered.
+                # This code path should seldom if ever get used
+                records.insert(records.index(m)+1, m = m.dup)
+              end
+              applied_set[pkv] = true
+              m.values.merge!(r)
+            end
           end
         end
       end

--- a/spec/extensions/hybrid_table_inheritance_spec.rb
+++ b/spec/extensions/hybrid_table_inheritance_spec.rb
@@ -1,0 +1,242 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
+
+describe Sequel::Model, "hybrid table inheritance plugin" do
+  before do
+    @db = Sequel.mock(:autoid=>proc{|sql| 1})
+    def @db.supports_schema_parsing?() true end
+    def @db.schema(table, opts={})
+      {:employees=>[[:id, {:primary_key=>true, :type=>:integer}], [:name, {:type=>:string}], [:kind, {:type=>:string}]],
+       :managers=>[[:id, {:type=>:integer}], [:num_staff, {:type=>:integer}]],
+       :uber_managers=>[[:id, {:type=>:integer}], [:special, {:type=>:string}]],
+       :executives=>[[:id, {:type=>:integer}], [:num_managers, {:type=>:integer}]],
+       :staff=>[[:id, {:type=>:integer}], [:manager_id, {:type=>:integer}]],
+       :cooks=>[[:id, {:type=>:integer}], [:speciality, {:type=>:string}]],
+      }[table.is_a?(Sequel::Dataset) ? table.first_source_table : table]
+    end
+    @db.extend_datasets do
+      def columns
+        {[:employees]=>[:id, :name, :kind],
+         [:managers]=>[:id, :num_staff],
+         [:uber_managers]=>[:id, :special],
+         [:executives]=>[:id, :num_managers],
+         [:staff]=>[:id, :manager_id],
+         [:staff, :cooks]=>[:id, :manager_id, :speciality],
+         [:cooks]=>[:id, :speciality],
+         [:employees, :managers]=>[:id, :name, :kind, :num_staff],
+         [:employees, :managers, :uber_managers]=>[:id, :name, :kind, :num_staff, :special],
+         [:employees, :managers, :executives]=>[:id, :name, :kind, :num_staff, :num_managers],
+         [:employees, :staff]=>[:id, :name, :kind, :manager_id],
+        }[opts[:from] + (opts[:join] || []).map{|x| x.table}]
+      end
+    end
+    class ::Employee < Sequel::Model(@db)
+      def _save_refresh; @values[:id] = 1 end
+      def self.columns
+        dataset.columns
+      end
+      plugin :class_table_inheritance, :key=>:kind, :table_map=>{:Staff=>:staff}, :subclass_load => :eager
+    end
+    class ::Unmanaged < Employee; end
+    class ::Manager < Employee
+      one_to_many :staff_members, :class=>:Staff
+    end
+    class ::SmartManager < Manager; end
+    class ::GeniusManager < SmartManager; end
+    class ::UberManager < SmartManager; end
+    class ::DumbManager < Manager; end
+    class ::Executive < Manager; end
+    class ::Staff < Employee
+      many_to_one :manager
+    end
+    class ::Cook < Staff; end
+
+    @ds = Employee.dataset
+  end
+
+  def remove_subclasses
+    Object.send(:remove_const, :Unmanaged)
+    Object.send(:remove_const, :Executive)
+    Object.send(:remove_const, :Manager)
+    Object.send(:remove_const, :SmartManager)
+    Object.send(:remove_const, :GeniusManager)
+    Object.send(:remove_const, :UberManager)
+    Object.send(:remove_const, :DumbManager)
+    Object.send(:remove_const, :Staff)
+    Object.send(:remove_const, :Cook)
+  end
+
+  after do
+    remove_subclasses
+    Object.send(:remove_const, :Employee)
+  end
+
+  def should_datasets
+    Unmanaged.dataset.sql.must_equal "SELECT * FROM employees WHERE (employees.kind IN ('Unmanaged'))"
+    Manager.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, managers.num_staff FROM employees INNER JOIN managers ON (managers.id = employees.id)"
+    SmartManager.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, managers.num_staff FROM employees INNER JOIN managers ON (managers.id = employees.id) WHERE (employees.kind IN ('SmartManager', 'GeniusManager', 'UberManager'))"
+    GeniusManager.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, managers.num_staff FROM employees INNER JOIN managers ON (managers.id = employees.id) WHERE (employees.kind IN ('GeniusManager'))"
+    UberManager.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, managers.num_staff, uber_managers.special FROM employees INNER JOIN managers ON (managers.id = employees.id) INNER JOIN uber_managers ON (uber_managers.id = managers.id)"
+    DumbManager.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, managers.num_staff FROM employees INNER JOIN managers ON (managers.id = employees.id) WHERE (employees.kind IN ('DumbManager'))"
+    Executive.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, managers.num_staff, executives.num_managers FROM employees INNER JOIN managers ON (managers.id = employees.id) INNER JOIN executives ON (executives.id = managers.id)"
+    Staff.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, staff.manager_id FROM employees INNER JOIN staff ON (staff.id = employees.id)"
+    Cook.dataset.sql.must_equal "SELECT employees.id, employees.name, employees.kind, staff.manager_id, cooks.speciality FROM employees INNER JOIN staff ON (staff.id = employees.id) INNER JOIN cooks ON (cooks.id = staff.id)"
+  end
+
+  specify "should implicity determine dataset" do
+    should_datasets
+  end
+
+  specify "should explicity determine dataset" do
+    table_map = {
+        :Employee => :employees,
+        :Unmanaged => :employees,
+        :Manager => :managers,
+        :SmartManager => :managers,
+        :GeniusManager => :managers,
+        :UberManager => :uber_managers,
+        :DumbManager => :managers,
+        :Executive => :executives,
+        :Staff => :staff,
+        :Cook => :cooks
+    }
+    Employee.plugin :class_table_inheritance, :key=>:kind, :table_map=>table_map, :subclass_load => :eager
+    remove_subclasses
+    class ::Unmanaged < Employee; end
+    class ::Manager < Employee
+      one_to_many :staff_members, :class=>:Staff
+    end
+    class ::SmartManager < Manager; end
+    class ::GeniusManager < SmartManager; end
+    class ::UberManager < SmartManager; end
+    class ::DumbManager < Manager; end
+    class ::Executive < Manager; end
+    class ::Staff < Employee
+      many_to_one :manager
+    end
+    class ::Cook < Staff; end
+
+    should_datasets
+  end
+
+  it "should allow setting and overriding subclass loading options" do
+    Employee.dataset.uses_eager_load?.must_equal true
+    Employee.dataset.eager.uses_eager_load?.must_equal true
+    Employee.dataset.lazy.uses_eager_load?.must_equal false
+
+    Employee.plugin :class_table_inheritance, :subclass_load => :lazy
+    Employee.dataset.uses_eager_load?.must_equal false
+    Employee.dataset.lazy.uses_eager_load?.must_equal false
+    Employee.dataset.eager.uses_eager_load?.must_equal true
+
+    Employee.plugin :class_table_inheritance, :subclass_load => :eager_only
+    Employee.dataset.uses_eager_load?.must_equal true
+    Employee.dataset.eager.uses_eager_load?.must_equal true
+    proc{Employee.dataset.lazy.uses_eager_load?}.must_raise(Sequel::Error)
+
+    Employee.plugin :class_table_inheritance, :subclass_load => :lazy_only
+    Employee.dataset.uses_eager_load?.must_equal false
+    Employee.dataset.lazy.uses_eager_load?.must_equal false
+    proc{Employee.dataset.eager.uses_eager_load?}.must_raise(Sequel::Error)
+  end
+
+  it "should initialize subclass datasets" do
+    Employee.cti_subclass_datasets.collect { |k, ds| [k, ds.sql] }.must_equal [
+        [Manager, "SELECT managers.id, managers.num_staff FROM managers"],
+        [UberManager, "SELECT managers.id, managers.num_staff, uber_managers.special FROM managers INNER JOIN uber_managers ON (uber_managers.id = managers.id)"],
+        [Executive, "SELECT managers.id, managers.num_staff, executives.num_managers FROM managers INNER JOIN executives ON (executives.id = managers.id)"],
+        [Staff, "SELECT staff.id, staff.manager_id FROM staff"],
+        [Cook, "SELECT staff.id, staff.manager_id, cooks.speciality FROM staff INNER JOIN cooks ON (cooks.id = staff.id)"]
+    ]
+    Manager.cti_subclass_datasets.collect { |k, ds| [k, ds.sql] }.must_equal [
+        [UberManager, "SELECT uber_managers.id, uber_managers.special FROM uber_managers"],
+        [Executive, "SELECT executives.id, executives.num_managers FROM executives"]
+        ]
+    Staff.cti_subclass_datasets.collect { |k, ds| [k, ds.sql] }.must_equal [
+        [Cook, "SELECT cooks.id, cooks.speciality FROM cooks"]
+    ]
+    [Unmanaged, SmartManager, GeniusManager, UberManager, DumbManager, Executive].each do |klass|
+      klass.cti_subclass_datasets.must_be_empty
+    end
+  end
+
+  it "should eager load subclasses with first" do
+    Employee.dataset._fetch = [ { :id=>1, :kind => 'Executive', :name=>'Tim'} ]
+    Employee.cti_subclass_datasets[Executive]._fetch = [
+        { :id=>1, :num_managers => 4 },
+    ]
+    rec = Employee.first
+    rec.class.must_equal Executive
+    rec.values.must_equal(:id=>1, :kind => 'Executive', :name=>'Tim', :num_managers => 4)
+    @db.sqls.must_equal [
+        "SELECT * FROM employees LIMIT 1",
+        "SELECT managers.id, managers.num_staff, executives.num_managers FROM managers INNER JOIN executives ON (executives.id = managers.id) WHERE (managers.id = 1) LIMIT 1",
+    ]
+  end
+
+  it "should eager load subclasses with all" do
+    Employee.dataset._fetch = [
+        { :id=>1, :kind=>'Unmanaged', :name=>'Mr Unmanagable'},
+        { :id=>2, :kind=>'SmartManager', :name=>'Joe'},
+        { :id=>3, :kind=>'GeniusManager', :name=>'Steve'},
+        { :id=>4, :kind=>'UberManager', :name=>'Jesus'},
+        { :id=>5, :kind=>'DumbManager', :name=>'Erkle'},
+        { :id=>6, :kind=>'Executive', :name=>'Tim'},
+        { :id=>7, :kind=>'Staff', :name=>'Kim'},
+    ]
+    Employee.cti_subclass_datasets[Manager]._fetch = [
+        { :id=>2, :num_staff=>1 },
+        { :id=>3, :num_staff=>2 },
+        { :id=>5, :num_staff=>3 },
+    ]
+    Employee.cti_subclass_datasets[UberManager]._fetch = [
+        { :id=>4, :num_staff=>4, :special=>'Very Special' },
+        { :id=>4, :num_staff=>4, :special=>'Very Special Duplicate' }
+    ]
+    Employee.cti_subclass_datasets[Executive]._fetch = [
+        { :id=>6, :num_managers=>5 },
+    ]
+    Employee.cti_subclass_datasets[Staff]._fetch = [
+        { :id=>7, :manager_id=>2 },
+    ]
+    list = Employee.all
+    list.collect{|x| [x.class, x.values] }.must_equal [
+        [Unmanaged,     {:id=>1, :kind=>"Unmanaged", :name=>"Mr Unmanagable"}],
+        [SmartManager,  {:id=>2, :kind=>"SmartManager", :name=>"Joe", :num_staff=>1} ],
+        [GeniusManager, {:id=>3, :kind=>"GeniusManager", :name=>"Steve", :num_staff=>2}],
+        [UberManager,   {:id=>4, :kind=>"UberManager", :name=>"Jesus", :num_staff=>4, :special=>'Very Special'}],
+        [UberManager,   {:id=>4, :kind=>"UberManager", :name=>"Jesus", :num_staff=>4, :special=>'Very Special Duplicate'}],
+        [DumbManager,   {:id=>5, :kind=>"DumbManager", :name=>"Erkle", :num_staff=>3}],
+        [Executive,     {:id=>6, :kind=>"Executive", :name=>"Tim", :num_managers=>5}],
+        [Staff,         {:id=>7, :kind=>"Staff", :name=>"Kim", :manager_id => 2}]
+    ]
+    @db.sqls.must_equal [
+        "SELECT * FROM employees",
+        "SELECT managers.id, managers.num_staff FROM managers WHERE (managers.id IN (2, 3, 5))",
+        "SELECT managers.id, managers.num_staff, uber_managers.special FROM managers INNER JOIN uber_managers ON (uber_managers.id = managers.id) WHERE (managers.id IN (4))",
+        "SELECT managers.id, managers.num_staff, executives.num_managers FROM managers INNER JOIN executives ON (executives.id = managers.id) WHERE (managers.id IN (6))",
+        "SELECT staff.id, staff.manager_id FROM staff WHERE (staff.id IN (7))"
+    ]
+  end
+
+  it "should eager load many_to_one relationships correctly" do
+    Manager.dataset._fetch = {:id=>3, :name=>'E', :kind=>'Executive'}
+    Manager.cti_subclass_datasets[Executive]._fetch = { :id=>3, :num_managers=>3}
+    ldr = Staff.load(:manager_id=>3)
+    res = ldr.manager
+    res.must_equal Executive.load(:id=>3, :name=>'E', :kind=>'Executive', :num_managers=>3)
+    @db.sqls.must_equal [
+        'SELECT employees.id, employees.name, employees.kind, managers.num_staff FROM employees INNER JOIN managers ON (managers.id = employees.id) WHERE (managers.id = 3) LIMIT 1',
+        'SELECT executives.id, executives.num_managers FROM executives WHERE (executives.id = 3) LIMIT 1'
+    ]
+  end
+
+  it "should eager load one_to_many relationships correctly" do
+    Staff.dataset._fetch = {:id=>1, :name=>'S', :kind=>'Cook', :manager_id=>3}
+    Staff.cti_subclass_datasets[Cook]._fetch = { :id=>1, :speciality=>'Burgers'}
+    Executive.load(:id=>3).staff_members.must_equal [Cook.load(:id=>1, :name=>'S', :kind=>'Cook', :manager_id=>3, :speciality=>'Burgers')]
+    @db.sqls.must_equal [
+        'SELECT employees.id, employees.name, employees.kind, staff.manager_id FROM employees INNER JOIN staff ON (staff.id = employees.id) WHERE (staff.manager_id = 3)',
+        'SELECT cooks.id, cooks.speciality FROM cooks WHERE (cooks.id IN (1))'
+    ]
+  end
+end


### PR DESCRIPTION
This PR is the minimal change to replace the class_table_inheritance plugin with the hybrid_table_inheritance at http://github.com/QuinnHarris/sequel-table_inheritance
This adds and additional hybrid_table_inheritance_spec.rb test with test specific to features added over the existing class_table_inheritance plugin.
