### PR TITLE
call Model methods when serializing dataset

### DIFF
--- a/lib/sequel/plugins/csv_serializer.rb
+++ b/lib/sequel/plugins/csv_serializer.rb
@@ -163,7 +163,7 @@ module Sequel
 
           CSV.generate(opts) do |csv|
             items.each do |object|
-              csv << opts[:headers].map{|header| object[header]}
+              csv << opts[:headers].map{|header| object.send(header) }
             end
           end
         end


### PR DESCRIPTION
This change will call the model method instead of returning raw value from the
database. It will make the CSV serializer consistent in behavior with JSON
serializer. Also, the InstanceMethod also calls the model methods rather than
returning a value.


## Example
```ruby
class Device < Sequel::Model
      def management_ip
        IPAddr.new(self[:management_ip], Socket::AF_INET)
      end
end
```

## Before
```ruby
[16] pry(main)> Device.select(:management_ip).limit(1).to_csv
I, [2015-10-06T18:17:55.731001 #12379]  INFO -- : (0.000443s) SELECT `management_ip` FROM `device` LIMIT 1
I, [2015-10-06T18:17:55.732052 #12379]  INFO -- : (0.000564s) SELECT `management_ip` FROM `device` LIMIT 1
=> "168125324\n"
```

## After
```ruby
[3] pry(main)> Device.select(:management_ip).limit(1).to_csv
I, [2015-10-06T18:18:52.490121 #14588]  INFO -- : (0.000440s) SELECT `management_ip` FROM `device` LIMIT 1
I, [2015-10-06T18:18:52.490839 #14588]  INFO -- : (0.000187s) SELECT `management_ip` FROM `device` LIMIT 1
=> "10.5.99.140\n"
[4] pry(main)>
```