### PR TITLE
Fix indentation in rdoc for self.register

### DIFF
--- a/lib/sequel/extensions/pg_range.rb
+++ b/lib/sequel/extensions/pg_range.rb
@@ -92,8 +92,8 @@ module Sequel
       # :oid :: The PostgreSQL OID for the range type.  This is used by the Sequel postgres adapter
       #         to set up automatic type conversion on retrieval from the database.
       # :subtype_oid :: Should be the PostgreSQL OID for the range's subtype. If given,
-      #                automatically sets the :converter option by looking for scalar conversion
-      #                proc.
+      #                 automatically sets the :converter option by looking for scalar conversion
+      #                 proc.
       #
       # If a block is given, it is treated as the :converter option.
       def self.register(db_type, opts=OPTS, &block)


### PR DESCRIPTION
It wasn't parsing properly: http://sequel.jeremyevans.net/rdoc-plugins/classes/Sequel/Postgres/PGRange.html#method-c-register