### PR TITLE
Fix a memory leak in ADO adapter's execute method

### DIFF
--- a/lib/sequel/adapters/ado.rb
+++ b/lib/sequel/adapters/ado.rb
@@ -76,7 +76,11 @@ module Sequel
         synchronize(opts[:server]) do |conn|
           begin
             r = log_connection_yield(sql, conn){conn.Execute(sql)}
-            yield(r) if block_given?
+            begin
+              yield(r) if block_given?
+            ensure
+              r.close
+            end
           rescue ::WIN32OLERuntimeError => e
             raise_error(e)
           end


### PR DESCRIPTION
`ADODB.Connection#Execute` returns an *open* recordset for a row-returning query (and a closed recordset for a non-row-returning query).

Since it's an open recordset, it will remain in memory until it's either closed, or it's associated connection object is closed (which is never, thanks to connection pooling).

(If I understand correctly, ADO adapter's `execute` method is for row-returning queries only, and for non-row-returning queries, `execute_dui` is used instead. Please correct me if I'm wrong, in which case I may need to add a `rescue nil` after `r.close`)