### PR TITLE
specify the name of an association in json_serialize plugin

### DIFF
--- a/lib/sequel/plugins/json_serializer.rb
+++ b/lib/sequel/plugins/json_serializer.rb
@@ -307,7 +307,7 @@ module Sequel
             if inc.is_a?(Hash)
               inc.each do |k, v|
                 key_name = if v.is_a?(Hash) && v[:name]
-                  v.delete(:name)
+                  v[:name]
                 else
                   k.to_s
                 end

--- a/lib/sequel/plugins/json_serializer.rb
+++ b/lib/sequel/plugins/json_serializer.rb
@@ -306,10 +306,10 @@ module Sequel
           if inc = opts[:include]
             if inc.is_a?(Hash)
               inc.each do |k, v|
-                key_name = if v.is_a?(Hash) && v[:name]
-                  v[:name]
-                else
-                  k.to_s
+                key_name = k.to_s
+                if k.is_a?(Sequel::SQL::AliasedExpression)
+                  key_name = k.aliaz.to_s
+                  k = k.expression
                 end
                 v = v.empty? ? [] : [v]
 

--- a/spec/extensions/json_serializer_spec.rb
+++ b/spec/extensions/json_serializer_spec.rb
@@ -260,6 +260,10 @@ describe "Sequel::Plugins::JsonSerializer" do
     Album.dataset.to_json(:root=>"bars", :only => :id).to_s.must_equal '{"bars":[{"id":1},{"id":1}]}'
   end
 
+  it "should handle the :name option of the include hash with a string to qualify an association using the string as the key" do\
+    JSON.parse(@album.to_json(:include=>{:artist=>{:only=>:name, :name=>'singer'}}).to_s).must_equal JSON.parse('{"id":1,"name":"RF","artist_id":2,"singer":{"name":"YJM"}}')
+  end
+
   it "should store the default options in json_serializer_opts" do
     Album.json_serializer_opts.must_equal(:naked=>true)
     c = Class.new(Album)

--- a/spec/extensions/json_serializer_spec.rb
+++ b/spec/extensions/json_serializer_spec.rb
@@ -260,8 +260,8 @@ describe "Sequel::Plugins::JsonSerializer" do
     Album.dataset.to_json(:root=>"bars", :only => :id).to_s.must_equal '{"bars":[{"id":1},{"id":1}]}'
   end
 
-  it "should handle the :name option of the include hash with a string to qualify an association using the string as the key" do\
-    JSON.parse(@album.to_json(:include=>{:artist=>{:only=>:name, :name=>'singer'}}).to_s).must_equal JSON.parse('{"id":1,"name":"RF","artist_id":2,"singer":{"name":"YJM"}}')
+  it "should use an alias for an included asscociation to qualify an association" do\
+    JSON.parse(@album.to_json(:include=>{Sequel.as(:artist, :singer)=>{:only=>:name}}).to_s).must_equal JSON.parse('{"id":1,"name":"RF","artist_id":2,"singer":{"name":"YJM"}}')
   end
 
   it "should store the default options in json_serializer_opts" do


### PR DESCRIPTION
add :name option to :include hash to specify the name of the association.

tested in 1.8.7, 1.9.3 and 2.3.1
compared using JSON.parse, because 1.8.7 reversed the keys in the hash ;)

added the example in the rdoc comments (but I guess the doc directories are git ignored...). I noticed that the examples don't quite show whats expected (they have json_class as a key) but I followed that style in case I missed something!
