### PR TITLE
Transaction Synchronization on MRI

### DIFF
--- a/lib/sequel/core.rb
+++ b/lib/sequel/core.rb
@@ -388,7 +388,7 @@ module Sequel
 
   private_class_method :adapter_method, :def_adapter_method
 
-  require(%w"deprecated sql connection_pool exceptions dataset database timezones ast_transformer version")
+  require(%w"deprecated sql connection_pool exceptions dataset database timezones ast_transformer version synchronized_hash")
 
   # Add the database adapter class methods to Sequel via metaprogramming
   def_adapter_method(*Database::ADAPTERS)

--- a/lib/sequel/core.rb
+++ b/lib/sequel/core.rb
@@ -293,24 +293,14 @@ module Sequel
     end
   end
 
-  if defined?(RUBY_ENGINE) && RUBY_ENGINE != 'ruby'
-  # :nocov:
-    # Mutex used to protect mutable data structures
-    @data_mutex = Mutex.new
+  # Mutex used to protect mutable data structures
+  @data_mutex = Mutex.new
 
-    # Unless in single threaded mode, protects access to any mutable
-    # global data structure in Sequel.
-    # Uses a non-reentrant mutex, so calling code should be careful.
-    def self.synchronize(&block)
-      @single_threaded ? yield : @data_mutex.synchronize(&block)
-    end
-  # :nocov:
-  else
-    # Yield directly to the block.  You don't need to synchronize
-    # access on MRI because the GVL makes certain methods atomic.
-    def self.synchronize
-      yield
-    end
+  # Unless in single threaded mode, protects access to any mutable
+  # global data structure in Sequel.
+  # Uses a non-reentrant mutex, so calling code should be careful.
+  def self.synchronize(&block)
+    @single_threaded ? yield : @data_mutex.synchronize(&block)
   end
 
   # Uses a transaction on all given databases with the given options. This:

--- a/lib/sequel/database/misc.rb
+++ b/lib/sequel/database/misc.rb
@@ -125,7 +125,7 @@ module Sequel
       @schemas = {}
       @default_string_column_size = @opts[:default_string_column_size] || DEFAULT_STRING_COLUMN_SIZE
       @prepared_statements = {}
-      @transactions = {}
+      @transactions = SynchronizedHash.new
       @identifier_input_method = nil
       @identifier_output_method = nil
       @quote_identifiers = nil

--- a/lib/sequel/database/transactions.rb
+++ b/lib/sequel/database/transactions.rb
@@ -159,10 +159,9 @@ module Sequel
       end
     end
 
-    # Synchronize access to the current transactions, returning the hash
-    # of options for the current transaction (if any)
+    # Returns the hash of options for the current transaction (if any)
     def _trans(conn)
-      Sequel.synchronize{@transactions[conn]}
+      @transactions[conn]
     end
 
     # Add the current thread to the list of active transactions

--- a/lib/sequel/synchronized_hash.rb
+++ b/lib/sequel/synchronized_hash.rb
@@ -1,0 +1,35 @@
+module Sequel
+  # A Hash with synchronized access. This class only provides methods actually
+  # used by Sequel (e.g. [] and []=).
+  class SynchronizedHash
+    def initialize
+      @mutex = Mutex.new
+      @hash  = {}
+    end
+
+    # Returns the value of the given key
+    def [](key)
+      @mutex.synchronize { @hash[key] }
+    end
+
+    # Sets the key +key+ to +value+
+    def []=(key, value)
+      @mutex.synchronize { @hash[key] = value }
+    end
+
+    # Deletes the given key
+    def delete(key)
+      @mutex.synchronize { @hash.delete(key) }
+    end
+
+    # Returns the keys of the Hash
+    def keys
+      @mutex.synchronize { @hash.keys }
+    end
+
+    # Returns whether or not the Hash is empty
+    def empty?
+      @mutex.synchronize { @hash.empty? }
+    end
+  end
+end

--- a/spec/core/synchronized_hash_spec.rb
+++ b/spec/core/synchronized_hash_spec.rb
@@ -1,0 +1,51 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), 'spec_helper')
+
+describe Sequel::SynchronizedHash do
+  describe '#[]' do
+    it 'should return the value of a key' do
+      hash = Sequel::SynchronizedHash.new
+
+      hash[:number] = 10
+
+      hash[:number].must_equal 10
+    end
+  end
+
+  describe '#delete' do
+    it 'should remove a key' do
+      hash = Sequel::SynchronizedHash.new
+
+      hash[:number] = 10
+
+      hash.delete(:number)
+
+      hash[:number].must_equal nil
+    end
+  end
+
+  describe '#keys' do
+    it 'should return an Array of the keys' do
+      hash = Sequel::SynchronizedHash.new
+
+      hash[:number] = 10
+
+      hash.keys.must_equal [:number]
+    end
+  end
+
+  describe '#empty?' do
+    it 'should return true for an empty Hash' do
+      hash = Sequel::SynchronizedHash.new
+
+      hash.empty?.must_equal true
+    end
+
+    it 'should return false for a non-empty Hash' do
+      hash = Sequel::SynchronizedHash.new
+
+      hash[:number] = 10
+
+      hash.empty?.must_equal false
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes two things:

1. Synchronization on MRI when calling `Sequel.synchronize`
2. Synchronization of transaction options, without the need for global locks

Both commits explain the problem and rationale pretty well, so see those for more information. If anything has to be changed styling wise, just say the word.