### PR TITLE
Fix unquoted collate argument when creating columns

### DIFF
--- a/lib/sequel/database/schema_methods.rb
+++ b/lib/sequel/database/schema_methods.rb
@@ -524,7 +524,7 @@ module Sequel
 
     # Add collate SQL fragment to column creation SQL.
     def column_definition_collate_sql(sql, column)
-      sql << " COLLATE #{column[:collate]}" if column[:collate]
+      sql << " COLLATE #{quote_identifier(column[:collate])}" if column[:collate]
     end
 
     # Add default SQL fragment to column creation SQL.


### PR DESCRIPTION
I was getting an error trying to use `collate` on PostgreSQL:

```ruby
DB.create_table :configurations do
  primary_key :id
  String :test, null: false, collate: 'C'
end
```
resulted in:

```ruby
Sequel::DatabaseError: PG::UndefinedObject: ERROR:  collation "c" for encoding "UTF8" does not exist
LINE 1: ...figurations" ("id" serial PRIMARY KEY, "test" text COLLATE C ...
```

(unquoted argument to COLLATE)

This PR adds `quote_identifier` to it which fixes it (not sure if it should be `quote_identifier` or `literal` though)