### PR TITLE
Supports AFTER and FIRST MySQL column positioning options for migrations

### DIFF
--- a/doc/schema_modification.rdoc
+++ b/doc/schema_modification.rdoc
@@ -339,6 +339,11 @@ hash:
     add_column :copies_sold, Integer, :default=>0
   end
 
+The +add_column+ method also accepts some additional options:
+
+:after :: The name of an existing column that the new column should be positioned after within the table row.
+:first :: Create this new column at the first position within the table row.
+
 === +drop_column+
 
 As you may expect, +drop_column+ takes a column name and drops the column.  It's

--- a/lib/sequel/adapters/shared/mysql.rb
+++ b/lib/sequel/adapters/shared/mysql.rb
@@ -197,6 +197,12 @@ module Sequel
             sql << "CONSTRAINT #{quote_identifier(constraint_name)} "
           end
           sql << "FOREIGN KEY (#{quote_identifier(op[:name])})#{column_references_sql(op)}"
+        elsif after_col = op.delete(:after)
+          sql = super.dup
+          sql << " AFTER #{quote_identifier(after_col)}"
+        elsif op.delete(:first)
+          sql = super.dup
+          sql << " FIRST"
         else
           super
         end

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -515,6 +515,24 @@ describe "A MySQL database" do
     end
   end
 
+  it "should correctly format ALTER TABLE statements with specified after column" do
+    @db.create_table(:items){Integer :id; Integer :value}
+    @db.alter_table(:items){add_column :name, String, :after=>:id}
+    check_sqls do
+      @db.sqls.must_equal ["CREATE TABLE `items` (`id` integer, `value` integer)",
+        "ALTER TABLE `items` ADD COLUMN `name` varchar(255) AFTER `id`"]
+    end
+  end
+
+  it "should correctly format ALTER TABLE statements with specified first option" do
+    @db.create_table(:items){Integer :id; Integer :value}
+    @db.alter_table(:items){add_column :name, String, :first => true}
+    check_sqls do
+      @db.sqls.must_equal ["CREATE TABLE `items` (`id` integer, `value` integer)",
+        "ALTER TABLE `items` ADD COLUMN `name` varchar(255) FIRST"]
+    end
+  end
+
   it "should have rename_column support keep existing options" do
     @db.create_table(:items){String :id, :null=>false, :default=>'blah'}
     @db.alter_table(:items){rename_column :id, :nid}


### PR DESCRIPTION
This PR allows columns to be added at a specific position within a table row by using `AFTER` and `FIRST` when using `alter_table(:some_table) { add_column ... }` MySQL schema generators.