### PR TITLE
Support multiple expressions in the ON CONFLICT target list on Postgres.

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1595,9 +1595,8 @@ module Sequel
             sql << " ON CONSTRAINT "
             identifier_append(sql, target)
           elsif target = opts[:target]
-            sql << ' ('
-            identifier_append(sql, target)
-            sql << ')'
+            sql << ' '
+            identifier_append(sql, Array(target))
           end
 
           if values = opts[:update]


### PR DESCRIPTION
Tried to call `insert_conflict()` with an array of target expressions, to work with a compound unique index, and was surprised when Sequel generated `ON CONFLICT (("a", "b"))`, which Postgres rejected as a syntax error.

I added some unit tests for the generated SQL, just to be thorough. I realize that this spec file is primarily integration tests, but couldn't find a set of unit tests for Postgres-specific functionality anywhere. It also seemed good to have all the insert_conflict specs in one place. If you'd prefer that that unit spec live somewhere else, though, please let me know!