### PR TITLE
Make MigrationAlterTableReverser work with add_constraint with name in a hash

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -245,7 +245,9 @@ module Sequel
     end
 
     def add_constraint(*args)
-      @actions << [:drop_constraint, args.first]
+      name = args.first
+      name = name.is_a?(Hash) ? name[:name] : name
+      @actions << [:drop_constraint, name]
     end
 
     def add_foreign_key(key, table, *args)

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -129,6 +129,7 @@ describe "Reversible Migrations with Sequel.migration{change{}}" do
       alter_table(:b) do
         add_column :d, String
         add_constraint :blah, 'd IS NOT NULL'
+        add_constraint({:name=>:merp}, 'a > 1')
         add_foreign_key :e, :b
         add_foreign_key [:e], :b, :name=>'e_fk'
         add_foreign_key [:e, :a], :b
@@ -154,6 +155,7 @@ describe "Reversible Migrations with Sequel.migration{change{}}" do
       [:alter_table, [
         [:add_column, :d, String],
         [:add_constraint, :blah, "d IS NOT NULL"],
+        [:add_constraint, {:name=>:merp}, "a > 1"],
         [:add_foreign_key, :e, :b],
         [:add_foreign_key, [:e], :b, {:name=>"e_fk"}],
         [:add_foreign_key, [:e, :a], :b],
@@ -182,6 +184,7 @@ describe "Reversible Migrations with Sequel.migration{change{}}" do
         [:drop_foreign_key, [:e, :a]],
         [:drop_foreign_key, [:e], {:name=>"e_fk"}],
         [:drop_foreign_key, :e],
+        [:drop_constraint, :merp],
         [:drop_constraint, :blah],
         [:drop_column, :d]]
       ],


### PR DESCRIPTION
If you are using postgresql and you want to have a reversible migration with an `add_constraint` and `:not_valid => true` like this:

```ruby
Sequel.migration do
  change do
    alter_table :my_table do
      add_constraint({:name => :new_check, :not_valid => true}, 'col_a > 5')
    end
  end
end
```

You will get an error like this: `PG::UndefinedObject: ERROR:  constraint "{:name => :new_check, :not_valid => true}" of relation "my_table" does not exist`

This patch fixes this.