### PR TITLE
Make all Sequel::Inflections' methods public

### DIFF
--- a/lib/sequel/model/inflections.rb
+++ b/lib/sequel/model/inflections.rb
@@ -105,8 +105,6 @@ module Sequel
 
     instance_eval(&DEFAULT_INFLECTIONS_PROC)
 
-    private
-
     # Convert the given string to CamelCase.  Will also convert '/' to '::' which is useful for converting paths to namespaces.
     def camelize(s)
       s = s.to_s


### PR DESCRIPTION
Make all Sequel::Inflections' methods public.
I.e. we can use `Sequel.inflections.pluralize` in plugins, code, etc.
Why are they `private`?