### PR TITLE
Remove 'not initialized instance variable' warning

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1290,6 +1290,7 @@ module Sequel
       #     a.name = 'Bob'
       #   end
       def initialize(values = {})
+        @singleton_setter_added = false
         @values = {}
         @new = true
         @modified = true


### PR DESCRIPTION
Hello,
I use `Sequel::Model` in simple sinatra app and when I call tests I see warning about instance variable like this:
```
User
  validation
    when user does not have name
../gems/sequel-4.37.0/lib/sequel/model/base.rb:2307: warning: instance variable @singleton_setter_added not initialized
      should not be valid
```

That's why I created this PR which fixed this warning.

_P.S.: should I create some tests for this?_