### PR TITLE
Remove minor inconsistency when :update_on_create == true

### DIFF
--- a/lib/sequel/plugins/timestamps.rb
+++ b/lib/sequel/plugins/timestamps.rb
@@ -93,7 +93,8 @@ module Sequel
         def set_create_timestamp(time=nil)
           field = model.create_timestamp_field
           meth = :"#{field}="
-          set_column_value(meth, time||=model.dataset.current_datetime) if respond_to?(field) && respond_to?(meth) && (model.create_timestamp_overwrite? || get_column_value(field).nil?)
+          time = model.dataset.current_datetime if !time
+          set_column_value(meth, time) if respond_to?(field) && respond_to?(meth) && (model.create_timestamp_overwrite? || get_column_value(field).nil?)
           set_update_timestamp(time) if model.set_update_timestamp_on_create?
         end
         

--- a/lib/sequel/plugins/timestamps.rb
+++ b/lib/sequel/plugins/timestamps.rb
@@ -93,7 +93,7 @@ module Sequel
         def set_create_timestamp(time=nil)
           field = model.create_timestamp_field
           meth = :"#{field}="
-          time = model.dataset.current_datetime if !time
+          time ||= model.dataset.current_datetime
           set_column_value(meth, time) if respond_to?(field) && respond_to?(meth) && (model.create_timestamp_overwrite? || get_column_value(field).nil?)
           set_update_timestamp(time) if model.set_update_timestamp_on_create?
         end


### PR DESCRIPTION
Currently the update time can be a couple of milliseconds later then the create time, which is undesired behaviour when :update_on_create == true. This patch solves that by passing the same time value to both set_create_timestamp and set_update_timestamp.