### PR TITLE
Change Sequel::Model#lock! to accept a lock style

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,8 @@
 
 * Allow json_serializer :include option with cascaded values to work correctly when used with association_proxies (jeremyevans)
 
+* Allow Sequel::Model#lock! to accept an (optional) lock style (similarly to Dataset#lock_style) (petedmarsh)
+
 === 4.34.0 (2016-05-01)
 
 * Add support for :dataset_associations_join association option to dataset_associations plugin, for making resulting datasets have appropriate joins (jeremyevans)

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1402,17 +1402,31 @@ module Sequel
         @values.keys
       end
       
-      # Refresh this record using +for_update+ unless this is a new record.  Returns self.
-      # This can be used to make sure no other process is updating the record at the
-      # same time.
+      # Refresh this record using +for_update+ (by default, or the specified style when given)
+      # unless this is a new record.  Returns self. This can be used to make sure no other
+      # process is updating the record at the same time.
+      #
+      # If style is a string, it will be used directly. You should never pass a string
+      # to this method that is derived from user input, as that can lead to
+      # SQL injection.
+      #
+      # A symbol may be used for database independent locking behavior, but
+      # all supported symbols have separate methods (e.g. for_update).
+      #
       #
       #   a = Artist[1]
       #   Artist.db.transaction do
       #     a.lock!
       #     a.update(:name=>'A')
       #   end
-      def lock!
-        _refresh(this.for_update) unless new?
+      #
+      #  a = Artist[2]
+      #  Artist.db.transaction do
+      #    a.lock!('FOR NO KEY UPDATE')
+      #    a.update(:name=>'B')
+      #  end
+      def lock!(style=:update)
+        _refresh(this.lock_style(style)) unless new?
         self
       end
       

--- a/spec/model/record_spec.rb
+++ b/spec/model/record_spec.rb
@@ -2142,6 +2142,15 @@ describe "Model#lock!" do
     o.instance_variable_get(:@a).must_equal 1
     DB.sqls.must_equal ["SELECT * FROM items WHERE (id = 1) LIMIT 1 FOR UPDATE"]
   end
+
+  it "should refresh the record using the specified lock when it is not a new record and a style is given" do
+    o = @c.load(:id => 1)
+    def o._refresh(x) instance_variable_set(:@a, 1); super(x) end
+    x = o.lock!('FOR NO KEY UPDATE')
+    x.must_equal o
+    o.instance_variable_get(:@a).must_equal 1
+    DB.sqls.must_equal ["SELECT * FROM items WHERE (id = 1) LIMIT 1 FOR NO KEY UPDATE"]
+  end
 end
 
 describe "Model#schema_type_class" do


### PR DESCRIPTION
Previously lock! locked the row the model represented with whatever
Dataset#for_update resolved to for the underlying database. This
changes it to accept an optional style of lock that will be aquired
instead (working as Dataset#lock_style does):

    e = Example.first
    e.lock!
    #=> SELECT * FROM examples WHERE id = 1 FOR UPDATE LIMIT 1

    e = Example.first
    e.lock!('FOR NO KEY UPDATE')
    #=> SELECT * FROM examples WHERE id = 1 FOR NO KEY UPDATE LIMIT 1