### PR TITLE
Support weeks and hours in pg_interval extension.

### DIFF
--- a/lib/sequel/extensions/pg_interval.rb
+++ b/lib/sequel/extensions/pg_interval.rb
@@ -42,7 +42,7 @@ module Sequel
   module Postgres
     module IntervalDatabaseMethods
       EMPTY_INTERVAL = '0'.freeze
-      DURATION_UNITS = [:years, :months, :days, :minutes, :seconds].freeze
+      DURATION_UNITS = [:years, :months, :weeks, :days, :hours, :minutes, :seconds].freeze
 
       # Return an unquoted string version of the duration object suitable for
       # use as a bound variable.

--- a/spec/extensions/pg_interval_spec.rb
+++ b/spec/extensions/pg_interval_spec.rb
@@ -15,6 +15,7 @@ describe "pg_interval extension" do
     @db.literal(ActiveSupport::Duration.new(0, [])).must_equal "'0'::interval"
     @db.literal(ActiveSupport::Duration.new(0, [[:seconds, 0]])).must_equal "'0'::interval"
     @db.literal(ActiveSupport::Duration.new(0, [[:seconds, 10], [:minutes, 20], [:days, 3], [:months, 4], [:years, 6]])).must_equal "'6 years 4 months 3 days 20 minutes 10 seconds '::interval"
+    @db.literal(ActiveSupport::Duration.new(0, [[:seconds, 10], [:minutes, 20], [:hours, 8], [:days, 3], [:weeks, 2], [:months, 4], [:years, 6]])).must_equal "'6 years 4 months 2 weeks 3 days 8 hours 20 minutes 10 seconds '::interval"
     @db.literal(ActiveSupport::Duration.new(0, [[:seconds, -10.000001], [:minutes, -20], [:days, -3], [:months, -4], [:years, -6]])).must_equal "'-6 years -4 months -3 days -20 minutes -10.000001 seconds '::interval"
   end
 


### PR DESCRIPTION
See #1232. This fix is pretty simple and only handles literalization, to remain backwards compatible with earlier versions of ActiveSupport. I suppose it'd be nice to tweak the parsing to populate the week and hour parts, but it'd require checking the current version of ActiveSupport supports that, and felt like it wouldn't really be worth the trouble.