### PR TITLE
Support :eager_limit and :eager_limit_strategy Dataset options.

### DIFF
--- a/doc/advanced_associations.rdoc
+++ b/doc/advanced_associations.rdoc
@@ -287,15 +287,35 @@ the window function strategy:
     :eager_limit_strategy=>:window_function
   Artist.where(:id=>[1,2]).eager(:first_10_albums).all
   # SELECT * FROM (
-  #   SELECT *, row_number() OVER (PARTITION BY tracks.album_id ORDER BY release_date) AS x_sequel_row_number_x
-  #   FROM tracks
-  #   WHERE (tracks.album_id IN (1, 2))
+  #   SELECT *, row_number() OVER (PARTITION BY albums.artist_id ORDER BY release_date) AS x_sequel_row_number_x
+  #   FROM albums
+  #   WHERE (albums.artist_id IN (1, 2))
   # ) AS t1
   # WHERE (x_sequel_row_number_x <= 10)
   
 Alternatively, you can use the :ruby strategy, which will fall back to
 retrieving all records, and then will slice the resulting array to get
 the first 10 after retrieval.
+
+=== Dynamic Eager Loading Limits
+
+If you need to eager load variable numbers of records (with limits that aren't
+known at the time of the association definition), Sequel supports an
+:eager_limit dataset option that can be defined in an eager loading callback:
+
+  Artist.one_to_many :albums
+  Artist.where(:id => [1, 2]).eager(:albums => proc{|ds| ds.order(:release_date).clone(:eager_limit => 3)}).all
+  # SELECT * FROM (
+  #   SELECT *, row_number() OVER (PARTITION BY albums.artist_id ORDER BY release_date) AS x_sequel_row_number_x
+  #   FROM albums
+  #   WHERE (albums.artist_id IN (1, 2))
+  # ) AS t1
+  # WHERE (x_sequel_row_number_x <= 3)
+
+You can also customize the :eager_limit_strategy on a case-by-case basis by passing in that option in the same way:
+
+  Artist.where(:id => [1, 2]).eager(:albums => proc{|ds| ds.order(:release_date).clone(:eager_limit => 3, :eager_limit_strategy => :ruby)}).all
+  # SELECT * FROM albums WHERE (albums.artist_id IN (1, 2)) ORDER BY release_date
 
 === Eager Loading via eager_graph_with_options
 

--- a/doc/advanced_associations.rdoc
+++ b/doc/advanced_associations.rdoc
@@ -317,6 +317,9 @@ You can also customize the :eager_limit_strategy on a case-by-case basis by pass
   Artist.where(:id => [1, 2]).eager(:albums => proc{|ds| ds.order(:release_date).clone(:eager_limit => 3, :eager_limit_strategy => :ruby)}).all
   # SELECT * FROM albums WHERE (albums.artist_id IN (1, 2)) ORDER BY release_date
 
+The :eager_limit and :eager_limit_strategy options currently only work when
+eager loading via #eager, not with #eager_graph.
+
 === Eager Loading via eager_graph_with_options
 
 When eager loading an association via eager_graph (which uses JOINs), the

--- a/spec/integration/associations_test.rb
+++ b/spec/integration/associations_test.rb
@@ -1914,6 +1914,28 @@ describe "Sequel::Model Simple Associations" do
     artists.each{|a| a.first_two_albums.length.must_equal 1}
   end
 
+  it "should handle the :eager_limit option in eager-loading callbacks" do
+    @db[:artists].import([:name], (1..4).map{|i| ['test']})
+    artist_ids = @db[:artists].where(name: 'test').select_map(:id)
+    @db[:albums].import([:artist_id], artist_ids * 3)
+
+    artists = Artist.where(id: artist_ids).eager(:albums => proc{|ds| ds.clone(:eager_limit => 1)}).all
+    artists.length.must_equal 4
+    artists.each{|a| a.albums.length.must_equal 1}
+
+    artists = Artist.where(id: artist_ids).eager(:albums => proc{|ds| ds.clone(:eager_limit => 2)}).all
+    artists.length.must_equal 4
+    artists.each{|a| a.albums.length.must_equal 2}
+
+    artists = Artist.where(id: artist_ids).eager(:albums => proc{|ds| ds.clone(:eager_limit => 3)}).all
+    artists.length.must_equal 4
+    artists.each{|a| a.albums.length.must_equal 3}
+
+    artists = Artist.where(id: artist_ids).eager(:albums => proc{|ds| ds.clone(:eager_limit => 4)}).all
+    artists.length.must_equal 4
+    artists.each{|a| a.albums.length.must_equal 3}
+  end
+
   it "should handle many_to_one associations with same name as :key" do
     Album.def_column_alias(:artist_id_id, :artist_id)
     Album.many_to_one :artist_id, :key_column =>:artist_id, :class=>Artist


### PR DESCRIPTION
As discussed on sequel-talk. A couple of notes:

- The eager-loading association logic is a bit messier, by virtue of needing to passing around limit and offset information between methods, rather than being able to simply pull it from the association reflection when it was necessary. For backwards compatibility I made sure to not change the arguments required by any methods.
- I've added the support for Dataset#eager, but not Dataset#eager_graph. I started on the work for #eager_graph, but it seemed like it was going to be a more complicated addition and I wasn't planning on actually using the feature with #eager_graph, so I figured it would be safer and simpler to add it for #eager only and just document that the feature only works there. If you think it's important to also support it for #eager_graph so that the APIs are similar, I can certainly add it. Or, if you think it's fine to only support #eager with this feature, I can add documentation to that effect.