### PR TITLE
Add #paged_each to odbc dataset for loading large datasets

### DIFF
--- a/lib/sequel/adapters/odbc.rb
+++ b/lib/sequel/adapters/odbc.rb
@@ -93,13 +93,17 @@ module Sequel
 
       Database::DatasetClass = self
 
+      def paged_each(opts=OPTS, &block)
+        clone({:rows_per_fetch=>1000}.merge!(opts)).each(&block)
+      end
+
       def fetch_rows(sql)
         execute(sql) do |s|
           i = -1
           cols = s.columns(true).map{|c| [output_identifier(c.name), c.type, i+=1]}
           columns = cols.map{|c| c.at(0)}
           self.columns = columns
-          if rows = s.fetch_all
+          fetch_raw_rows(s) do |rows|
             rows.each do |row|
               hash = {}
               cols.each{|n,t,j| hash[n] = convert_odbc_value(row[j], t)}
@@ -111,6 +115,16 @@ module Sequel
       end
       
       private
+
+      def fetch_raw_rows(statement)
+        if opts[:rows_per_fetch]
+          while rows = statement.fetch_many(opts[:rows_per_fetch])
+            yield rows
+          end
+        else
+          yield statement.fetch_all
+        end
+      end
 
       def convert_odbc_value(v, t)
         # When fetching a result set, the Ruby ODBC driver converts all ODBC 


### PR DESCRIPTION
When loading large datasets, we don't want to load all the rows in at once, but rather load them in a chunk at a time.  This follows the same API as in Postgres::DataSet's #paged_each.