### PR TITLE
Added `#mssql_sproc_ds` method

### DIFF
--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -141,7 +141,7 @@ module Sequel
 
         ds = dataset.with_sql(sql)
         ds = ds.server(opts[:server]) if opts[:server]
-        ds
+        ds.all
       end
 
       # Microsoft SQL Server uses the :mssql type.

--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -38,6 +38,8 @@ module Sequel
 
       # Execute the given stored procedure with the given name.
       #
+      # This method returns a single hash. See call_mssql_sproc.
+      #
       # Options:
       # :args :: Arguments to stored procedure.  For named arguments, this should be a
       #          hash keyed by argument named.  For unnamed arguments, this should be an
@@ -64,6 +66,33 @@ module Sequel
       #       'output_arg_name' => [:output, 'int', 'varname']
       #     })
       def call_mssql_sproc(name, opts=OPTS)
+        mssql_sproc_ds(name, opts).first
+      end
+
+      # Execute the given stored procedure with the given name.
+      #
+      # Options:
+      # :args :: Arguments to stored procedure.  For named arguments, this should be a
+      #          hash keyed by argument named.  For unnamed arguments, this should be an
+      #          array.  Output parameters to the function are specified using :output.
+      #          You can also name output parameters and provide a type by using an
+      #          array containing :output, the type name, and the parameter name.
+      # :server :: The server/shard on which to execute the procedure.
+      #
+      # This method returns a Dataset.
+      #
+      # Examples:
+      #
+      #     DB.mssql_sproc_ds(:SequelTest, {:args => ['input arg', :output]})
+      #     DB.mssql_sproc_ds(:SequelTest, {:args => ['input arg', [:output, 'int', 'varname']]})
+      #
+      #     named params:
+      #     DB.mssql_sproc_ds(:SequelTest, :args => {
+      #       'input_arg1_name' => 'input arg1 value',
+      #       'input_arg2_name' => 'input arg2 value',
+      #       'output_arg_name' => [:output, 'int', 'varname']
+      #     })
+      def mssql_sproc_ds(name, opts=OPTS)
         args = opts[:args] || []
         names = ['@RC AS RESULT', '@@ROWCOUNT AS NUMROWS']
         declarations = ['@RC int']
@@ -112,7 +141,7 @@ module Sequel
 
         ds = dataset.with_sql(sql)
         ds = ds.server(opts[:server]) if opts[:server]
-        ds.first
+        ds
       end
 
       # Microsoft SQL Server uses the :mssql type.

--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -141,7 +141,7 @@ module Sequel
 
         ds = dataset.with_sql(sql)
         ds = ds.server(opts[:server]) if opts[:server]
-        ds.all
+        ds
       end
 
       # Microsoft SQL Server uses the :mssql type.

--- a/spec/adapters/mssql_spec.rb
+++ b/spec/adapters/mssql_spec.rb
@@ -670,7 +670,7 @@ describe "MSSQL Stored Procedure support" do
   describe "with dataset" do
     it "should return a Dataset with the hash of output variables" do
       r = @db.mssql_sproc_ds(:SequelTest, {:args => [@now, 1, :output, :output]})
-      r.must_be_kind_of(Array)
+      r.must_be_kind_of(Dataset)
       r.first.must_be_kind_of(Hash)
     end
   end

--- a/spec/adapters/mssql_spec.rb
+++ b/spec/adapters/mssql_spec.rb
@@ -667,6 +667,14 @@ describe "MSSQL Stored Procedure support" do
     @db.execute('DROP PROCEDURE dbo.SequelTest')
   end
 
+  describe "with dataset" do
+    it "should return a Dataset with the hash of output variables" do
+      r = @db.mssql_sproc_ds(:SequelTest, {:args => [@now, 1, :output, :output]})
+      r.must_be_kind_of(Dataset)
+      r.first.must_be_kind_of(Hash)
+    end
+  end
+
   describe "with unnamed parameters" do
     it "should return a hash of output variables" do
       r = @db.call_mssql_sproc(:SequelTest, {:args => [@now, 1, :output, :output]})

--- a/spec/adapters/mssql_spec.rb
+++ b/spec/adapters/mssql_spec.rb
@@ -670,7 +670,7 @@ describe "MSSQL Stored Procedure support" do
   describe "with dataset" do
     it "should return a Dataset with the hash of output variables" do
       r = @db.mssql_sproc_ds(:SequelTest, {:args => [@now, 1, :output, :output]})
-      r.must_be_kind_of(Dataset)
+      r.must_be_kind_of(Array)
       r.first.must_be_kind_of(Hash)
     end
   end


### PR DESCRIPTION
To be able to use multiple results from a Stored Procedure this method is added that returns the entire dataset.