### PR TITLE
Use exception codes for SQLite on JRuby

### DIFF
--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -359,6 +359,24 @@ module Sequel
         DATABASE_ERROR_REGEXPS
       end
 
+      def database_specific_error_class(exception, opts)
+        return super unless exception.respond_to?(:resultCode)
+        case exception.resultCode.code
+        when 1299
+          NotNullConstraintViolation
+        when 2067
+          UniqueConstraintViolation
+        when 787
+          ForeignKeyConstraintViolation
+        when 275
+          CheckConstraintViolation
+        when 19
+          ConstraintViolation
+        else
+          super
+        end
+      end
+
       # The array of column schema hashes for the current columns in the table
       def defined_columns_for(table)
         cols = parse_pragma(table, {})


### PR DESCRIPTION
Hello @jeremyevans 

I've found ROM's specs are failing on translating SQLite exceptions on JRuby. That's because jdbc-sqlite3 adapter [was updated](https://github.com/jruby/activerecord-jdbc-adapter/commit/754c63c7ef169cb0c919c2d443cb343f164d779b) recently. The release introduced extended exception codes added to Java adapter [in June](https://github.com/xerial/sqlite-jdbc/commit/7509994a073c1a16d98be93de5ca7cacdbfd700b). I used [the approach](https://github.com/jeremyevans/sequel/blob/f526db79aebc2231a5c74f5292f48b6af12eac1f/lib/sequel/adapters/oracle.rb#L144-L160) from Oracle's adapter to pick a proper exception class, then tested the changes with `jdbc-sqlite3` v3.8.11.2 (without ext. codes) and v3.15.1 (with codes), works fine on both, but let Travis verify it.