### PR TITLE
Make the dirty plugin notice when a serialized column is changed.

### DIFF
--- a/lib/sequel/plugins/dirty.rb
+++ b/lib/sequel/plugins/dirty.rb
@@ -38,7 +38,13 @@ module Sequel
     #   artist.update(:name=>'Bar')
     #   artist.column_changes        # => {}
     #   artist.previous_changes      # => {:name=>['Foo', 'Bar']}
-    # 
+    #
+    # There is one caveat; when used with a column that also uses the
+    # serialization plugin, setting the column back to its original value
+    # after changing it is not correctly detected and will leave an entry
+    # in changed_columns.
+    #
+    #
     # Usage:
     #
     #   # Make all model subclass instances record previous values (called before loading subclasses)

--- a/lib/sequel/plugins/serialization.rb
+++ b/lib/sequel/plugins/serialization.rb
@@ -165,6 +165,10 @@ module Sequel
               define_method("#{column}=") do |v| 
                 if !changed_columns.include?(column) && (new? || get_column_value(column) != v)
                   changed_columns << column
+
+                  if respond_to? :will_change_column
+                    will_change_column(column)
+                  end
                 end
 
                 deserialized_values[column] = v

--- a/spec/extensions/serialization_spec.rb
+++ b/spec/extensions/serialization_spec.rb
@@ -338,4 +338,25 @@ describe "Serialization plugin" do
     o.def = 'hello2'
     o.changed_columns.must_equal [:abc, :def]
   end
+
+  it "should update column_changes if the dirty plugin is used" do
+    @c.plugin :serialization, :yaml, :abc, :def
+    @c.plugin :dirty
+    @c.dataset._fetch = {:id => 1, :abc => "--- 1\n", :def => "--- hello\n"}
+    o = @c.first
+    o.column_changes.must_equal({})
+    o.abc = 1
+    o.column_changes.must_equal({})
+    o.abc = 1
+    o.column_changes.must_equal({})
+    o.abc = 2
+    o.column_changes.must_equal(:abc=>[1, 2])
+    o.def = 'hello'
+    o.column_changes.must_equal(:abc=>[1, 2])
+    o.def = 'hello'
+    o.column_changes.must_equal(:abc=>[1, 2])
+    o.def = 'hello2'
+    o.column_changes.must_equal(:abc=>[1, 2], :def=>["hello", "hello2"])
+  end
+
 end


### PR DESCRIPTION
This PR makes the dirty plugin a bit more aware of changes happening inside serialized columns.

Previously, changing a serialized column made an entry in `changed_columns`, but not in `column_changes` (and hence `initial_values` etc) which was a bit inconsistent.

Now, everything in the dirty plugin is aware of the change. However this does bring about a new caveat - changing a serialized column from its initial value, then back again, leaves an entry in the dirty plugin structures (which the dirty plugin is supposed to prevent in the first place).

I couldn't see how to fix this (reset_column didn't seem to work) but I still think the new behaviour is an improvement, so I just added a note to the docs about it.