### PR TITLE
Add note about adding extensions

### DIFF
--- a/doc/migration.rdoc
+++ b/doc/migration.rdoc
@@ -635,3 +635,14 @@ database the migration is being run on, and operate accordingly:
       end
     end
   end
+
+== Adding Extensions
+
+When using the +sequel+ CLI it is possible to load the required extensions for a given migration into that migration. For example, to add +:pg_enum+ support you might do:
+
+  DB.extension :pg_enum
+
+  Sequel.migration do
+    # migration here
+  end
+


### PR DESCRIPTION
Spent some time searching for the appropriate way to add extensions (pg_enum, pg_json) to standalone migrations using the `sequel` CLI. Thought I should add some quick docs while I was here. Open to any suggestions to improve/add/modify. Or, if this exists somewhere else, please let me know. Maybe my googling skill isn't so great.