### PR TITLE
Add connection_expiration extension for automatically disconnecting c…

### DIFF
--- a/lib/sequel/extensions/connection_expiration.rb
+++ b/lib/sequel/extensions/connection_expiration.rb
@@ -1,0 +1,88 @@
+# frozen-string-literal: true
+#
+# The connection_expiration extension modifies a database's
+# connection pool to validate that connections checked out
+# from the pool are not expired, before yielding them for
+# use.  If it detects an expired connection, it removes it
+# from the pool and tries the next available connection,
+# creating a new connection if no available connection is
+# unexpired.  Example of use:
+#
+#   DB.extension(:connection_expiration)
+#
+# Note that this extension only affects the default threaded
+# and the sharded threaded connection pool.  The single
+# threaded and sharded single threaded connection pools are
+# not affected.  As the only reason to use the single threaded
+# pools is for speed, and this extension makes the connection
+# pool slower, there's not much point in modifying this
+# extension to work with the single threaded pools.  The
+# threaded pools work fine even in single threaded code, so if
+# you are currently using a single threaded pool and want to
+# use this extension, switch to using a threaded pool.
+#
+# Related module: Sequel::ConnectionExpiration
+
+#
+module Sequel
+  module ConnectionExpiration
+    class Retry < Error; end
+
+    # The number of seconds that need to pass since
+    # connection creation before expiring a connection.
+    # Defaults to 14400 seconds (4 hours).
+    attr_accessor :connection_expiration_timeout
+
+    # Initialize the data structures used by this extension.
+    def self.extended(pool)
+      pool.instance_eval do
+        @connection_expiration_timestamps ||= {}
+        @connection_expiration_timeout = 14400
+      end
+    end
+
+    private
+
+    # Record the time the connection was created.
+    def make_new(*)
+      conn = super
+      @connection_expiration_timestamps[conn] = Time.now
+      conn
+    end
+
+    # When acquiring a connection, check if the connection is expired.
+    # If it is expired, disconnect the connection, and retry with a new
+    # connection.
+    def acquire(*a)
+      begin
+        if (conn = super) &&
+           (t = @connection_expiration_timestamps[conn]) &&
+           Time.now - t > @connection_expiration_timeout
+
+          if pool_type == :sharded_threaded
+            sync{allocated(a.last).delete(Thread.current)}
+          else
+            sync{@allocated.delete(Thread.current)}
+          end
+
+          @connection_expiration_timestamps.delete(conn)
+          db.disconnect_connection(conn)
+          raise Retry
+        end
+      rescue Retry
+        retry
+      end
+
+      conn
+    end
+
+    # Clean up expiration timestamps when connections are 
+    def disconnect(*)
+      @connection_expiration_timestamps.delete(conn)
+      super
+    end
+  end
+
+  Database.register_extension(:connection_expiration){|db| db.pool.extend(ConnectionExpiration)}
+end
+

--- a/spec/extensions/connection_expiration_spec.rb
+++ b/spec/extensions/connection_expiration_spec.rb
@@ -1,0 +1,109 @@
+require File.join(File.dirname(File.expand_path(__FILE__)), "spec_helper")
+
+connection_expiration_specs = shared_description do
+  describe "connection expiration" do
+    before do
+      @db.extend(Module.new do
+        def disconnect_connection(conn)
+          @sqls << 'disconnect'
+        end
+      end)
+      @db.extension(:connection_expiration)
+      @db.pool.connection_expiration_timeout = 2
+    end
+
+    it "should still allow new connections" do
+      @db.synchronize{|c| c}.must_be_kind_of(Sequel::Mock::Connection)
+    end
+
+    it "should only expire if older than timeout" do
+      c1 = @db.synchronize{|c| c}
+      @db.sqls.must_equal []
+      @db.synchronize{|c| c}.must_be_same_as(c1)
+      @db.sqls.must_equal []
+    end
+
+    it "should disconnect connection if expired" do
+      c1 = @db.synchronize{|c| c}
+      @db.sqls.must_equal []
+      simulate_sleep(c1)
+      c2 = @db.synchronize{|c| c}
+      @db.sqls.must_equal ['disconnect']
+      c2.wont_be_same_as(c1)
+    end
+
+    it "should disconnect only expired connections among multiple" do
+      c1, c2 = multiple_connections
+
+      # Expire c1 only.
+      simulate_sleep(c1)
+      simulate_sleep(c2, 1)
+      c1, c2 = multiple_connections
+
+      c3 = @db.synchronize{|c| c}
+      @db.sqls.must_equal ['disconnect']
+      c3.wont_be_same_as(c1)
+      c3.must_be_same_as(c2)
+    end
+
+    it "should disconnect connections repeatedly if they are expired" do
+      c1, c2 = multiple_connections
+
+      simulate_sleep(c1)
+      simulate_sleep(c2)
+
+      c3 = @db.synchronize{|c| c}
+      @db.sqls.must_equal ['disconnect', 'disconnect']
+      c3.wont_be_same_as(c1)
+      c3.wont_be_same_as(c2)
+    end
+
+    it "should not leak connection references to expiring connections" do
+      c1 = @db.synchronize{|c| c}
+      simulate_sleep(c1)
+      c2 = @db.synchronize{|c| c}
+      c2.wont_be_same_as(c1)
+      @db.pool.instance_variable_get(:@connection_expiration_timestamps).must_include(c2)
+      @db.pool.instance_variable_get(:@connection_expiration_timestamps).wont_include(c1)
+    end
+
+    def multiple_connections
+      q, q1 = Queue.new, Queue.new
+      c1 = nil
+      c2 = nil
+      @db.synchronize do |c|
+        Thread.new do
+          @db.synchronize do |cc|
+            c2 = cc
+          end
+          q1.pop
+          q.push nil
+        end
+        q1.push nil
+        q.pop
+        c1 = c
+      end
+      [c1, c2]
+    end
+
+    # Set the timestamp back in time to simulate sleep / passage of time.
+    def simulate_sleep(conn, sleep_time = 3)
+      timestamps = @db.pool.instance_variable_get(:@connection_expiration_timestamps)
+      timestamps[conn] -= sleep_time
+      @db.pool.instance_variable_set(:@connection_expiration_timestamps, timestamps)
+    end
+  end
+end
+
+describe "Sequel::ConnectionExpiration with threaded pool" do
+  before do
+    @db = Sequel.mock
+  end
+  include connection_expiration_specs
+end
+describe "Sequel::ConnectionExpiration with sharded threaded pool" do
+  before do
+    @db = Sequel.mock(:servers=>{})
+  end
+  include connection_expiration_specs
+end


### PR DESCRIPTION
…onnections after an expiration time.

This is useful in cases where the recommendation is not to maintain open connections for an extended period of time such as with RDS (see https://forums.aws.amazon.com/message.jspa?messageID=546388#546388).