### PR TITLE
Support specifying the predicate of a partial unique index in Dataset#insert_conflict

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1407,7 +1407,7 @@ module Sequel
       # ON CONFLICT. With no options, uses ON CONFLICT DO NOTHING.  Options:
       # :constraint :: An explicit constraint name, has precendence over :target.
       # :target :: The column name or expression to handle uniqueness violations on.
-      # :where :: The index filter, when using a partial index to determine uniqueness.
+      # :conflict_where :: The index filter, when using a partial index to determine uniqueness.
       # :update :: A hash of columns and values to set.  Uses ON CONFLICT DO UPDATE.
       # :update_where :: A WHERE condition to use for the update.
       #
@@ -1425,7 +1425,7 @@ module Sequel
       #   # INSERT INTO TABLE (a, b) VALUES (1, 2)
       #   # ON CONFLICT (a) DO NOTHING
       #
-      #   DB[:table].insert_conflict(:target=>:a, :where=>{:c=>true}).insert(:a=>1, :b=>2)
+      #   DB[:table].insert_conflict(:target=>:a, :conflict_where=>{:c=>true}).insert(:a=>1, :b=>2)
       #   # INSERT INTO TABLE (a, b) VALUES (1, 2)
       #   # ON CONFLICT (a) WHERE (c IS TRUE) DO NOTHING
       #   
@@ -1649,9 +1649,9 @@ module Sequel
           elsif target = opts[:target]
             sql << ' '
             identifier_append(sql, Array(target))
-            if where = opts[:where]
+            if conflict_where = opts[:conflict_where]
               sql << " WHERE "
-              literal_append(sql, where)
+              literal_append(sql, conflict_where)
             end
           end
 

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -203,7 +203,7 @@ describe "PostgreSQL", 'INSERT ON CONFLICT' do
     @ds.insert_conflict.insert(1, 3, 4).must_equal nil
     @ds.insert_conflict.insert(11, 12, 3, true).must_equal nil
     @ds.insert_conflict(:target=>:a).insert(1, 3, 4).must_equal nil
-    @ds.insert_conflict(:target=>:c, :where=>:c_is_unique).insert(11, 12, 3, true).must_equal nil
+    @ds.insert_conflict(:target=>:c, :conflict_where=>:c_is_unique).insert(11, 12, 3, true).must_equal nil
     @ds.insert_conflict(:constraint=>:ic_test_a_uidx).insert(1, 3, 4).must_equal nil
     @ds.all.must_equal [{:a=>1, :b=>2, :c=>3, :c_is_unique=>false}, {:a=>10, :b=>11, :c=>3, :c_is_unique=>true}]
   end
@@ -235,7 +235,7 @@ describe "PostgreSQL", 'INSERT ON CONFLICT' do
 
   it "Dataset#insert_conflict should respect expressions in the target argument" do
     @ds.insert_conflict(:target=>:a).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"a\") DO NOTHING"
-    @ds.insert_conflict(:target=>:c, :where=>{:c_is_unique=>true}).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"c\") WHERE (\"c_is_unique\" IS TRUE) DO NOTHING"
+    @ds.insert_conflict(:target=>:c, :conflict_where=>{:c_is_unique=>true}).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"c\") WHERE (\"c_is_unique\" IS TRUE) DO NOTHING"
     @ds.insert_conflict(:target=>[:b, :c]).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"b\", \"c\") DO NOTHING"
     @ds.insert_conflict(:target=>[:b, Sequel.function(:round, :c)]).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"b\", round(\"c\")) DO NOTHING"
     @ds.insert_conflict(:target=>[:b, Sequel.virtual_row{|o| o.round(:c)}]).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"b\", round(\"c\")) DO NOTHING"

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -184,7 +184,7 @@ end
 describe "PostgreSQL", 'INSERT ON CONFLICT' do
   before(:all) do
     @db = DB
-    @db.create_table!(:ic_test){Integer :a; Integer :b; Integer :c; unique :a, :name=>:ic_test_a_uidx; unique [:b, :c], :name=>:ic_test_b_c_uidx}
+    @db.create_table!(:ic_test){Integer :a; Integer :b; Integer :c; TrueClass :c_is_unique, :default=>false; unique :a, :name=>:ic_test_a_uidx; unique [:b, :c], :name=>:ic_test_b_c_uidx; index [:c], :where=>:c_is_unique, :unique=>true}
     @ds = @db[:ic_test]
   end
   before do
@@ -196,41 +196,46 @@ describe "PostgreSQL", 'INSERT ON CONFLICT' do
 
   it "Dataset#insert_ignore and insert_conflict should ignore uniqueness violations" do
     @ds.insert(1, 2, 3)
+    @ds.insert(10, 11, 3, true)
     proc{@ds.insert(1, 3, 4)}.must_raise Sequel::UniqueConstraintViolation
+    proc{@ds.insert(11, 12, 3, true)}.must_raise Sequel::UniqueConstraintViolation
     @ds.insert_ignore.insert(1, 3, 4).must_equal nil
     @ds.insert_conflict.insert(1, 3, 4).must_equal nil
+    @ds.insert_conflict.insert(11, 12, 3, true).must_equal nil
     @ds.insert_conflict(:target=>:a).insert(1, 3, 4).must_equal nil
+    @ds.insert_conflict(:target=>:c, :where=>:c_is_unique).insert(11, 12, 3, true).must_equal nil
     @ds.insert_conflict(:constraint=>:ic_test_a_uidx).insert(1, 3, 4).must_equal nil
-    @ds.all.must_equal [{:a=>1, :b=>2, :c=>3}]
+    @ds.all.must_equal [{:a=>1, :b=>2, :c=>3, :c_is_unique=>false}, {:a=>10, :b=>11, :c=>3, :c_is_unique=>true}]
   end
 
   it "Dataset#insert_ignore and insert_conflict should work with multi_insert/import" do
     @ds.insert(1, 2, 3)
     @ds.insert_ignore.multi_insert([{:a=>1, :b=>3, :c=>4}])
     @ds.insert_ignore.import([:a, :b, :c], [[1, 3, 4]])
-    @ds.all.must_equal [{:a=>1, :b=>2, :c=>3}]
+    @ds.all.must_equal [{:a=>1, :b=>2, :c=>3, :c_is_unique=>false}]
     @ds.insert_conflict(:target=>:a, :update=>{:b=>3}).import([:a, :b, :c], [[1, 3, 4]])
-    @ds.all.must_equal [{:a=>1, :b=>3, :c=>3}]
+    @ds.all.must_equal [{:a=>1, :b=>3, :c=>3, :c_is_unique=>false}]
     @ds.insert_conflict(:target=>:a, :update=>{:b=>4}).multi_insert([{:a=>1, :b=>5, :c=>6}])
-    @ds.all.must_equal [{:a=>1, :b=>4, :c=>3}]
+    @ds.all.must_equal [{:a=>1, :b=>4, :c=>3, :c_is_unique=>false}]
     end
 
   it "Dataset#insert_conflict should handle upserts" do
     @ds.insert(1, 2, 3)
     @ds.insert_conflict(:target=>:a, :update=>{:b=>3}).insert(1, 3, 4).must_equal nil
-    @ds.all.must_equal [{:a=>1, :b=>3, :c=>3}]
+    @ds.all.must_equal [{:a=>1, :b=>3, :c=>3, :c_is_unique=>false}]
     @ds.insert_conflict(:target=>[:b, :c], :update=>{:c=>5}).insert(5, 3, 3).must_equal nil
-    @ds.all.must_equal [{:a=>1, :b=>3, :c=>5}]
+    @ds.all.must_equal [{:a=>1, :b=>3, :c=>5, :c_is_unique=>false}]
     @ds.insert_conflict(:constraint=>:ic_test_a_uidx, :update=>{:b=>4}).insert(1, 3).must_equal nil
-    @ds.all.must_equal [{:a=>1, :b=>4, :c=>5}]
+    @ds.all.must_equal [{:a=>1, :b=>4, :c=>5, :c_is_unique=>false}]
     @ds.insert_conflict(:constraint=>:ic_test_a_uidx, :update=>{:b=>5}, :update_where=>{:ic_test__b=>4}).insert(1, 3, 4).must_equal nil
-    @ds.all.must_equal [{:a=>1, :b=>5, :c=>5}]
+    @ds.all.must_equal [{:a=>1, :b=>5, :c=>5, :c_is_unique=>false}]
     @ds.insert_conflict(:constraint=>:ic_test_a_uidx, :update=>{:b=>6}, :update_where=>{:ic_test__b=>4}).insert(1, 3, 4).must_equal nil
-    @ds.all.must_equal [{:a=>1, :b=>5, :c=>5}]
+    @ds.all.must_equal [{:a=>1, :b=>5, :c=>5, :c_is_unique=>false}]
   end
 
   it "Dataset#insert_conflict should respect expressions in the target argument" do
     @ds.insert_conflict(:target=>:a).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"a\") DO NOTHING"
+    @ds.insert_conflict(:target=>:c, :where=>{:c_is_unique=>true}).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"c\") WHERE (\"c_is_unique\" IS TRUE) DO NOTHING"
     @ds.insert_conflict(:target=>[:b, :c]).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"b\", \"c\") DO NOTHING"
     @ds.insert_conflict(:target=>[:b, Sequel.function(:round, :c)]).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"b\", round(\"c\")) DO NOTHING"
     @ds.insert_conflict(:target=>[:b, Sequel.virtual_row{|o| o.round(:c)}]).insert_sql(1, 2, 3).must_equal "INSERT INTO \"ic_test\" VALUES (1, 2, 3) ON CONFLICT (\"b\", round(\"c\")) DO NOTHING"


### PR DESCRIPTION
I have a partial unique index, declared like `index [:a, :b], unique: true, where: {c: true}`. Postgres supports using it in an ON CONFLICT clause by specifying the index predicate as part of the target, e.g. `INSERT ... ON CONFLICT ("a", "b") WHERE ("c" IS TRUE) DO UPDATE ...`. Unfortunately, Sequel doesn't support that part of ON CONFLICT yet, so here's a small PR implementing it.

(Side note: I initially tried to work around this issue by passing a constraint name to `insert_conflict`'s constraint naming option, but unfortunately Postgres doesn't support filters on unique constraints, only unique indexes, and it won't accept being passed an index name rather than a constraint name. So it looks like the only way to support this use case in Sequel is via a patch like this.)

The only downside I can see with this patch is that the `:where` and `:update_where` options might be easily confused by users. I went with `:where` as the option name because it matches the SQL output (and I'm glad that `:update_where` was named as specifically as it was!), and I tried to make its usage clear in the docs. I think renaming the option to something like `:index_where` might be preferable, but erred on the side of matching the generated SQL.

Postgres' INSERT docs, for convenience: https://www.postgresql.org/docs/9.5/static/sql-insert.html