### PR TITLE
Add Postgres Bignum -> bigserial fix

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1143,7 +1143,7 @@ module Sequel
 
       # Handle bigserial type if :serial option is present
       def type_literal_generic_bignum(column)
-        column[:serial] ? :bigserial : super
+        column[:serial] && !column.include?(:default) ? :bigserial : super
       end
 
       # PostgreSQL uses the bytea data type for blobs


### PR DESCRIPTION
Do convert Bignum to bigserial on Postgres, but
only if the default value has not been specified.

Otherwise, Postgres errors out with:

ERROR:  multiple default values specified for column "..." of table "..."