### PR TITLE
Memoize version_numbers

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -618,13 +618,15 @@ module Sequel
     # so that each number in the array is the migration version
     # that will be in affect after the migration is run.
     def version_numbers
-      versions = files.
-        compact.
-        map{|f| migration_version_from_file(File.basename(f))}.
-        select{|v| up? ? (v > current && v <= target) : (v <= current && v > target)}.
-        sort
-      versions.reverse! unless up?
-      versions
+      @version_numbers ||= begin
+        versions = files.
+          compact.
+          map{|f| migration_version_from_file(File.basename(f))}.
+          select{|v| up? ? (v > current && v <= target) : (v <= current && v > target)}.
+          sort
+        versions.reverse! unless up?
+        versions
+      end
     end
   end
 


### PR DESCRIPTION
Running migrations in ruby 2.3.0 gives us the following:

> ›  git:(master) bundle exec sequel -m db postgres://127.0.0.1:5432/database
Assertion failed: (!STR_EMBED_P(shared)), function str_new_frozen, file string.c, line 1075.
zsh: abort      bundle exec sequel -m db postgres://127.0.0.1:5432/database

While it works properly locally.
The `version_numbers` method is called twice, and this error happens on `File.basename`.
Memoizing the method hides that error, as only the second call causes the issue.

I have a repro project so simple, I can paste it here:

```
diff --git a/Gemfile b/Gemfile
new file mode 100644
index 0000000..4f3759b
--- /dev/null
+++ b/Gemfile
@@ -0,0 +1,5 @@
+source 'http://rubygems.org'
+
+ruby '2.3.0'
+gem 'pg'
+gem 'sequel'
diff --git a/Gemfile.lock b/Gemfile.lock
new file mode 100644
index 0000000..2ba999f
--- /dev/null
+++ b/Gemfile.lock
@@ -0,0 +1,15 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    pg (0.18.3)
+    sequel (4.33.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pg
+  sequel
+
+BUNDLED WITH
+   1.11.2
diff --git a/db/0001_dump.rb b/db/0001_dump.rb
new file mode 100644
index 0000000..530ae10
--- /dev/null
+++ b/db/0001_dump.rb
@@ -0,0 +1,3 @@
+Sequel.migration do
+
+end
```