### PR TITLE
Add validate_numericality_of validator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@
 
 * Allow foreign_key schema method to handle SQL::Identifier and SQL::QualifiedIdentifier as 2nd argument (jeremyevans)
 
+* Add validate_numericality_of validator for less/greater/equal validations (petedmarsh)
+
 === 4.32.0 (2016-03-01)
 
 * Use mutex for synchronizing access to association reflection cache on MRI (jeremyevans)

--- a/spec/extensions/validation_helpers_spec.rb
+++ b/spec/extensions/validation_helpers_spec.rb
@@ -538,4 +538,103 @@ describe "Sequel::Plugins::ValidationHelpers" do
     m.wont_be :valid?
     DB.sqls.must_equal []
   end
+
+  it "should support validates_numericality_of with equal_to option" do
+    @c.set_validations{validates_numericality_of(:value, :equal_to=>123)}
+    @m.value = 456
+    @m.wont_be :valid?
+    @m.value = 0
+    @m.wont_be :valid?
+    @m.value = 123
+    @m.must_be :valid?
+    @m.value = 123.00001
+    @m.wont_be :valid?
+    @m.value = 122.99999
+    @m.wont_be :valid?
+    @m.value = -123
+    @m.wont_be :valid?
+    @m.value = 123.0
+    @m.must_be :valid?
+  end
+
+  it "should support validates_numericality_of with greater_than option" do
+    @c.set_validations{validates_numericality_of(:value, :greater_than=>123)}
+    @m.value = 456
+    @m.must_be :valid?
+    @m.value = 0
+    @m.wont_be :valid?
+    @m.value = 123
+    @m.wont_be :valid?
+    @m.value = 123.00001
+    @m.must_be :valid?
+    @m.value = 122.99999
+    @m.wont_be :valid?
+    @m.value = -123
+    @m.wont_be :valid?
+  end
+
+  it "should support validates_numericality_of with greater_than_or_equal_to option" do
+    @c.set_validations{validates_numericality_of(:value, :greater_than_or_equal_to=>123)}
+    @m.value = 456
+    @m.must_be :valid?
+    @m.value = 0
+    @m.wont_be :valid?
+    @m.value = 123
+    @m.must_be :valid?
+    @m.value = 123.00001
+    @m.must_be :valid?
+    @m.value = 122.99999
+    @m.wont_be :valid?
+    @m.value = -123
+    @m.wont_be :valid?
+  end
+
+  it "should support validates_numericality_of with less_than option" do
+    @c.set_validations{validates_numericality_of(:value, :less_than=>123)}
+    @m.value = 456
+    @m.wont_be :valid?
+    @m.value = 0
+    @m.must_be :valid?
+    @m.value = 123
+    @m.wont_be :valid?
+    @m.value = 123.00001
+    @m.wont_be :valid?
+    @m.value = 122.99999
+    @m.must_be :valid?
+    @m.value = -123
+    @m.must_be :valid?
+  end
+
+  it "should support validates_numericality_of with less_than_or_equal_to option" do
+    @c.set_validations{validates_numericality_of(:value, :less_than_or_equal_to=>123)}
+    @m.value = 456
+    @m.wont_be :valid?
+    @m.value = 0
+    @m.must_be :valid?
+    @m.value = 123
+    @m.must_be :valid?
+    @m.value = 123.00001
+    @m.wont_be :valid?
+    @m.value = 122.99999
+    @m.must_be :valid?
+    @m.value = -123
+    @m.must_be :valid?
+  end
+
+
+  it "should support validates_numericality_of with multiple options" do
+    @c.set_validations{validates_numericality_of(:value, :less_than=>456, :greater_than=>123)}
+    @m.value = 456
+    @m.wont_be :valid?
+    @m.value = 0
+    @m.wont_be :valid?
+    @m.value = 123
+    @m.wont_be :valid?
+    @m.value = 123.00001
+    @m.must_be :valid?
+    @m.value = 122.99999
+    @m.wont_be :valid?
+    @m.value = -123
+    @m.wont_be :valid?
+  end
 end 


### PR DESCRIPTION
This that checks if a value is less/greater/equal than a specified
value, e.g.:

    class Example < Sequel::Model
        validates_numericality_of :something, less_than: 123
    end

The validator supports the following options (which may be used in
conjunction):

    :equal_to
    :less_than
    :less_than_or_equal_to
    :greater_than
    :greater_than_or_equal_to

NOTE: This is based on ActiveRecord's validate_numericality_of
validator, code:

    https://github.com/rails/rails/blob/2fc6c094e54103db2a4550af6e2ac2f34420f084/activemodel/lib/active_model/validations/numericality.rb

As both ActiveRecord and Sequel are MIT licensed I believe this is
fine.