### PR TITLE
Fix broken link in validations.rdoc

### DIFF
--- a/doc/validations.rdoc
+++ b/doc/validations.rdoc
@@ -1,6 +1,6 @@
 = Model Validations
 
-This guide is based on http://guides.rubyonrails.org/activerecord_validations_callbacks.html
+This guide is based on http://guides.rubyonrails.org/active_record_validations.html
 
 == Overview
 


### PR DESCRIPTION
This AR guide seems to have been split into two (Callbacks and Validations) since the link was made.