### PR TITLE
Add support for DB2 pagination

### DIFF
--- a/lib/sequel/adapters/jdbc/as400.rb
+++ b/lib/sequel/adapters/jdbc/as400.rb
@@ -55,15 +55,20 @@ module Sequel
       
       # Dataset class for AS400 datasets accessed via JDBC.
       class Dataset < JDBC::Dataset
-        include EmulateOffsetWithRowNumber
-
         WILDCARD = Sequel::LiteralString.new('*').freeze
+        OFFSET = Dataset::OFFSET
+        ROWS = " ROWS".freeze
         FETCH_FIRST_ROW_ONLY = " FETCH FIRST ROW ONLY".freeze
         FETCH_FIRST = " FETCH FIRST ".freeze
         ROWS_ONLY = " ROWS ONLY".freeze
         
         # Modify the sql to limit the number of rows returned
         def select_limit_sql(sql)
+          if o = @opts[:offset]
+            sql << OFFSET
+            literal_append(sql, o)
+            sql << ROWS
+          end
           if l = @opts[:limit]
             if l == 1
               sql << FETCH_FIRST_ROW_ONLY


### PR DESCRIPTION
We found out by lucky coincidence that IBM DB2 for AS400 (a.k.a IBM i) _does_ support offsetting. This is really useful when fetching large chunks of data, since it is much more performant.

```sql
SELECT * FROM FOO
OFFSET 5000 ROWS
```

The downside: it's only supported by IBM i servers that are newer than 10? years or so. We don't _yet_ know the exact cutoff date for this.

For now, I would vote for including this in the codebase anyway though; if someone runs this on an antique version of IBM DB2 for iSeries, we can ask them for more information so we can fix the proper conditionalizing of this feature. (and use `EmulateOffsetWithRowNumber` for such versions)
