### PR TITLE
fix: convert non-nil elements

### DIFF
--- a/lib/sequel/core.rb
+++ b/lib/sequel/core.rb
@@ -204,7 +204,7 @@ module Sequel
     array.map do |i|
       if i.is_a?(Array)
         recursive_map(i, converter)
-      elsif i
+      elsif !i.nil?
         converter.call(i)
       end
     end

--- a/spec/core/expression_filters_spec.rb
+++ b/spec/core/expression_filters_spec.rb
@@ -1228,6 +1228,7 @@ describe "Sequel.recursive_map" do
   
   it "should call callable for falsey value" do 
     Sequel.recursive_map([false], proc{|s| 'false'}).must_equal ['false']  
+    Sequel.recursive_map([[false]], proc{|s| 'false'}).must_equal [['false']]  
   end
 end
 

--- a/spec/core/expression_filters_spec.rb
+++ b/spec/core/expression_filters_spec.rb
@@ -1225,6 +1225,10 @@ describe "Sequel.recursive_map" do
     Sequel.recursive_map([nil], proc{|s| s.to_i}).must_equal [nil]
     Sequel.recursive_map([[nil]], proc{|s| s.to_i}).must_equal [[nil]]
   end
+  
+  it "should call callable for falsey value" do 
+    Sequel.recursive_map([false], proc{|s| 'false'}).must_equal ['false']  
+  end
 end
 
 describe "Sequel.delay" do


### PR DESCRIPTION
This fixes boolean pg_array conversion:

>> DB.schema(:foos).last
=> [**:barray**, {:oid=>1000, :db_type=>"boolean[]", :default=>nil, :allow_null=>true, :primary_key=>false, :type=>**:boolean_array**, :ruby_default=>nil}]
>> x = Foo.new
=> #<Foo @values={}>
>> x.barray = [ false, true, false ]
=> [false, true, false]
>> x.barray
=> [nil, true, nil]