### PR TITLE
Add a Sequel::Model#was_new? method

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -117,6 +117,7 @@ module Sequel
       def call(values)
         o = allocate
         o.instance_variable_set(:@values, values)
+        o.instance_variable_set(:@fetched, true)
         o
       end
       
@@ -1452,7 +1453,18 @@ module Sequel
       def new?
         defined?(@new) ? @new : (@new = false)
       end
-      
+
+      # Returns true if the current (maybe saved) instance was just created, as opposed to having been
+      # originally fetched from the database
+      #
+      #   artist = Artist.new.save
+      #   artist.was_new? # => true
+      #
+      #   Artist[1].was_new? # => false
+      def was_new?
+        !@fetched
+      end
+
       # Returns the primary key value identifying the model instance.
       # Raises an +Error+ if this model does not have a primary key.
       # If the model has a composite primary key, returns an array of values.


### PR DESCRIPTION
Add a `Sequel::Model#was_new?` method, that returns true if the model
instance was just created, as opposed to having been fetched from the
database.

fwiw, my current use case is a helper method that returns HTTP 201 if 
a model was just created, and 200 if it was updated