### PR TITLE
fix Sequel alias expression when not used in hash context

### DIFF
--- a/lib/sequel/plugins/json_serializer.rb
+++ b/lib/sequel/plugins/json_serializer.rb
@@ -330,7 +330,14 @@ module Sequel
                 end
               end
             else
-              Array(inc).each{|c| h[c.to_s] = send(c)}
+              Array(inc).each do |c|
+                key_name = c.to_s
+                if c.is_a?(Sequel::SQL::AliasedExpression)
+                  key_name = c.aliaz.to_s
+                  c = c.expression
+                end
+                h[key_name] = send(c)
+              end
             end
           end
 

--- a/lib/sequel/plugins/json_serializer.rb
+++ b/lib/sequel/plugins/json_serializer.rb
@@ -331,10 +331,11 @@ module Sequel
               end
             else
               Array(inc).each do |c|
-                key_name = c.to_s
                 if c.is_a?(Sequel::SQL::AliasedExpression)
                   key_name = c.aliaz.to_s
                   c = c.expression
+                else
+                  key_name = c.to_s
                 end
                 h[key_name] = send(c)
               end

--- a/lib/sequel/plugins/json_serializer.rb
+++ b/lib/sequel/plugins/json_serializer.rb
@@ -35,7 +35,7 @@ module Sequel
     # You can specify a name for a given association by passing <tt>:name</tt>
     # to the <tt>:include</tt> hash
     #
-    #   album.to_json(:include=>{:artist=>{:only=>:name, :name=>:singer}})
+    #   album.to_json(:include=>{Sequel.as(:artist, :singer)=>{:only=>:name}})
     #   # => '{"id":1,"name":"RF","artist_id":2,
     #   #      "singer":{"name":"YJM"}}'
     # 

--- a/spec/extensions/json_serializer_spec.rb
+++ b/spec/extensions/json_serializer_spec.rb
@@ -66,12 +66,12 @@ describe "Sequel::Plugins::JsonSerializer" do
   end
 
   it "should raise an error if attempting to parse json when providing array to non-array association or vice-versa" do
-    proc{Artist.from_json('{"albums":{"id":1,"name":"RF","artist_id":2,"json_class":"Album"},"id":2,"name":"YJM"}', :associations=>:albums)}.must_raise(Sequel::Error)
-    proc{Album.from_json('{"artist":[{"id":2,"name":"YJM","json_class":"Artist"}],"id":1,"name":"RF","artist_id":2}', :associations=>:artist)}.must_raise(Sequel::Error)
+    proc{Artist.from_json('{"albums":{"id":1,"name":"RF","artist_id":2},"id":2,"name":"YJM"}', :associations=>:albums)}.must_raise(Sequel::Error)
+    proc{Album.from_json('{"artist":[{"id":2,"name":"YJM"}],"id":1,"name":"RF","artist_id":2}', :associations=>:artist)}.must_raise(Sequel::Error)
   end
 
   it "should raise an error if attempting to parse an array containing non-hashes" do
-    proc{Artist.from_json('[{"id":2,"name":"YJM","json_class":"Artist"}, 2]')}.must_raise(Sequel::Error)
+    proc{Artist.from_json('[{"id":2,"name":"YJM"}, 2]')}.must_raise(Sequel::Error)
   end
 
   it "should raise an error if attempting to parse invalid JSON" do
@@ -260,12 +260,7 @@ describe "Sequel::Plugins::JsonSerializer" do
     Album.dataset.to_json(:root=>"bars", :only => :id).to_s.must_equal '{"bars":[{"id":1},{"id":1}]}'
   end
 
-  it "should use an alias for an included asscociation to qualify an association" do
-    @artist.json_serializer_opts(:only=>:name)
-    JSON.parse(@album.to_json(:include => Sequel.as(:artist, :singer)).to_s).must_equal JSON.parse('{"id":1,"name":"RF","artist_id":2,"singer":{"name":"YJM"}}')
-  end
-
-  it "should use an alias for an included asscociation when passed in a hash to qualify an association" do
+  it "should use an alias for an included asscociation to qualify an association" do\
     JSON.parse(@album.to_json(:include=>{Sequel.as(:artist, :singer)=>{:only=>:name}}).to_s).must_equal JSON.parse('{"id":1,"name":"RF","artist_id":2,"singer":{"name":"YJM"}}')
   end
 

--- a/spec/extensions/json_serializer_spec.rb
+++ b/spec/extensions/json_serializer_spec.rb
@@ -66,12 +66,12 @@ describe "Sequel::Plugins::JsonSerializer" do
   end
 
   it "should raise an error if attempting to parse json when providing array to non-array association or vice-versa" do
-    proc{Artist.from_json('{"albums":{"id":1,"name":"RF","artist_id":2},"id":2,"name":"YJM"}', :associations=>:albums)}.must_raise(Sequel::Error)
-    proc{Album.from_json('{"artist":[{"id":2,"name":"YJM"}],"id":1,"name":"RF","artist_id":2}', :associations=>:artist)}.must_raise(Sequel::Error)
+    proc{Artist.from_json('{"albums":{"id":1,"name":"RF","artist_id":2,"json_class":"Album"},"id":2,"name":"YJM"}', :associations=>:albums)}.must_raise(Sequel::Error)
+    proc{Album.from_json('{"artist":[{"id":2,"name":"YJM","json_class":"Artist"}],"id":1,"name":"RF","artist_id":2}', :associations=>:artist)}.must_raise(Sequel::Error)
   end
 
   it "should raise an error if attempting to parse an array containing non-hashes" do
-    proc{Artist.from_json('[{"id":2,"name":"YJM"}, 2]')}.must_raise(Sequel::Error)
+    proc{Artist.from_json('[{"id":2,"name":"YJM","json_class":"Artist"}, 2]')}.must_raise(Sequel::Error)
   end
 
   it "should raise an error if attempting to parse invalid JSON" do
@@ -260,7 +260,12 @@ describe "Sequel::Plugins::JsonSerializer" do
     Album.dataset.to_json(:root=>"bars", :only => :id).to_s.must_equal '{"bars":[{"id":1},{"id":1}]}'
   end
 
-  it "should use an alias for an included asscociation to qualify an association" do\
+  it "should use an alias for an included asscociation to qualify an association" do
+    @artist.json_serializer_opts(:only=>:name)
+    JSON.parse(@album.to_json(:include => Sequel.as(:artist, :singer)).to_s).must_equal JSON.parse('{"id":1,"name":"RF","artist_id":2,"singer":{"name":"YJM"}}')
+  end
+
+  it "should use an alias for an included asscociation when passed in a hash to qualify an association" do
     JSON.parse(@album.to_json(:include=>{Sequel.as(:artist, :singer)=>{:only=>:name}}).to_s).must_equal JSON.parse('{"id":1,"name":"RF","artist_id":2,"singer":{"name":"YJM"}}')
   end
 


### PR DESCRIPTION
the alias expression for an association did not work when used standalone (or in an array), this fixes that - didn't spot it before!