### PR TITLE
Update docs to reflect transaction use in cursors

### DIFF
--- a/doc/transactions.rdoc
+++ b/doc/transactions.rdoc
@@ -6,6 +6,7 @@ Sequel uses autocommit mode by default for all of its database adapters, so in g
 * Model#save
 * Model#destroy
 * Migrations if the database supports transactional schema
+* Postgres cursor usage
 * A few model plugins
 
 Everywhere else, it is up to you to use a database transaction if you want to.

--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -674,9 +674,11 @@ module Sequel
       end
 
       # Uses a cursor for fetching records, instead of fetching the entire result
-      # set at once.  Can be used to process large datasets without holding
-      # all rows in memory (which is what the underlying drivers may do
-      # by default). Options:
+      # set at once.  Note this uses a transaction around the cursor usage by
+      # default and can be changed using `hold: true` as described below.
+      # Cursors can be used to process large datasets without holding all rows
+      # in memory (which is what the underlying drivers may do by default).
+      # Options:
       #
       # :cursor_name :: The name assigned to the cursor (default 'sequel_cursor').
       #                 Nested cursors require different names.


### PR DESCRIPTION
Reason for change:
* The documentation wasn't clear about the default transaction when using Postgres cursors and I found myself stuck.
* The nice `use_cursor` method takes an option of `hold: true` which prevents rolling back all changes if a block fails, for example iterating over 10k records.

What the change was:
* Clarify that `use_cursor` uses a transaction by default and how to disable it.
* Add cursors to the Transactions document as another method which uses them by default.

Relevant discussion on the mailing list: https://groups.google.com/forum/#!topic/sequel-talk/7IRBCE-Rwv0