### PR TITLE
Raise early if the installed version of sequel_pg is too old to behave reliably

### DIFF
--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -9,6 +9,9 @@ begin
   raise LoadError unless defined?(PGconn::CONNECTION_OK)
 
   SEQUEL_POSTGRES_USES_PG = true
+  # The minimum version of the sequel_pg accelerator that
+  # is intended to work with this sequel
+  SEQUEL_PG_MINIMUM_VERSION = '1.6.17'
 rescue LoadError => e 
   SEQUEL_POSTGRES_USES_PG = false
   begin
@@ -857,6 +860,11 @@ end
 if SEQUEL_POSTGRES_USES_PG && !ENV['NO_SEQUEL_PG']
   begin
     require 'sequel_pg'
+    if defined?( Gem ) && ( sequel_pg_spec = Gem.loaded_specs['sequel_pg'] )
+      unless sequel_pg_spec.version >= Gem::Version.new( SEQUEL_PG_MINIMUM_VERSION )
+        raise "the installed sequel_pg is too old, please update to at least #{SEQUEL_PG_MINIMUM_VERSION}"
+      end
+    end
   rescue LoadError
     if RUBY_PLATFORM =~ /mingw|mswin/
       begin


### PR DESCRIPTION
Hello!  This pull request is in regards to #1297.

A few notes:

  * Just using `gem` instead of `require` seems the most natural way to do this, but rescuing/warning became more involved when dealing with bundler's different exception classing.  Trying to default to being unobtrusive, and adding special casing for bundler doesn't feel appealing.
  * If the environment doesn't have sequel_pg installed via gem, but it's still in the $LOAD_PATH, the behavior is "just as it was" beforehand.
  * I omitted the check for the Windows bit... the sequel_pg docs claim there isn't recent Windows support anyway, so it feels like you're on your own in a Windows environment regardless.  Not sure what feelings are surrounding that.
