### PR TITLE
JDBC#connect: obey the frozen string literal rule

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -224,7 +224,7 @@ module Sequel
               c
             rescue JavaSQL::SQLException, NativeException, StandardError => e2
               unless e2.message == e.message
-                e2.message << "\n#{e.class.name}: #{e.message}"
+                e2.message = "#{e2.message}\n#{e.class.name}: #{e.message}"
               end
               raise e2
             end


### PR DESCRIPTION
When I had a bad connection string and it was unable to connect, the error exception's message was a frozen String, which led to me not being able to see it, since `#connect` seems like it wants to `<<` onto the `e2.message`. jruby-9.1.2.0

This PR tries to edge around that problem by replacing the full string instead of appending to it.

```
Sequel::DatabaseConnectionError: RuntimeError: can't modify frozen String

/home/foobar/.app-gems/jruby/2.3.0/gems/sequel-4.36.0/lib/sequel/adapters/jdbc.rb:227:in `connect'
/home/foobar/.app-gems/jruby/2.3.0/gems/sequel-4.36.0/lib/sequel/connection_pool.rb:110:in `make_new'
/home/foobar/.app-gems/jruby/2.3.0/gems/sequel-4.36.0/lib/sequel/connection_pool/threaded.rb:226:in `make_new'
/home/foobar/.app-gems/jruby/2.3.0/gems/sequel-4.36.0/lib/sequel/connection_pool/threaded.rb:199:in `available'
/home/foobar/.app-gems/jruby/2.3.0/gems/sequel-4.36.0/lib/sequel/connection_pool/threaded.rb:135:in `_acquire'
/home/foobar/.app-gems/jruby/2.3.0/gems/sequel-4.36.0/lib/sequel/connection_pool/threaded.rb:149:in `block in acquire'
/home/foobar/.app-gems/jruby/2.3.0/gems/sequel-4.36.0/lib/sequel/connection_pool/threaded.rb:280:in `block in sync'
```