### PR TITLE
Add set_extra and update_extra model instance methods

### DIFF
--- a/doc/mass_assignment.rdoc
+++ b/doc/mass_assignment.rdoc
@@ -36,7 +36,13 @@ By default, if an invalid setter method call is attempted, Sequel raises a <tt>S
   # Instance level
   post.strict_param_setting = false
 
-In addition to +set_only+ and +update_only+, Sequel also has +set_fields+ and +update_fields+ methods, and these may be a better mass assignment choice for most users.
+Note that +set_only+ and +update_only+ will ignore your previously defined +allowed_columns+ and raise an error for any columns not explicitly provided by your call. If you'd like to extend your model's allowed columns instead, you can use +set_extra+ and +update_extra+. These methods allow you to modify the fields that you explicity provided *plus* any of your +allowed_columns+.
+
+  post.set_extra(params[:post], :date)
+
+In this case, the <tt>date=</tt> method will be allowed in the mass assignment in addition to the previously defined allowed columns of <tt>title=</tt>, <tt>body=</tt>, and <tt>category=</tt>.
+
+In addition to +set_only+, +set_extra+, +update_only+, and +update_extra+, Sequel also has +set_fields+ and +update_fields+ methods, and these may be a better mass assignment choice for most users.
 These methods take two arguments, the attributes hash as the first argument, and a single array of valid field names as the second argument:
 
   post.set_fields(params[:post], [:title, :body])

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1648,6 +1648,20 @@ module Sequel
       def set_only(hash, *only)
         set_restricted(hash, only.flatten)
       end
+
+      # Set the values using the entries in the hash, only if the key
+      # is included in extra OR model.allowed_columns.
+      #
+      #   Artist.set_allowed_columns(:name)
+      #
+      #   artist.set_extra({:name=>'Jim', :age => 30}, :age)
+      #   artist.name # => 'Jim'
+      #   artist.age # => 30
+      #
+      #   artist.set_extra({:hometown=>'LA'}, :age) # Raise Error
+      def set_extra(hash, *extra)
+        set_restricted(hash, [model.allowed_columns, extra].flatten)
+      end
   
       # Set the shard that this object is tied to.  Returns self.
       def set_server(s)
@@ -1720,6 +1734,19 @@ module Sequel
         update_restricted(hash, only.flatten)
       end
       
+      # Update the values using the entries in the hash, only if the key
+      # is included in extra OR model.allowed_columns.
+      #
+      #   Artist.set_allowed_columns(:name)
+      #
+      #   artist.update_extra({:name=>'Jim', :age => 30}, :age)
+      #   # UPDATE artists SET name = 'Jim', age = 30 WHERE (id = 1)
+      #
+      #   artist.update_extra({:hometown=>'LA'}, :age) # Raise Error
+      def update_extra(hash, *extra)
+        update_restricted(hash, [model.allowed_columns, extra].flatten)
+      end
+
       # Validates the object.  If the object is invalid, errors should be added
       # to the errors attribute.  By default, does nothing, as all models
       # are valid by default.  See the {"Model Validations" guide}[rdoc-ref:doc/validations.rdoc].

--- a/lib/sequel/plugins/blacklist_security.rb
+++ b/lib/sequel/plugins/blacklist_security.rb
@@ -56,7 +56,7 @@ module Sequel
         end
 
         # Set all values using the entries in the hash, except for the keys
-        # given in except.  You should probably use +set_fields+ or +set_only+
+        # given in except.  You should probably use +set_fields+, +set_only+, or +set_extra+
         # instead of this method, as blacklist approaches to security are a bad idea.
         #
         #   artist.set_except({:name=>'Jim'}, :hometown)
@@ -66,7 +66,7 @@ module Sequel
         end
     
         # Update all values using the entries in the hash, except for the keys
-        # given in except.  You should probably use +update_fields+ or +update_only+
+        # given in except.  You should probably use +update_fields+, +update_only+, or +update_extra+
         # instead of this method, as blacklist approaches to security are a bad idea.
         #
         #   artist.update_except({:name=>'Jim'}, :hometown) # UPDATE artists SET name = 'Jim' WHERE (id = 1)

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -526,7 +526,7 @@ end
 describe Sequel::Model, ".strict_param_setting" do
   before do
     @c = Class.new(Sequel::Model(:blahblah)) do
-      columns :x, :y, :z, :id
+      columns :x, :y, :z, :z2, :id
       set_allowed_columns :x, :y
     end
   end
@@ -542,9 +542,11 @@ describe Sequel::Model, ".strict_param_setting" do
     proc{c.set(:z=>1)}.must_raise(Sequel::MassAssignmentRestriction)
     proc{c.set_all(:use_after_commit_rollback => false)}.must_raise(Sequel::MassAssignmentRestriction)
     proc{c.set_only({:x=>1}, :y)}.must_raise(Sequel::MassAssignmentRestriction)
+    proc{c.set_extra({:z2=>1}, :z)}.must_raise(Sequel::MassAssignmentRestriction)
     proc{c.update(:z=>1)}.must_raise(Sequel::MassAssignmentRestriction)
     proc{c.update_all(:use_after_commit_rollback=>false)}.must_raise(Sequel::MassAssignmentRestriction)
     proc{c.update_only({:x=>1}, :y)}.must_raise(Sequel::MassAssignmentRestriction)
+    proc{c.update_extra({:z2=>1}, :z)}.must_raise(Sequel::MassAssignmentRestriction)
   end
 
   it "should be disabled by strict_param_setting = false" do


### PR DESCRIPTION
This PR adds a couple of methods that give you the option of extending your models' allowed columns while performing a set/update instead of overriding them.