### PR TITLE
Extension: Duplicate columns handler

### DIFF
--- a/lib/sequel/adapters/ado.rb
+++ b/lib/sequel/adapters/ado.rb
@@ -135,7 +135,7 @@ module Sequel
       def fetch_rows(sql)
         execute(sql) do |s|
           columns = cols = s.Fields.extend(Enumerable).map{|column| output_identifier(column.Name)}
-          @columns = columns
+          self.columns = columns
           s.getRows.transpose.each do |r|
             row = {}
             cols.each{|c| row[c] = r.shift}

--- a/lib/sequel/adapters/amalgalite.rb
+++ b/lib/sequel/adapters/amalgalite.rb
@@ -160,7 +160,7 @@ module Sequel
       # Yield a hash for each row in the dataset.
       def fetch_rows(sql)
         execute(sql) do |stmt|
-          @columns = cols = stmt.result_fields.map{|c| output_identifier(c)}
+          self.columns = cols = stmt.result_fields.map{|c| output_identifier(c)}
           col_count = cols.size
           stmt.each do |result|
             row = {}

--- a/lib/sequel/adapters/cubrid.rb
+++ b/lib/sequel/adapters/cubrid.rb
@@ -127,7 +127,7 @@ module Sequel
         execute(sql) do |stmt|
           begin
             cols = stmt.column_info.map{|c| [output_identifier(c[COLUMN_INFO_NAME]), CUBRID_TYPE_PROCS[c[COLUMN_INFO_TYPE]]]}
-            @columns = cols.map(&:first)
+            self.columns = cols.map(&:first)
             stmt.each do |r|
               row = {}
               cols.zip(r).each{|(k, p), v| row[k] = (v && p) ? p.call(v) : v}

--- a/lib/sequel/adapters/do.rb
+++ b/lib/sequel/adapters/do.rb
@@ -144,7 +144,7 @@ module Sequel
       # with symbol keys.
       def fetch_rows(sql)
         execute(sql) do |reader|
-          cols = @columns = reader.fields.map{|f| output_identifier(f)}
+          cols = self.columns = reader.fields.map{|f| output_identifier(f)}
           while(reader.next!) do
             h = {}
             cols.zip(reader.values).each{|k, v| h[k] = v}

--- a/lib/sequel/adapters/ibmdb.rb
+++ b/lib/sequel/adapters/ibmdb.rb
@@ -401,7 +401,7 @@ module Sequel
             columns << [key, cps[type]]
           end
           cols = columns.map{|c| c.at(0)}
-          @columns = cols
+          self.columns = cols
 
           while res = stmt.fetch_array
             row = {}

--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -800,7 +800,7 @@ module Sequel
           i += 1
           cols << [output_identifier(meta.getColumnLabel(i)), i, convert ? type_convertor(map, meta, meta.getColumnType(i), i) : basic_type_convertor(map, meta, meta.getColumnType(i), i)]
         end
-        @columns = cols.map{|c| c.at(0)}
+        self.columns = cols.map{|c| c.at(0)}
 
         while result.next
           row = {}

--- a/lib/sequel/adapters/mock.rb
+++ b/lib/sequel/adapters/mock.rb
@@ -365,7 +365,7 @@ module Sequel
         if cs.empty?
           super
         else
-          @columns = cs
+          self.columns = cs
           self
         end
       end

--- a/lib/sequel/adapters/mysql.rb
+++ b/lib/sequel/adapters/mysql.rb
@@ -305,7 +305,7 @@ module Sequel
             type_proc = f.type == 1 && cast_tinyint_integer?(f) ? cps[2] : cps[f.type]
             [output_identifier(f.name), type_proc, i+=1]
           end
-          @columns = cols.map(&:first)
+          self.columns = cols.map(&:first)
           if opts[:split_multiple_result_sets]
             s = []
             yield_rows(r, cols){|h| s << h}

--- a/lib/sequel/adapters/mysql2.rb
+++ b/lib/sequel/adapters/mysql2.rb
@@ -154,7 +154,7 @@ module Sequel
       # Yield all rows matching this dataset.
       def fetch_rows(sql)
         execute(sql) do |r|
-          @columns = if identifier_output_method
+          self.columns = if identifier_output_method
             r.fields.map!{|c| output_identifier(c.to_s)}
           else
             r.fields

--- a/lib/sequel/adapters/odbc.rb
+++ b/lib/sequel/adapters/odbc.rb
@@ -98,7 +98,7 @@ module Sequel
           i = -1
           cols = s.columns(true).map{|c| [output_identifier(c.name), c.type, i+=1]}
           columns = cols.map{|c| c.at(0)}
-          @columns = columns
+          self.columns = columns
           if rows = s.fetch_all
             rows.each do |row|
               hash = {}

--- a/lib/sequel/adapters/oracle.rb
+++ b/lib/sequel/adapters/oracle.rb
@@ -366,7 +366,7 @@ module Sequel
           cols = columns = cursor.get_col_names.map{|c| output_identifier(c)}
           metadata = cursor.column_metadata
           cm = cols.zip(metadata).map{|c, m| [c, cps[m.data_type]]}
-          @columns = columns
+          self.columns = columns
           while r = cursor.fetch
             row = {}
             r.zip(cm).each{|v, (c, cp)| row[c] = ((v && cp) ? cp.call(v) : v)}

--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -835,7 +835,7 @@ module Sequel
         res.nfields.times do |fieldnum|
           cols << [fieldnum, procs[res.ftype(fieldnum)], output_identifier(res.fname(fieldnum))]
         end
-        @columns = cols.map{|c| c.at(2)}
+        self.columns = cols.map{|c| c.at(2)}
         cols
       end
       

--- a/lib/sequel/adapters/sqlanywhere.rb
+++ b/lib/sequel/adapters/sqlanywhere.rb
@@ -159,7 +159,7 @@ module Sequel
             col_infos << [i, output_identifier(name), cp]
           end
 
-          @columns = col_infos.map{|a| a[1]}
+          self.columns = col_infos.map{|a| a[1]}
 
           if rs
             while api.sqlany_fetch_next(rs) == 1

--- a/lib/sequel/adapters/sqlite.rb
+++ b/lib/sequel/adapters/sqlite.rb
@@ -324,7 +324,7 @@ module Sequel
           cps = db.conversion_procs
           type_procs = result.types.map{|t| cps[base_type_name(t)]}
           cols = result.columns.map{|c| i+=1; [output_identifier(c), i, type_procs[i]]}
-          @columns = cols.map(&:first)
+          self.columns = cols.map(&:first)
           result.each do |values|
             row = {}
             cols.each do |name,id,type_proc|

--- a/lib/sequel/adapters/swift.rb
+++ b/lib/sequel/adapters/swift.rb
@@ -134,7 +134,7 @@ module Sequel
       def fetch_rows(sql)
         execute(sql) do |res|
           col_map = {}
-          @columns = res.fields.map do |c|
+          self.columns = res.fields.map do |c|
             col_map[c] = output_identifier(c)
           end
           tz = db.timezone if Sequel.application_timezone

--- a/lib/sequel/adapters/tinytds.rb
+++ b/lib/sequel/adapters/tinytds.rb
@@ -225,7 +225,7 @@ module Sequel
             result.each(*args) do |r|
               unless cols
                 cols = result.fields.map{|c| [c, output_identifier(c)]}
-                @columns = columns = cols.map(&:last)
+                self.columns = columns = cols.map(&:last)
               end
               h = {}
               cols.each do |s, sym|
@@ -234,7 +234,7 @@ module Sequel
               yield h
             end
           else
-            @columns = columns
+            self.columns = columns
             if db.timezone == :utc
               result.each(:timezone=>:utc){|r| yield r}
             else

--- a/lib/sequel/dataset.rb
+++ b/lib/sequel/dataset.rb
@@ -36,6 +36,10 @@ module Sequel
     include SQL::NumericMethods
     include SQL::OrderMethods
     include SQL::StringMethods
+
+    private
+
+    attr_writer :columns
   end
   
   require(%w"query actions features graph prepared_statements misc mutation sql placeholder_literalizer", 'dataset')

--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -81,7 +81,7 @@ module Sequel
     #   DB[:table].columns!
     #   # => [:id, :name]
     def columns!
-      @columns = nil
+      self.columns = nil
       columns
     end
     

--- a/lib/sequel/extensions/columns_introspection.rb
+++ b/lib/sequel/extensions/columns_introspection.rb
@@ -30,7 +30,7 @@ module Sequel
     def columns
       return @columns if @columns
       if (pcs = probable_columns) && pcs.all?
-        @columns = pcs
+        self.columns = pcs
       else
         super
       end

--- a/lib/sequel/extensions/duplicate_columns_handler.rb
+++ b/lib/sequel/extensions/duplicate_columns_handler.rb
@@ -1,8 +1,41 @@
 # frozen-string-literal: true
+#
+# The duplicate_columns_handler extension allows you to customize handling of
+# duplicate column names in your queries on a per-database or per-dataset level.
+#
+# For example, you may want to raise an exception if you join 2 tables together
+# which contains a column that will override another columns.
+#
+# To use the extension, you need to load the extension into the database:
+#
+#   DB.extension :duplicate_columns_handler
+#
+# A database option is introduced: :on_duplicate_columns. It accepts a Symbol
+# or any object that responds to :call.
+#
+#   :on_duplicate_columns => :raise
+#   :on_duplicate_columns => :warn
+#   :on_duplicate_columns => :ignore
+#   :on_duplicate_columns => proc { |columns| arbitrary_condition? ? :raise : :warn }
+#
+# You may also configure duplicate columns handling for a specific dataset:
+#
+#   ds.on_duplicate_columns(:warn)
+#   ds.on_duplicate_columns(:raise)
+#   ds.on_duplicate_columns(:ignore)
+#   ds.on_duplicate_columns { |columns| arbitrary_condition? ? :raise : :warn }
+#   ds.on_duplicate_columns(proc { |columns| arbitrary_condition? ? :raise : :warn })
+#
+# If :raise is specified, a Sequel::DuplicateColumnError is raised.
+# If :warn is specified, you will receive a warning via `warn`.
+# If a callable is specified, it will be called.
+# If no on_duplicate_columns is specified, the default is :warn.
+#
+# Related module: Sequel::DuplicateColumnsHandler
 
 module Sequel
-  # TODO DOCS
   module DuplicateColumnsHandler
+    # Customize handling of duplicate columns for this dataset.
     def on_duplicate_columns(handler = nil, &block)
       if block_given?
         if handler.nil?
@@ -19,6 +52,8 @@ module Sequel
       ds
     end
 
+    # Override the attr_writer to check for duplicate columns, and call
+    # handle_duplicate_columns if necessary.
     def columns=(cols)
       if cols.uniq.size != cols.size
         handle_duplicate_columns(cols)
@@ -28,6 +63,7 @@ module Sequel
 
     private
 
+    # Invoke the appropriate behavior when duplicate columns are present.
     def handle_duplicate_columns(cols)
       message = "One or more duplicate columns present in #{cols.inspect}"
 
@@ -39,6 +75,9 @@ module Sequel
       end
     end
 
+    # Try to find dataset option for on_duplicate_columns. If not present on the dataset,
+    # use the on_duplicate_columns option on the database. If not present on the database,
+    # default to :warn.
     def duplicate_columns_handler_type(cols)
       handler = opts.fetch(:on_duplicate_columns){db.opts.fetch(:on_duplicate_columns, :warn)}
 
@@ -50,6 +89,8 @@ module Sequel
     end
   end
 
+  # Error which is raised when duplicate columns are present in a dataset which is configured
+  # to :raise on_duplicate_columns.
   class DuplicateColumnError < Error
   end
 

--- a/lib/sequel/extensions/duplicate_columns_handler.rb
+++ b/lib/sequel/extensions/duplicate_columns_handler.rb
@@ -1,0 +1,66 @@
+# frozen-string-literal: true
+
+module Sequel
+  # TODO DOCS
+  module DuplicateColumnsHandler
+
+    # TODO DOCS
+    module DatasetMethods
+      def on_duplicate_columns(handler = nil, &block)
+        if block_given?
+          if handler.nil?
+            handler = block
+          else
+            raise Error, "Cannot provide both an argument and a block to on_duplicate_columns"
+          end
+        elsif handler.nil?
+          raise Error, "Must provide either an argument or a block to on_duplicate_columns"
+        end
+
+        ds = clone
+        ds.instance_variable_set(:@on_duplicate_columns, handler)
+        ds
+      end
+
+      def columns=(cols)
+        @columns = cols
+        if cols.uniq.size != cols.size
+          handle_duplicate_columns
+        end
+        cols
+      end
+
+      private
+
+      def handle_duplicate_columns
+        message = "One or more duplicate columns present in #{@columns.inspect}"
+
+        case duplicate_columns_handler_type
+        when :raise
+          raise Error.new(message)
+        when :warn
+          warn message
+        end
+      end
+
+      def duplicate_columns_handler_type
+        handler = if @on_duplicate_columns
+          @on_duplicate_columns
+        else
+          db.opts[:on_duplicate_columns] || :warn
+        end
+
+        if handler.respond_to?(:call)
+          handler.call(@columns)
+        else
+          handler
+        end
+      end
+    end
+
+    class Error < Sequel::Error
+    end
+  end
+
+  Dataset.register_extension(:duplicate_columns_handler, Sequel::DuplicateColumnsHandler::DatasetMethods)
+end

--- a/spec/extensions/duplicate_columns_handler_spec.rb
+++ b/spec/extensions/duplicate_columns_handler_spec.rb
@@ -1,0 +1,161 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
+
+describe "Sequel::DuplicateColumnsHandler" do
+
+  def must_warn_for_columns(*cols)
+    out, err = capture_io do
+      @ds.send(:columns=, cols)
+    end
+    err.must_equal("One or more duplicate columns present in #{cols.inspect}\n")
+  end
+
+  def must_raise_for_columns(*cols)
+    proc do
+      @ds.send(:columns=, cols)
+    end.must_raise(Sequel::DuplicateColumnsHandler::Error)
+  end
+
+  def must_not_warn_for_columns(*cols)
+    out, err = capture_io do
+      @ds.send(:columns=, cols)
+    end
+    err.must_equal("")
+  end
+
+  def must_not_raise_for_columns(*cols)
+    @ds.send(:columns=, cols)
+  end
+
+  describe "database-level configuration" do
+    it "should raise error when `on_duplicate_columns` is :raise and 2 or more columns have the same name" do
+      @db = Sequel.mock(:on_duplicate_columns => :raise)
+      @db.extension(:duplicate_columns_handler)
+      @ds = @db[:things]
+      must_raise_for_columns(:id, :name, :id)
+    end
+
+    it "should warn when `on_duplicate_columns` is :warn and 2 or more columns have the same name" do
+      @db = Sequel.mock(:on_duplicate_columns => :warn)
+      @db.extension(:duplicate_columns_handler)
+      @ds = @db[:things]
+      must_warn_for_columns(:id, :name, :id)
+    end
+
+    it "should do nothing when `on_duplicate_columns` is :ignore and 2 or more columns have the same name" do
+      @db = Sequel.mock(:on_duplicate_columns => :ignore)
+      @db.extension(:duplicate_columns_handler)
+      @ds = @db[:things]
+      must_not_warn_for_columns(:id, :name, :id)
+    end
+
+    it "should warn when `on_duplicate_columns` is not specified and 2 or more columns have the same name" do
+      @db = Sequel.mock
+      @db.extension(:duplicate_columns_handler)
+      @ds = @db[:things]
+      must_warn_for_columns(:id, :name, :id)
+    end
+
+    it "should not raise error when `on_duplicate_columns` is :raise and no columns have the same name" do
+      @db = Sequel.mock(:on_duplicate_columns => :raise)
+      @db.extension(:duplicate_columns_handler)
+      @ds = @db[:things]
+      must_not_raise_for_columns(:id, :name)
+    end
+
+    it "should not warn when `on_duplicate_columns` is :warn and no columns have the same name" do
+      @db = Sequel.mock
+      @db.extension(:duplicate_columns_handler)
+      @ds = @db[:things]
+      must_not_warn_for_columns(:id, :name)
+    end
+
+    it "should not warn when `on_duplicate_columns` is not specified and no columns have the same name" do
+      @db = Sequel.mock(:on_duplicate_columns => :warn)
+      @db.extension(:duplicate_columns_handler)
+      @ds = @db[:things]
+      must_not_warn_for_columns(:id, :name)
+    end
+  end
+
+  describe "dataset-level configuration" do
+    before do
+      @db = Sequel.mock
+      @db.extension(:duplicate_columns_handler)
+    end
+
+    it "should raise error when `on_duplicate_columns` is :raise and 2 or more columns have the same name" do
+      @ds = @db[:things].on_duplicate_columns(:raise)
+      must_raise_for_columns(:id, :name, :id)
+    end
+
+    it "should warn when `on_duplicate_columns` is :warn and 2 or more columns have the same name" do
+      @ds = @db[:things].on_duplicate_columns(:warn)
+      must_warn_for_columns(:id, :name, :id)
+    end
+
+    it "should do nothing when `on_duplicate_columns` is :ignore and 2 or more columns have the same name" do
+      @ds = @db[:things].on_duplicate_columns(:ignore)
+      must_not_warn_for_columns(:id, :name, :id)
+    end
+
+    it "should warn when `on_duplicate_columns` is not specified and 2 or more columns have the same name" do
+      @ds = @db[:things]
+      must_warn_for_columns(:id, :name, :id)
+    end
+
+    it "should not raise error when `on_duplicate_columns` is :raise and no columns have the same name" do
+      @ds = @db[:things].on_duplicate_columns(:raise)
+      must_not_raise_for_columns(:id, :name)
+    end
+
+    it "should not warn when `on_duplicate_columns` is :warn and no columns have the same name" do
+      @ds = @db[:things].on_duplicate_columns(:warn)
+      must_not_warn_for_columns(:id, :name)
+    end
+
+    it "should not warn when `on_duplicate_columns` is not specified and no columns have the same name" do
+      @ds = @db[:things]
+      must_not_warn_for_columns(:id, :name)
+    end
+
+    it "should be able to accept a block handler which returns a symbol" do
+      called = false
+      @ds = @db[:things].on_duplicate_columns do
+        called = true
+        :raise
+      end
+      must_raise_for_columns(:id, :name, :id)
+      called.must_equal(true)
+    end
+
+    it "should be able to accept a block handler which performs its own action and does not return anything useful" do
+      called = false
+      @ds = @db[:things].on_duplicate_columns do
+        called = true
+      end
+      must_not_warn_for_columns(:id, :name, :id)
+      called.must_equal(true)
+    end
+
+    it "should not call the block when no columns have the same name" do
+      called = false
+      @ds = @db[:things].on_duplicate_columns do
+        called = true
+      end
+      must_not_warn_for_columns(:id, :name)
+      called.must_equal(false)
+    end
+
+    it "should be able to accept a callable argument handler which returns a symbol" do
+      called = false
+      handler = proc do
+        called = true
+        :raise
+      end
+      @ds = @db[:things].on_duplicate_columns(handler)
+      must_raise_for_columns(:id, :name, :id)
+      called.must_equal(true)
+    end
+  end
+
+end

--- a/spec/extensions/duplicate_columns_handler_spec.rb
+++ b/spec/extensions/duplicate_columns_handler_spec.rb
@@ -1,83 +1,88 @@
 require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
 
 describe "Sequel::DuplicateColumnsHandler" do
-
-  def must_warn_for_columns(*cols)
-    warned = nil
-    @ds.send(:define_singleton_method, :warn) do |message|
-      warned = message
-    end
-    @ds.send(:columns=, cols)
-    warned.must_equal("One or more duplicate columns present in #{cols.inspect}")
-  end
-
-  def must_raise_for_columns(*cols)
-    proc do
-      @ds.send(:columns=, cols)
-    end.must_raise(Sequel::DuplicateColumnError)
-  end
-
-  def must_not_warn_for_columns(*cols)
-    warned = nil
-    @ds.send(:define_singleton_method, :warn) do |message|
-      warned = message
-    end
-    @ds.send(:columns=, cols)
-    warned.must_be_nil
-  end
-
-  def must_not_raise_for_columns(*cols)
-    @ds.send(:columns=, cols)
-  end
-
   describe "database-level configuration" do
     it "should raise error when `on_duplicate_columns` is :raise and 2 or more columns have the same name" do
       @db = Sequel.mock(:on_duplicate_columns => :raise)
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_raise_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      proc do
+        @ds.send(:columns=, cols)
+      end.must_raise(Sequel::DuplicateColumnError)
     end
 
     it "should warn when `on_duplicate_columns` is :warn and 2 or more columns have the same name" do
       @db = Sequel.mock(:on_duplicate_columns => :warn)
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_warn_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_equal("One or more duplicate columns present in #{cols.inspect}")
     end
 
     it "should do nothing when `on_duplicate_columns` is :ignore and 2 or more columns have the same name" do
       @db = Sequel.mock(:on_duplicate_columns => :ignore)
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_not_warn_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
     end
 
     it "should warn when `on_duplicate_columns` is not specified and 2 or more columns have the same name" do
       @db = Sequel.mock
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_warn_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_equal("One or more duplicate columns present in #{cols.inspect}")
     end
 
     it "should not raise error when `on_duplicate_columns` is :raise and no columns have the same name" do
       @db = Sequel.mock(:on_duplicate_columns => :raise)
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_not_raise_for_columns(:id, :name)
+      cols = [:id, :name]
+      @ds.send(:columns=, cols)
     end
 
     it "should not warn when `on_duplicate_columns` is :warn and no columns have the same name" do
       @db = Sequel.mock
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_not_warn_for_columns(:id, :name)
+      cols = [:id, :name]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
     end
 
     it "should not warn when `on_duplicate_columns` is not specified and no columns have the same name" do
       @db = Sequel.mock(:on_duplicate_columns => :warn)
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_not_warn_for_columns(:id, :name)
+      cols = [:id, :name]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
     end
 
     it "should raise when `on_duplicate_columns` is callable and returns :raise and 2 or more columns have the same name" do
@@ -89,8 +94,11 @@ describe "Sequel::DuplicateColumnsHandler" do
       @db = Sequel.mock(:on_duplicate_columns => handler)
       @db.extension(:duplicate_columns_handler)
       @ds = @db[:things]
-      must_raise_for_columns(:id, :name, :id)
-      received_columns.must_equal([:id, :name, :id])
+      cols = [:id, :name, :id]
+      proc do
+        @ds.send(:columns=, cols)
+      end.must_raise(Sequel::DuplicateColumnError)
+      received_columns.must_equal(cols)
     end
   end
 
@@ -102,37 +110,71 @@ describe "Sequel::DuplicateColumnsHandler" do
 
     it "should raise error when `on_duplicate_columns` is :raise and 2 or more columns have the same name" do
       @ds = @db[:things].on_duplicate_columns(:raise)
-      must_raise_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      proc do
+        @ds.send(:columns=, cols)
+      end.must_raise(Sequel::DuplicateColumnError)
     end
 
     it "should warn when `on_duplicate_columns` is :warn and 2 or more columns have the same name" do
       @ds = @db[:things].on_duplicate_columns(:warn)
-      must_warn_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_equal("One or more duplicate columns present in #{cols.inspect}")
     end
 
     it "should do nothing when `on_duplicate_columns` is :ignore and 2 or more columns have the same name" do
       @ds = @db[:things].on_duplicate_columns(:ignore)
-      must_not_warn_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
     end
 
     it "should warn when `on_duplicate_columns` is not specified and 2 or more columns have the same name" do
       @ds = @db[:things]
-      must_warn_for_columns(:id, :name, :id)
+      cols = [:id, :name, :id]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_equal("One or more duplicate columns present in #{cols.inspect}")
     end
 
     it "should not raise error when `on_duplicate_columns` is :raise and no columns have the same name" do
       @ds = @db[:things].on_duplicate_columns(:raise)
-      must_not_raise_for_columns(:id, :name)
+      cols = [:id, :name]
+      @ds.send(:columns=, cols)
     end
 
     it "should not warn when `on_duplicate_columns` is :warn and no columns have the same name" do
       @ds = @db[:things].on_duplicate_columns(:warn)
-      must_not_warn_for_columns(:id, :name)
+      cols = [:id, :name]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
     end
 
     it "should not warn when `on_duplicate_columns` is not specified and no columns have the same name" do
       @ds = @db[:things]
-      must_not_warn_for_columns(:id, :name)
+      cols = [:id, :name]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
     end
 
     it "should be able to accept a block handler which receives a list of columns and returns a symbol" do
@@ -141,18 +183,26 @@ describe "Sequel::DuplicateColumnsHandler" do
         received_columns = columns
         :raise
       end
-      must_raise_for_columns(:id, :name, :id)
-      received_columns.must_equal([:id, :name, :id])
+      cols = [:id, :name, :id]
+      proc do
+        @ds.send(:columns=, cols)
+      end.must_raise(Sequel::DuplicateColumnError)
+      received_columns.must_equal(cols)
     end
 
     it "should be able to accept a block handler which performs its own action and does not return anything useful" do
-      called = false
-      @ds = @db[:things].on_duplicate_columns do
-        called = true
+      received_columns = nil
+      @ds = @db[:things].on_duplicate_columns do |columns|
+        received_columns = columns
       end
-      must_not_warn_for_columns(:id, :name, :id)
-      must_not_raise_for_columns(:id, :name, :id)
-      called.must_equal(true)
+      cols = [:id, :name, :id]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
+      received_columns.must_equal(cols)
     end
 
     it "should not call the block when no columns have the same name" do
@@ -160,7 +210,13 @@ describe "Sequel::DuplicateColumnsHandler" do
       @ds = @db[:things].on_duplicate_columns do
         called = true
       end
-      must_not_warn_for_columns(:id, :name)
+      cols = [:id, :name]
+      warned = nil
+      @ds.send(:define_singleton_method, :warn) do |message|
+        warned = message
+      end
+      @ds.send(:columns=, cols)
+      warned.must_be_nil
       called.must_equal(false)
     end
 
@@ -171,8 +227,11 @@ describe "Sequel::DuplicateColumnsHandler" do
         :raise
       end
       @ds = @db[:things].on_duplicate_columns(handler)
-      must_raise_for_columns(:id, :name, :id)
-      received_columns.must_equal([:id, :name, :id])
+      cols = [:id, :name, :id]
+      proc do
+        @ds.send(:columns=, cols)
+      end.must_raise(Sequel::DuplicateColumnError)
+      received_columns.must_equal(cols)
     end
   end
 

--- a/spec/extensions/duplicate_columns_handler_spec.rb
+++ b/spec/extensions/duplicate_columns_handler_spec.rb
@@ -3,23 +3,27 @@ require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
 describe "Sequel::DuplicateColumnsHandler" do
 
   def must_warn_for_columns(*cols)
-    out, err = capture_io do
-      @ds.send(:columns=, cols)
+    warned = nil
+    @ds.send(:define_singleton_method, :warn) do |message|
+      warned = message
     end
-    err.must_equal("One or more duplicate columns present in #{cols.inspect}\n")
+    @ds.send(:columns=, cols)
+    warned.must_equal("One or more duplicate columns present in #{cols.inspect}")
   end
 
   def must_raise_for_columns(*cols)
     proc do
       @ds.send(:columns=, cols)
-    end.must_raise(Sequel::DuplicateColumnsHandler::Error)
+    end.must_raise(Sequel::DuplicateColumnError)
   end
 
   def must_not_warn_for_columns(*cols)
-    out, err = capture_io do
-      @ds.send(:columns=, cols)
+    warned = nil
+    @ds.send(:define_singleton_method, :warn) do |message|
+      warned = message
     end
-    err.must_equal("")
+    @ds.send(:columns=, cols)
+    warned.must_be_nil
   end
 
   def must_not_raise_for_columns(*cols)


### PR DESCRIPTION
Original discussion: https://github.com/jeremyevans/sequel/issues/954

Continuation: https://github.com/TSMMark/sequel/pull/2

The duplicate_columns_handler extension allows you to customize handling of duplicate column names in your queries on a per-database or per-dataset level.