### PR TITLE
add YARD configuration to improve documentation compability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 *.swp
 /coverage
 /rdoc
+/doc/**/*.html
+/doc/css
+/doc/js
+/.yardoc
 /sequel-*.gem
 /spec/bin-sequel-*
 /spec/spec_config.rb

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,6 @@
+--no-private
+--title "Sequel: The Database Toolkit for Ruby"
+lib/**/*.rb
+-q
+-
+doc/*.rdoc

--- a/sequel.gemspec
+++ b/sequel.gemspec
@@ -13,7 +13,7 @@ SEQUEL_GEMSPEC = Gem::Specification.new do |s|
   s.homepage = "http://sequel.jeremyevans.net"
   s.license = 'MIT'
   s.required_ruby_version = ">= 1.8.7"
-  s.files = %w(MIT-LICENSE CHANGELOG README.rdoc Rakefile bin/sequel) + Dir["doc/**/*.{rdoc,txt}"] + Dir["{spec,lib}/**/*.{rb,RB}"]
+  s.files = %w(MIT-LICENSE CHANGELOG README.rdoc Rakefile bin/sequel .yardopts) + Dir["doc/**/*.{rdoc,txt}"] + Dir["{spec,lib}/**/*.{rb,RB}"]
   s.require_path = "lib"
   s.bindir = 'bin'
   s.executables << 'sequel'


### PR DESCRIPTION
While this project natively uses RDoc documentation format, it is possible to
use it with [YARD][1] without any major modifications.

One of the reasons why it might be useful is usage with offline documentation
tools that use YARD to generate HTML documentation from both RDoc and YARD input.
One popular example of such applications is [Dash][2].

Prior to this commit, the documentation converted that way included only
information that was embedded directly in the code, and all useful documents
from `doc/*.rdoc` were missing.

[1]: http://yardoc.org/
[2]: https://kapeli.com/dash