### PR TITLE
Create a test to reveal issue with quoting in Mock

### DIFF
--- a/spec/core/mock_adapter_spec.rb
+++ b/spec/core/mock_adapter_spec.rb
@@ -20,6 +20,10 @@ describe "Sequel Mock Adapter" do
           def foo
             @foo
           end
+
+          def quote_identifiers_default
+            true
+          end
         end
 
         module self::DatasetMethods
@@ -32,6 +36,7 @@ describe "Sequel Mock Adapter" do
       Sequel.connect('mock://foo') do |db|
         db.foo.must_equal :foo
         db.dataset.foo.must_equal :foo
+        db.quote_identifiers?.must_equal true
       end
     ensure
       Sequel.synchronize{Sequel::SHARED_ADAPTER_MAP.delete(:foo)}


### PR DESCRIPTION
I think I've found a bug where, even if quote_identifiers_default
returns true for a shared adapter, the mock adapter doesn't quote.

It looks like Mock::Database#quote_identifiers_default is called before
Mock::Database#adapter_initialize so Mock::Database#shared_adapter?
returns nil instead of true

I'm not sure how to fix the bug, but I hope this test proves useful.