### PR TITLE
fix `class java.lang.String` error when jdbc adapter with logstash

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -213,7 +213,7 @@ module Sequel
             props = java.util.Properties.new
             if opts && opts[:user] && opts[:password]
               props.setProperty("user", opts[:user])
-              props.setProperty("password", opts[:password])
+              props.setProperty("password", opts[:password].value)
             end
             opts[:jdbc_properties].each{|k,v| props.setProperty(k.to_s, v)} if opts[:jdbc_properties]
             begin


### PR DESCRIPTION
fix error `cannot convert instance of class org.jruby.RubyObject to class java.lang.String`
when providing a `jdbc_password` input field to the logstash-input-jdbc jruby plugin

reasoning: https://github.com/elastic/logstash/issues/3785#issuecomment-152104199