### PR TITLE
Fixed syntax error for jRuby 1.7.20 related to Java::JavaMath::BigDec…

### DIFF
--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -49,7 +49,9 @@ module Sequel
       # arbitrary code execution.
       def self.add_type_method(*types)
         types.each do |type|
-          class_eval("def #{type}(name, opts={}); column(name, #{type}, opts); end", __FILE__, __LINE__)
+          type_name = type.name
+          type_name = type_name.split('::').last if /::/ =~ type_name
+          class_eval("def #{type_name}(name, opts={}); column(name, #{type_name}, opts); end", __FILE__, __LINE__)
         end
       end
       


### PR DESCRIPTION
I got the error below when the gem is loaded with "require" using jruby 1.7.20. BigDecimal is converted to Java::JavaMath::BigDecimal and the definition of the generated method fails with syntax error on schema_generator. This PR fixed the issue but I'm not sure if it has side effects. Let me know what you think, thanks!

17:02:13,635 INFO  [stdout] (pool-1-thread-1) *** ovs_models exception: /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database/schema_generator.rb:52: syntax error, unexpected tCOLON2
17:02:13,636 INFO  [stdout] (pool-1-thread-1) def Java::JavaMath::BigDecimal(name, opts={}); column(name, Java::JavaMath::BigDecimal, opts); end
17:02:13,636 INFO  [stdout] (pool-1-thread-1)                    ^
17:02:13,638 INFO  [stdout] (pool-1-thread-1) *** ovs_models exception backtrace: org/jruby/RubyModule.java:2356:in `module_eval'
17:02:13,638 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database/schema_generator.rb:52:in `add_type_method'
17:02:13,639 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyArray.java:1613:in `each'
17:02:13,639 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database/schema_generator.rb:51:in `add_type_method'
17:02:13,639 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database/schema_generator.rb:286:in `CreateTableGenerator'
17:02:13,639 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database/schema_generator.rb:17:in `Schema'
17:02:13,639 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database/schema_generator.rb:3:in `Sequel'
17:02:13,640 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database/schema_generator.rb:1:in `(root)'
17:02:13,640 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyKernel.java:1072:in `require'
17:02:13,641 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:1:in `(root)'
17:02:13,641 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyArray.java:1613:in `each'
17:02:13,641 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:204:in `require'
17:02:13,641 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:204:in `require'
17:02:13,642 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database.rb:19:in `Sequel'
17:02:13,642 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyKernel.java:1072:in `require'
17:02:13,642 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/database.rb:1:in `(root)'
17:02:13,642 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyArray.java:1613:in `each'
17:02:13,642 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:1:in `(root)'
17:02:13,643 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:204:in `require'
17:02:13,643 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:204:in `require'
17:02:13,643 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyKernel.java:1072:in `require'
17:02:13,643 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:390:in `Sequel'
17:02:13,644 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyKernel.java:1072:in `require'
17:02:13,645 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/core.rb:22:in `(root)'
17:02:13,645 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyKernel.java:1072:in `require'
17:02:13,645 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/model.rb:1:in `(root)'
17:02:13,646 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyKernel.java:1072:in `require'
17:02:13,646 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel/model.rb:1:in `(root)'
17:02:13,646 INFO  [stdout] (pool-1-thread-1) org/jruby/RubyKernel.java:1072:in `require'
17:02:13,646 INFO  [stdout] (pool-1-thread-1) /home/vagrant/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/sequel-4.23.0/lib/sequel.rb:1:in `(root)'