### PR TITLE
Add block support to Sequel::Model::Errors#add

### DIFF
--- a/lib/sequel/model/errors.rb
+++ b/lib/sequel/model/errors.rb
@@ -7,11 +7,16 @@ module Sequel
     class Errors < ::Hash
       ATTRIBUTE_JOINER = ' and '.freeze
 
-      # Adds an error for the given attribute.
-      #
+      # Adds an error for the given attribute. If a block is given, only adds the error if the block returns false,
+      # and there are no other errors already associated with the attribute.
       #   errors.add(:name, 'is not valid') if name == 'invalid'
       def add(att, msg)
-        fetch(att){self[att] = []} << msg
+        att_errors = fetch(att){self[att] = []}
+        if block_given?
+          att_errors << msg if self[att].empty? && !yield
+        else
+          att_errors << msg
+        end
       end
 
       # Return the total number of error messages.


### PR DESCRIPTION
This is something I've been monkey patching in my projects, and figured it's probably worth adding to Sequel.

Here's the idea. Often when validating fields, a single field may have many validations. For example you may first check the format is correct, and then check that the value is within range; there's no use checking if the value is within range if it's not even in the right format to begin with. The block provides a convenient mechanism for this common situation. Refer to the following contrived example:

``` ruby
errors.add(:start_date, "Start date must be a valid date") { DateTime === start_date }
errors.add(:start_date, "Start date must not be in the past") { start_date >= DateTime.today }
```

In the example above, the second validation is only checked is there's not already an error associated with the `start_date` field. The block defines the valid condition, so it it returns false, the validation has failed, and the error message is appended.

Let me know if you would like me to add unit tests for this change.