### PR TITLE
Fix the :rank option to Dataset#full_text_search on Postgres to order…

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1331,7 +1331,7 @@ module Sequel
         end
 
         if opts[:rank]
-          ds = ds.order{ts_rank_cd(cols, terms)}
+          ds = ds.order{Sequel.desc(ts_rank_cd(cols, terms))}
         end
 
         ds

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -987,7 +987,7 @@ describe "A PostgreSQL database" do
     t2 = "ruby sequel " * 1000
     @db[:posts].insert(:title=>t1)
     @db[:posts].insert(:title=>t2)
-    @db[:posts].full_text_search(:title, 'ruby & sequel', :rank=>true).select_map(:title).must_equal [t1, t2]
+    @db[:posts].full_text_search(:title, 'ruby & sequel', :rank=>true).select_map(:title).must_equal [t2, t1]
   end
 
   it "should support spatial indexes" do


### PR DESCRIPTION
… by rank descending.

Postgres' `ts_rank_cd` function returns a rank where a higher number represents a closer association. Currently the `:rank` option to `full_text_search` orders by `ts_rank_cd(...)` rather than `ts_rank_cd(...) DESC`, which means users will get the least relevant search results first. This is probably not what anyone is expecting :smile: 