### PR TITLE
Add validates_operator validator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
 
 * Add :hash option to Dataset#(select|to)_hash(_groups)? methods for choosing object to populate (mwpastore) (#1167)
 
+* Add validates_operator validation helper (petedmarsh)
+
 === 4.33.0 (2016-04-01)
 
 * Handle arbitrary objects passed as arguments to the association method (jeremyevans) (#1166)

--- a/doc/validations.rdoc
+++ b/doc/validations.rdoc
@@ -231,6 +231,17 @@ These methods check that the specified attributes can be valid integers or valid
     end
   end
 
+=== +validates_operator+
+
++validates_operator+ checks that a given +operator+ method returns a truthy value when called on attribute with a specified value for comparison.  Generally, this is used for inequality checks (>, >=, etc) but any method that can be called on the attribute that accepts an argument and returns a truthy value may be used.
+
+  class Album < Sequel::Model
+    def validate
+      super
+      validates_operator(:>, 3, :tracks)
+    end
+  end
+
 === +validates_type+
 
 +validates_type+ checks that the specified attributes are instances of the class specified in the first argument.  The class can be specified as the class itself, or as a string or symbol with the class name, or as a an array of classes.

--- a/lib/sequel/plugins/validation_helpers.rb
+++ b/lib/sequel/plugins/validation_helpers.rb
@@ -87,6 +87,7 @@ module Sequel
         :min_length=>{:message=>lambda{|min| "is shorter than #{min} characters"}},
         :not_null=>{:message=>lambda{"is not present"}},
         :numeric=>{:message=>lambda{"is not a number"}},
+        :operator=>{:message=>lambda{|operator, rhs| "is not #{operator} #{rhs}"}},
         :type=>{:message=>lambda{|klass| klass.is_a?(Array) ? "is not a valid #{klass.join(" or ").downcase}" : "is not a valid #{klass.to_s.downcase}"}},
         :presence=>{:message=>lambda{"is not present"}},
         :unique=>{:message=>lambda{'is already taken'}}
@@ -153,6 +154,12 @@ module Sequel
               validation_error_message(m)
             end
           end
+        end
+
+        # Check attribute value(s) against a specified value and operation, e.g.
+        # validates_operator(:>, 3, :value) validates that value > 3.
+        def validates_operator(operator, rhs, atts, opts=OPTS)
+          validatable_attributes_for_type(:operator, atts, opts){|a,v,m| validation_error_message(m, operator, rhs) unless v.send(operator, rhs)}
         end
 
         # Validates for all of the model columns (or just the given columns)

--- a/spec/extensions/validation_helpers_spec.rb
+++ b/spec/extensions/validation_helpers_spec.rb
@@ -538,4 +538,15 @@ describe "Sequel::Plugins::ValidationHelpers" do
     m.wont_be :valid?
     DB.sqls.must_equal []
   end
+
+  it "should support validates_operator" do
+    @c.set_validations{validates_operator(:>, 3, :value)}
+    @m.value = 1
+    @m.wont_be :valid?
+    @m.errors.full_messages.must_equal ['value is not > 3']
+    @m.value = 3
+    @m.wont_be :valid?
+    @m.value = 4
+    @m.must_be :valid?
+  end
 end 


### PR DESCRIPTION
This checks that an attribute compares favourably against a specified
value for a given operation, e.g.

    class Example < Sequel::Model
      def validate
        super
        validates_operator(:>, 3, :something)
      end
    end

Feature discussion:

https://groups.google.com/forum/#!topic/sequel-talk/EMrbjLFrJpA