### PR TITLE
Correct reference to create_or_update in UpdateOrCreate docs

### DIFF
--- a/lib/sequel/plugins/update_or_create.rb
+++ b/lib/sequel/plugins/update_or_create.rb
@@ -7,7 +7,7 @@ module Sequel
     # The first method is update_or_create, which updates an object if it
     # exists in the database, or creates the object if it does not.
     #
-    # You can call create_or_update with a block:
+    # You can call update_or_create with a block:
     #
     #   Album.update_or_create(:name=>'Hello') do |album|
     #     album.num_copies_sold = 1000


### PR DESCRIPTION
This is an extremely minor change, happend to notice that there was a reference to `create_or_update` where it should have been `update_or_create` in the documentation for the UpdateOrCreate plugin.