### PR TITLE
Pass more MSSQL integration specs using ADO adapter

### DIFF
--- a/lib/sequel/adapters/ado/mssql.rb
+++ b/lib/sequel/adapters/ado/mssql.rb
@@ -56,7 +56,7 @@ module Sequel
         # is necessary as ADO's default :provider uses a separate native
         # connection for each query.
         def insert(*values)
-          return super if @opts[:sql]
+          return super if @opts[:sql] || @opts[:returning]
           with_sql("SET NOCOUNT ON; #{insert_sql(*values)}; SELECT CAST(SCOPE_IDENTITY() AS INTEGER)").single_value
         end
         

--- a/lib/sequel/extensions/sql_comments.rb
+++ b/lib/sequel/extensions/sql_comments.rb
@@ -71,7 +71,12 @@ module Sequel
           # SQL is appened to the query after the comment is added,
           # it will become part of the comment unless it is preceded
           # by a newline.
-          sql << comment
+          if sql.frozen?
+            sql += comment
+            sql.freeze
+          else
+            sql << comment
+          end
         end
         sql
       end

--- a/spec/integration/dataset_test.rb
+++ b/spec/integration/dataset_test.rb
@@ -108,7 +108,7 @@ describe "Simple Dataset operations" do
     @ds.all.must_equal [{:id=>1, :number=>11}]
   end
   
-  cspecify "should have update return the number of matched rows", [:do, :mysql], [:ado] do
+  cspecify "should have update return the number of matched rows", [:do, :mysql] do
     @ds.update(:number=>:number).must_equal 1
     @ds.filter(:id=>1).update(:number=>:number).must_equal 1
     @ds.filter(:id=>2).update(:number=>:number).must_equal 0


### PR DESCRIPTION
**My setup:**
```
C:\Users\Administrator\GitHub\sequel>cat spec\spec_config.rb
DB = Sequel.ado(
  provider: "SQLNCLI10",
  conn_string: "Provider=SQLNCLI10;Server=.\\SQLEXPRESS;Database=SEQUEL;Uid=sa;Pwd=sa1234;"
)
```
**Before this patch:**
```
Run options: --seed 25653

  1) Failure: MSSSQL::Dataset#insert#test_0004_should allow large text and binary values [C:/Users/Administrator/GitHub/sequel/spec/adapters/mssql_spec.rb:374]:
  2) Failure: Dataset#unbind#test_0002_should handle numerics and strings [C:/Users/Administrator/GitHub/sequel/spec/integration/prepared_statement_test.rb:434]:
  3) Failure: Dataset#unbind#test_0003_should handle dates and times [C:/Users/Administrator/GitHub/sequel/spec/integration/prepared_statement_test.rb:439]:
  4) Failure: RETURNING clauses in INSERT#test_0001_should give correct results [C:/Users/Administrator/GitHub/sequel/spec/integration/dataset_test.rb:775]:
  5) Failure: Bound Argument Types#test_0007_should handle blob type with special characters [C:/Users/Administrator/GitHub/sequel/spec/integration/prepared_statement_test.rb:368]:
  6) Failure: Bound Argument Types#test_0009_should handle blob type with embedded zeros [C:/Users/Administrator/GitHub/sequel/spec/integration/prepared_statement_test.rb:381]:
  7) Failure: Bound Argument Types#test_0006_should handle blob type [C:/Users/Administrator/GitHub/sequel/spec/integration/prepared_statement_test.rb:361]:
  8) Failure: Bound Argument Types#test_0002_should handle datetime type [C:/Users/Administrator/GitHub/sequel/spec/integration/prepared_statement_test.rb:338]:
  9) Failure: Bound Argument Types#test_0001_should handle date type [C:/Users/Administrator/GitHub/sequel/spec/integration/prepared_statement_test.rb:333]:
 10) Failure: Window Functions#test_0002_should give correct results for ranking window functions with orders [C:/Users/Administrator/GitHub/sequel/spec/integration/dataset_test.rb:847]:
 11) Error: Window Functions#test_0003_should give correct results for aggregate window functions with orders:
 12) Error: Window Functions#test_0004_should give correct results for aggregate window functions with frames:
 13) Failure: Supported types#test_0009_should support generic date type [C:/Users/Administrator/GitHub/sequel/spec/integration/type_test.rb:74]:
 14) Failure: Supported types#test_0012_should support generic file type [C:/Users/Administrator/GitHub/sequel/spec/integration/type_test.rb:106]:
 15) Failure: Supported types#test_0004_should support generic bignum type [C:/Users/Administrator/GitHub/sequel/spec/integration/type_test.rb:37]:
 16) Failure: Supported types#test_0010_should support generic time type [C:/Users/Administrator/GitHub/sequel/spec/integration/type_test.rb:83]:
 17) Failure: Supported types#test_0006_should support generic numeric type [C:/Users/Administrator/GitHub/sequel/spec/integration/type_test.rb:49]:
 18) Error: Simple Dataset operations#test_0038_should support the sql_comments extension:
 19) Failure: Simple Dataset operations#test_0002_should support sequential primary keys with a Bignum [C:/Users/Administrator/GitHub/sequel/spec/integration/dataset_test.rb:33]:
 20) Failure: Sequel::Database#test_0002_should properly escape binary data [C:/Users/Administrator/GitHub/sequel/spec/integration/dataset_test.rb:489]:
 21) Failure: Sequel::Database#test_0003_should properly handle empty blobs [C:/Users/Administrator/GitHub/sequel/spec/integration/dataset_test.rb:493]:
 22) Error: Sequel::SQL::Constants#test_0002_should have working CURRENT_TIME:
 23) Error: Sequel::SQL::Constants#test_0001_should have working CURRENT_DATE:
 24) Failure: Sequel timezone support#test_0001_should support using UTC for database storage and local time for the application [C:/Users/Administrator/GitHub/sequel/spec/integration/timezone_test.rb:11]:
 25) Failure: Sequel timezone support#test_0002_should support using local time for database storage and UTC for the application [C:/Users/Administrator/GitHub/sequel/spec/integration/timezone_test.rb:12]:
 26) Failure: Sequel timezone support#test_0003_should support using UTC for both database storage and for application [C:/Users/Administrator/GitHub/sequel/spec/integration/timezone_test.rb:11]:
 27) Error: MSSQL optimistic locking plugin#test_0001_should not allow stale updates:

825 runs, 6474 assertions, 21 failures, 6 errors, 6 skips
```
**After this patch:**
```
Run options: --seed 12145

  1) Failure: Supported types#test_0010_should support generic time type [C:/Users/Administrator/GitHub/sequel/spec/integration/type_test.rb:83]:
  2) Error: Sequel::SQL::Constants#test_0002_should have working CURRENT_TIME:
  3) Error: Window Functions#test_0003_should give correct results for aggregate window functions with orders:
  4) Error: Window Functions#test_0004_should give correct results for aggregate window functions with frames:

825 runs, 6561 assertions, 1 failures, 3 errors, 5 skips
```
I could not fix `1)` and `2)` above because there seems to be a bug in Ruby's `win32ole` library that causes it to always return `nil` for time fields. Regarding `3)` and `4)`, I see they also fail using the `tinytds` adapter, so I'm not sure if these should be skipped for MSSQL altogether for now, or if some enhancement could be made in the shared MSSQL adapter to make these two work, or if that's even possible (unfortunately I don't have much experience working with window functions on MSSQL, or in Sequel for that matter).

:beers: 