### PR TITLE
Add optional block parameter to dataset hash methods

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -2367,12 +2367,12 @@ module Sequel
       #   # => {1=>#<Artist {:id=>1, ...}>,
       #   #     2=>#<Artist {:id=>2, ...}>,
       #   #     ...}
-      def to_hash(key_column=nil, value_column=nil)
+      def to_hash(key_column=nil, value_column=nil, opts={})
         if key_column
           super
         else
           raise(Sequel::Error, "No primary key for model") unless model && (pk = model.primary_key)
-          super(pk, value_column) 
+          super(pk, value_column, opts) 
         end
       end
 

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -1761,6 +1761,10 @@ describe "Dataset#to_hash" do
     @d.to_hash(:b).must_equal(2 => {:a => 1, :b => 2}, 4 => {:a => 3, :b => 4}, 6 => {:a => 5, :b => 6})
   end
 
+  it "should accept an optional :hash parameter into which entries can be merged" do
+    @d.to_hash(:a, :b, :hash => (tmp = {})).must_be_same_as(tmp)
+  end
+
   it "should support using an array of columns as either the key or the value" do
     @d.to_hash([:a, :b], :b).must_equal([1, 2] => 2, [3, 4] => 4, [5, 6] => 6)
     @d.to_hash(:b, [:a, :b]).must_equal(2 => [1, 2], 4 => [3, 4], 6 => [5, 6])
@@ -1816,6 +1820,10 @@ describe "Dataset#to_hash_groups" do
     @d.to_hash_groups(:b, [:a, :b]).must_equal(2 => [[1, 2]], 4 => [[3, 4], [7, 4]], 6 => [[1, 6]])
     @d.to_hash_groups([:b, :a], [:a, :b]).must_equal([2, 1] => [[1, 2]], [4, 3] => [[3, 4]], [6, 1] => [[1, 6]], [4, 7]=>[[7, 4]])
     @d.to_hash_groups([:a, :b]).must_equal([1, 2] => [{:a => 1, :b => 2}], [3, 4] => [{:a => 3, :b => 4}], [1, 6] => [{:a => 1, :b => 6}], [7, 4] => [{:a => 7, :b => 4}])
+  end
+
+  it "should accept an optional :hash parameter into which entries can be merged" do
+    @d.to_hash_groups(:a, :b, :hash => (tmp = {})).must_be_same_as(tmp)
   end
 
   it "should not call the row_proc if two arguments are given" do

--- a/spec/integration/dataset_test.rb
+++ b/spec/integration/dataset_test.rb
@@ -1169,6 +1169,8 @@ describe "Sequel::Dataset convenience methods" do
     @ds.to_hash([:a, :c], :b).must_equal([1, 3]=>2, [5, 7]=>6)
     @ds.to_hash(:a, [:b, :c]).must_equal(1=>[2, 3], 5=>[6, 7])
     @ds.to_hash([:a, :c], [:b, :d]).must_equal([1, 3]=>[2, 4], [5, 7]=>[6, 8])
+
+    @ds.to_hash(:a, :b, :hash => (tmp = {})).must_be_same_as(tmp)
   end
 
   it "should have working #to_hash_groups" do
@@ -1182,6 +1184,8 @@ describe "Sequel::Dataset convenience methods" do
     ds.to_hash_groups([:a, :c], :d).must_equal([1, 3]=>[4, 9], [5, 7]=>[8])
     ds.to_hash_groups(:a, [:b, :d]).must_equal(1=>[[2, 4], [2, 9]], 5=>[[6, 8]])
     ds.to_hash_groups([:a, :c], [:b, :d]).must_equal([1, 3]=>[[2, 4], [2, 9]], [5, 7]=>[[6, 8]])
+
+    ds.to_hash_groups(:a, :d, :hash => (tmp = {})).must_be_same_as(tmp)
   end
 
   it "should have working #select_map" do
@@ -1225,6 +1229,7 @@ describe "Sequel::Dataset convenience methods" do
     @ds.select_hash([:a, :c], :b).must_equal([1, 3]=>2, [5, 7]=>6)
     @ds.select_hash(:a, [:b, :c]).must_equal(1=>[2, 3], 5=>[6, 7])
     @ds.select_hash([:a, :c], [:b, :d]).must_equal([1, 3]=>[2, 4], [5, 7]=>[6, 8])
+    @ds.select_hash(:a, :b, :hash => (tmp = {})).must_be_same_as(tmp)
   end
 
   it "should have working #select_hash_groups" do
@@ -1238,6 +1243,7 @@ describe "Sequel::Dataset convenience methods" do
     ds.select_hash_groups([:a, :c], :d).must_equal([1, 3]=>[4, 9], [5, 7]=>[8])
     ds.select_hash_groups(:a, [:b, :d]).must_equal(1=>[[2, 4], [2, 9]], 5=>[[6, 8]])
     ds.select_hash_groups([:a, :c], [:b, :d]).must_equal([1, 3]=>[[2, 4], [2, 9]], [5, 7]=>[[6, 8]])
+    ds.select_hash_groups(:a, :d, :hash => (tmp = {})).must_be_same_as(tmp)
   end
 end
 


### PR DESCRIPTION
Using to_hash (or select_hash, or _groups) to build quick lookups from datasets and models is extremely handy, but I find myself writing constructs like this:

```ruby
lookup = Hash.new do |hash, key|
  hash[key] = MyModel.new :key => key, :value => "unknown"
end.merge! MyModel.to_hash(:key)
```

or:

```ruby
lookup = Hash.new(["unknown"])
  .merge! DB[:my_table].select_hash_groups(:key, :value)
```

This patch adds an optional `:hash` parameter to the various hash methods, into which entries are merged. This allows slightly more readable versions of the above:

```ruby
lookup = MyModel.to_hash :key, nil, :hash => Hash.new do |hash, key|
  hash[key] = MyModel.new :key => key, :value => "unknown"
end
```

and:

```ruby
lookup = DB[:my_table].select_hash_groups(:key, :value, :hash => Hash.new(["unknown"]))
```

I did not carry the change through to the StaticCache plugin. 

Methods affected:
* Dataset#to_hash
* Dataset#to_hash_groups
* Dataset#select_hash
* Dataset#select_hash_groups
* Model#to_hash