### PR TITLE
Add "none" section to active_record docs

### DIFF
--- a/doc/active_record.rdoc
+++ b/doc/active_record.rdoc
@@ -626,6 +626,22 @@ For anything more complex, you can use +dataset_module+:
     end
   end
 
+=== +none+
+
+If you want to return an empty dataset, but still preserve chaining, you can use the +null_dataset+ extension:
+
+  DB.extension(:null_dataset)
+
+  class User < Sequel::Model
+    def self.nullify
+      dataset.nullify
+    end
+  end
+
+  user = User.create(name: 'John Doe')
+  User.nullify.where(name: 'John Doe')
+  # []
+
 ==== +reset_column_information+
 
 If you want to completely reload the schema for the table:


### PR DESCRIPTION
This adds a tip for users wishing to replicate AR's `none`. The example is taken from from [this](http://stackoverflow.com/a/36087167/1048479) SO answer.

Points of interest:

1. I'm not super famliar with RDOC, please let me know if I've made gaff
2. I'm not sure if the example should encourage extending every dataset. It seems like the clearest and cleanest way to do so (and fitting with how AR handles things) 