### PR TITLE
Add timestamps method when creating table

### DIFF
--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -288,6 +288,12 @@ module Sequel
         index(columns, opts.merge(:type => :spatial))
       end
 
+      # Add fields for timestamp (:created_at, :updated_at as DateTime)
+      def timestamps
+        column(:created_at, DateTime, null: false)
+        column(:updated_at, DateTime, null: false)
+      end
+
       # Add a unique constraint on the given columns to the DDL.
       #
       #   unique(:name) # UNIQUE (name)

--- a/spec/core/schema_spec.rb
+++ b/spec/core/schema_spec.rb
@@ -453,6 +453,14 @@ describe "DB#create_table" do
     @db.sqls.must_equal ["CREATE TABLE cats (id integer)", "CREATE INDEX cats_id_index ON cats (id) WHERE (id > 1)"]
   end
 
+  it "should accept timestamps method and add respective columns" do
+    @db.create_table(:cats) do
+      integer :id
+      timestamps
+    end
+    @db.sqls.must_equal ["CREATE TABLE cats (id integer, created_at timestamp NOT NULL, updated_at timestamp NOT NULL)"]
+  end
+
   it "should raise an error if partial indexes are not supported" do
     proc do 
       @db.create_table(:cats) do


### PR DESCRIPTION
Hi,

This PR will add a behave to create default timestamps columns with a syntax sugar.

Instead of defining both columns in all migrations (:created_at, :updated_at),
```
    create_table :cats do
      primary_key :id
      column :created_at, DateTime, null: false
      column :updated_at, DateTime, null: false
```
Is possible to use `timestamps` method, and it will generate both columns
```
    create_table :cats do
      primary_key :id
      timestamps
```

I don't know if this PR is a valid idea for Sequel 😄 .
I tried to find other PR with this behave, and didn't find any result.

Thanks so much

🍻 