### PR TITLE
Travis: gem install bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-18mode
     - rvm: jruby-19mode
+before_install:
+  - gem install bundler
 script: bundle exec rake spec_travis
 gemfile: .travis.gemfile
 before_script:


### PR DESCRIPTION
This PR adds a `before_install` step to install a Bundler, in order to see if  jruby-head can build.



**Update**: That did it. It now runs, see [Travis build configured on my fork](https://travis-ci.org/olleolleolle/sequel).

And, comes up with a test failure on jruby-head:

```
  1) Failure:
Supported types#test_0010_should support generic time type [/home/travis/build/olleolleolle/sequel/spec/integration/type_test.rb:83]:
Expected: "'19:49:16.047188'"
  Actual: "'19:49:16.047000'"
```