### PR TITLE
Refactor DB2 REORG

### DIFF
--- a/lib/sequel/adapters/shared/db2.rb
+++ b/lib/sequel/adapters/shared/db2.rb
@@ -16,15 +16,6 @@ module Sequel
       NOT_NULL      = ' NOT NULL'.freeze
       NULL          = ''.freeze
 
-      # REORG the related table whenever it is altered.  This is not always
-      # required, but it is necessary for compatibilty with other Sequel
-      # code in many cases.
-      def alter_table(name, generator=nil)
-        res = super
-        reorg(name)
-        res
-      end
-
       # DB2 always uses :db2 as it's database type
       def database_type
         :db2
@@ -144,6 +135,16 @@ module Sequel
           end
         else
           super
+        end
+      end
+
+      # REORG the related table whenever it is altered.  This is not always
+      # required, but it is necessary for compatibilty with other Sequel
+      # code in many cases.
+      def apply_alter_table(name, ops)
+        alter_table_sql_list(name, ops).each do |sql|
+          execute_ddl(sql)
+          reorg(name)
         end
       end
 

--- a/spec/adapters/db2_spec.rb
+++ b/spec/adapters/db2_spec.rb
@@ -66,6 +66,7 @@ describe Sequel::Database do
   after do
     @db.drop_table(:items)
   end
+
   it "should parse primary keys from the schema properly" do
     @db.create_table!(:items){Integer :number}
     @db.schema(:items).collect{|k,v| k if v[:primary_key]}.compact.must_equal []
@@ -73,6 +74,17 @@ describe Sequel::Database do
     @db.schema(:items).collect{|k,v| k if v[:primary_key]}.compact.must_equal [:number]
     @db.create_table!(:items){Integer :number1, :null => false; Integer :number2, :null => false; primary_key [:number1, :number2]}
     @db.schema(:items).collect{|k,v| k if v[:primary_key]}.compact.must_equal [:number1, :number2]
+  end
+
+  it "should not error on alter_table operations that need REORG" do
+    @db.create_table!(:items) do
+      varchar :a
+    end
+    @db.alter_table(:items) do
+      add_column :b, :varchar, :null => true
+      set_column_allow_null :a, false
+      add_index :a, :unique => true
+    end
   end
 end
 


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/sequel-talk/OwaKtriHeTk

1. Moves code to REORG during `alter_table` and `table_exists?` to DB2 shared adapter.
2. Overrides `apply_alter_table` to REORG after each ALTER TABLE operation.