### PR TITLE
Move JDBC::PostgreSQL adapter initialization to #after_initialize

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -368,11 +368,16 @@ module Sequel
           prok.call(self)
         else
           @opts[:driver]
-        end        
+        end
 
+        initialize_subadapter
         setup_type_convertor_map
+        super
       end
-      
+
+      def initialize_subadapter
+      end
+
       # Yield the native prepared statements hash for the given connection
       # to the block in a thread-safe manner.
       def cps_sync(conn, &block)

--- a/lib/sequel/adapters/jdbc/postgresql.rb
+++ b/lib/sequel/adapters/jdbc/postgresql.rb
@@ -43,13 +43,6 @@ module Sequel
       module DatabaseMethods
         include Sequel::Postgres::DatabaseMethods
 
-        # Add the primary_keys and primary_key_sequences instance variables,
-        # so we can get the correct return values for inserted rows.
-        def self.extended(db)
-          super
-          db.send(:initialize_postgres_adapter)
-        end
-
         # See Sequel::Postgres::Adapter#copy_into
         def copy_into(table, opts=OPTS)
           data = opts[:data]
@@ -128,7 +121,14 @@ module Sequel
         end
 
         private
-        
+
+        # Add the primary_keys and primary_key_sequences instance variables,
+        # so we can get the correct return values for inserted rows.
+        def initialize_subadapter
+          super
+          initialize_postgres_adapter
+        end
+
         # Clear oid convertor map cache when conversion procs are updated.
         def conversion_procs_updated
           super


### PR DESCRIPTION
Hello @jeremyevans 

I've run into the issue after adding support for automatic inference for the `hstore` datatype under JRuby in [rom-sql](https://github.com/rom-rb/rom-sql). If `:pg_hstore` extension was enabled before a DB connection has been established then `Sequel` goes to PG's catalog tables before `:identifier_mangling` extension was loaded, therefore it fails with an error like `relation "PG_TYPES" does not exist`.

The issue can be easily reproduced:
```ruby
require 'sequel'
Sequel.extension(:pg_hstore)
Sequel.connect('jdbc:postgresql://localhost/sequel_test')

__END__
Sequel::DatabaseError: Java::OrgPostgresqlUtil::PSQLException: ERROR: relation "PG_TYPE" does not exist
  Position: 30
                   raise_error at /Users/gordon/dev/sequel/lib/sequel/database/misc.rb:413
                     statement at /Users/gordon/dev/sequel/lib/sequel/adapters/jdbc.rb:683
              block in execute at /Users/gordon/dev/sequel/lib/sequel/adapters/jdbc.rb:248
                          hold at /Users/gordon/dev/sequel/lib/sequel/connection_pool/threaded.rb:107
                   synchronize at /Users/gordon/dev/sequel/lib/sequel/database/connecting.rb:285
                       execute at /Users/gordon/dev/sequel/lib/sequel/adapters/jdbc.rb:247
                       execute at /Users/gordon/dev/sequel/lib/sequel/dataset/actions.rb:1064
                    fetch_rows at /Users/gordon/dev/sequel/lib/sequel/adapters/jdbc.rb:744
                          each at /Users/gordon/dev/sequel/lib/sequel/dataset/actions.rb:149
                           map at org/jruby/RubyEnumerable.java:830
                           map at /Users/gordon/dev/sequel/lib/sequel/dataset/actions.rb:455
          _select_map_multiple at /Users/gordon/dev/sequel/lib/sequel/dataset/actions.rb:970
                   _select_map at /Users/gordon/dev/sequel/lib/sequel/dataset/actions.rb:1019
                    select_map at /Users/gordon/dev/sequel/lib/sequel/dataset/actions.rb:695
  convert_named_procs_to_procs at /Users/gordon/dev/sequel/lib/sequel/adapters/shared/postgres.rb:776
    add_named_conversion_procs at /Users/gordon/dev/sequel/lib/sequel/adapters/shared/postgres.rb:623
          get_conversion_procs at /Users/gordon/dev/sequel/lib/sequel/adapters/shared/postgres.rb:1012
        reset_conversion_procs at /Users/gordon/dev/sequel/lib/sequel/adapters/shared/postgres.rb:476
   initialize_postgres_adapter at /Users/gordon/dev/sequel/lib/sequel/adapters/shared/postgres.rb:1045
                      extended at /Users/gordon/dev/sequel/lib/sequel/adapters/jdbc/postgresql.rb:50
                        extend at org/jruby/RubyKernel.java:1981
                 block in JDBC at /Users/gordon/dev/sequel/lib/sequel/adapters/jdbc/postgresql.rb:12
            adapter_initialize at /Users/gordon/dev/sequel/lib/sequel/adapters/jdbc.rb:368
                    initialize at /Users/gordon/dev/sequel/lib/sequel/database/misc.rb:151
                       connect at /Users/gordon/dev/sequel/lib/sequel/database/connecting.rb:67
                       connect at /Users/gordon/dev/sequel/lib/sequel/core.rb:109
                        <main> at extension_issue.rb:4
```

I spent a decent amount of time searching for the root of the problem and found that initialization process differs on MRI and JRuby. I've made a straight-forward fix, so you can spot the problem, and ran `sequel`'s and `rom-sql`'s specs against it. Ofc, feel free to reject the PR and find a better way for this, or just ask me to change it.

refs https://github.com/rom-rb/rom-sql/pull/143