### PR TITLE
Add sqlite3 dependency to examples

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,6 +43,7 @@ If you have any comments or suggestions please post to the Google group.
 == A Short Example
 
   require 'sequel'
+  require 'sqlite3'
   
   DB = Sequel.sqlite # memory database
   
@@ -109,6 +110,7 @@ Or getting results as a hash via +to_hash+, with one column as key and another a
 To connect to a database you simply provide <tt>Sequel.connect</tt> with a URL:
 
   require 'sequel'
+  require 'sqlite3'
   DB = Sequel.connect('sqlite://blog.db')
   
 The connection URL can also include such stuff as the user name, password, and port:


### PR DESCRIPTION
Using the code in the examples yielded an exception because sqlite3 was not required. 
It seems like that dependency should be shown in the examples.