### PR TITLE
Save a reference to the dataset with Sequel::NoMatchingRow

### DIFF
--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -203,7 +203,7 @@ module Sequel
     # Calls first.  If first returns nil (signaling that no
     # row matches), raise a Sequel::NoMatchingRow exception.
     def first!(*args, &block)
-      first(*args, &block) || raise(Sequel::NoMatchingRow)
+      first(*args, &block) || raise(Sequel::NoMatchingRow.new(self))
     end
 
     # Return the column value for the first matching record in the dataset.

--- a/lib/sequel/exceptions.rb
+++ b/lib/sequel/exceptions.rb
@@ -52,7 +52,13 @@ module Sequel
 
   # Error raised when the user requests a record via the first! or similar
   # method, and the dataset does not yield any rows.
-  NoMatchingRow = Class.new(Error)
+  class NoMatchingRow < Error
+    attr_accessor :dataset
+
+    def initialize(dataset)
+      @dataset = dataset
+    end
+  end
 
   # Error raised when the connection pool cannot acquire a database connection
   # before the timeout.

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -468,7 +468,7 @@ module Sequel
       # An alias for calling first! on the model's dataset, but with
       # optimized handling of the single argument case.
       def first!(*args, &block)
-        first(*args, &block) || raise(Sequel::NoMatchingRow)
+        first(*args, &block) || raise(Sequel::NoMatchingRow.new(dataset))
       end
 
       # Clear the setter_methods cache when a module is included, as it
@@ -783,7 +783,7 @@ module Sequel
 
       # Return the model instance with the primary key, or raise NoMatchingRow if there is no matching record.
       def with_pk!(pk)
-        with_pk(pk) || raise(NoMatchingRow)
+        with_pk(pk) || raise(NoMatchingRow.new(dataset))
       end
   
       # Add model methods that call dataset methods
@@ -2346,7 +2346,7 @@ module Sequel
       # Same as with_pk, but raises NoMatchingRow instead of returning nil if no
       # row matches.
       def with_pk!(pk)
-        with_pk(pk) || raise(NoMatchingRow)
+        with_pk(pk) || raise(NoMatchingRow.new(self))
       end
     end
 

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -2580,6 +2580,15 @@ describe "Dataset #first!" do
   it "should raise NoMatchingRow exception if no rows match" do
     proc{Sequel.mock[:t].first!}.must_raise(Sequel::NoMatchingRow)
   end
+
+  it "saves a reference to the dataset with the exception to allow further processing" do
+    dataset = Sequel.mock[:t]
+    begin
+      dataset.first!
+    rescue Sequel::NoMatchingRow => e
+      e.dataset.must_equal(dataset)
+    end
+  end
 end
   
 describe "Dataset compound operations" do


### PR DESCRIPTION
This way error handlers can inspect the exception to get the table name or even the model that originated it (if any).