### PR TITLE
Add a name for Pools to allow identification in pooltimeouts

### DIFF
--- a/lib/sequel/connection_pool.rb
+++ b/lib/sequel/connection_pool.rb
@@ -17,6 +17,7 @@
 #         or for the given shard/server if sharding is supported.
 # max_size :: an integer representing the maximum size of the connection pool,
 #             or the maximum size per shard/server if sharding is supported.
+# name :: a string used to identify the pool in PoolTimeout errors.
 #
 # For sharded connection pools, the sharded API adds the following methods:
 #
@@ -68,6 +69,7 @@ class Sequel::ConnectionPool
 
   # The Sequel::Database object tied to this connection pool.
   attr_accessor :db
+  attr_reader   :name
 
   # Instantiates a connection pool with the given options.  The block is called
   # with a single symbol (specifying the server/shard to use) every time a new

--- a/lib/sequel/connection_pool/sharded_single.rb
+++ b/lib/sequel/connection_pool/sharded_single.rb
@@ -15,6 +15,7 @@ class Sequel::ShardedSingleConnectionPool < Sequel::ConnectionPool
     super
     @conns = {}
     @servers = opts.fetch(:servers_hash, Hash.new(:default))
+    @name = opts[:name]
     add_servers([:default])
     add_servers(opts[:servers].keys) if opts[:servers]
   end

--- a/lib/sequel/connection_pool/sharded_threaded.rb
+++ b/lib/sequel/connection_pool/sharded_threaded.rb
@@ -194,7 +194,7 @@ class Sequel::ShardedThreadedConnectionPool < Sequel::ThreadedConnectionPool
         until conn = _acquire(thread, server)
           deadline ||= time + @timeout
           current_time = Time.now
-          raise(::Sequel::PoolTimeout, "timeout: #{@timeout}, elapsed: #{current_time - time}") if current_time > deadline
+          raise(::Sequel::PoolTimeout, "timeout: #{@timeout}, elapsed: #{current_time - time}, name: #{name}") if current_time > deadline
           # :nocov:
           # It's difficult to get to this point, it can only happen if there is a race condition
           # where a connection cannot be acquired even after the thread is signalled by the condition

--- a/lib/sequel/connection_pool/sharded_threaded.rb
+++ b/lib/sequel/connection_pool/sharded_threaded.rb
@@ -17,6 +17,7 @@ class Sequel::ShardedThreadedConnectionPool < Sequel::ThreadedConnectionPool
   #                  server is used.
   def initialize(db, opts = OPTS)
     super
+    @name = opts[:name]
     @available_connections = {}
     @connections_to_remove = []
     @servers = opts.fetch(:servers_hash, Hash.new(:default))

--- a/lib/sequel/connection_pool/threaded.rb
+++ b/lib/sequel/connection_pool/threaded.rb
@@ -33,6 +33,7 @@ class Sequel::ThreadedConnectionPool < Sequel::ConnectionPool
   #   before raising a PoolTimeoutError (default 5)
   def initialize(db, opts = OPTS)
     super
+    @name = opts[:name]
     @max_size = Integer(opts[:max_connections] || 4)
     raise(Sequel::Error, ':max_connections must be positive') if @max_size < 1
     @mutex = Mutex.new  

--- a/lib/sequel/connection_pool/threaded.rb
+++ b/lib/sequel/connection_pool/threaded.rb
@@ -161,7 +161,7 @@ class Sequel::ThreadedConnectionPool < Sequel::ConnectionPool
         until conn = _acquire(thread)
           deadline ||= time + @timeout
           current_time = Time.now
-          raise(::Sequel::PoolTimeout, "timeout: #{@timeout}, elapsed: #{current_time - time}") if current_time > deadline
+          raise(::Sequel::PoolTimeout, "timeout: #{@timeout}, elapsed: #{current_time - time}, name: #{name}") if current_time > deadline
           # :nocov:
           # It's difficult to get to this point, it can only happen if there is a race condition
           # where a connection cannot be acquired even after the thread is signalled by the condition

--- a/spec/core/connection_pool_spec.rb
+++ b/spec/core/connection_pool_spec.rb
@@ -301,10 +301,10 @@ ThreadedConnectionPoolSpecs = shared_description do
 
   it "should raise a PoolTimeout error if a connection couldn't be acquired before timeout" do
     q, q1 = Queue.new, Queue.new
-    pool = Sequel::ConnectionPool.get_pool(mock_db.call(&@icpp), @cp_opts.merge(:max_connections=>1, :pool_timeout=>0))
+    pool = Sequel::ConnectionPool.get_pool(mock_db.call(&@icpp), @cp_opts.merge(:max_connections=>1, :pool_timeout=>0, :name => "testing"))
     t = Thread.new{pool.hold{|c| q1.push nil; q.pop}}
     q1.pop
-    proc{pool.hold{|c|}}.must_raise(Sequel::PoolTimeout)
+    proc{pool.hold{|c|}}.must_raise(Sequel::PoolTimeout).message.must_match "name: testing"
     q.push nil
     t.join
   end

--- a/spec/core/connection_pool_spec.rb
+++ b/spec/core/connection_pool_spec.rb
@@ -42,6 +42,11 @@ describe "ConnectionPool options" do
     lambda{Sequel::ConnectionPool.get_pool(mock_db.call{1}, :max_connections=>'-10')}.must_raise(Sequel::Error)
     lambda{Sequel::ConnectionPool.get_pool(mock_db.call{1}, :max_connections=>'0')}.must_raise(Sequel::Error)
   end
+
+  it "should support an optional pool name" do
+    cpool = Sequel::ConnectionPool.get_pool(mock_db.call, {:name => 'testing'})
+    cpool.name.must_equal 'testing'
+  end
 end
 
 describe "A connection pool handling connections" do


### PR DESCRIPTION
We are having issues with pooltimeouts in an app with several pools to several databases.

This adds a name attribute, which is logged in a PoolTimeout message which would help us identify which of our databases we're having issues with in the logs.

Is there a better alternative to name: nil in the logs when there's no name, should it just not log the name: part if there's no name, or should there be a default name?