### PR TITLE
JDBC: #schema_parse_table to include remarks

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -632,7 +632,8 @@ module Sequel
             :allow_null=>(h[:nullable] != 0),
             :primary_key=>pks.include?(h[:column_name]),
             :column_size=>h[:column_size],
-            :scale=>h[:decimal_digits]
+            :scale=>h[:decimal_digits],
+            :remarks=>h[:remarks]
           }
           if s[:primary_key]
             s[:auto_increment] = h[:is_autoincrement] == "YES"


### PR DESCRIPTION
Comments on columns are metadata in the schema. We can include them in the schema metadata.

[DatabaseMetaData.html#getColumns](https://docs.oracle.com/javase/7/docs/api/java/sql/DatabaseMetaData.html#getColumns(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String))