### PR TITLE
Added note about the jdbc-jt400 gem

### DIFF
--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -195,8 +195,8 @@ Houses Sequel's JDBC support when running on JRuby.
 Support for individual database types is done using subadapters.
 There are currently subadapters for PostgreSQL, MySQL, SQLite, H2, HSQLDB, Derby,
 Oracle, MSSQL, JTDS, AS400, Progress, Firebird, Informix, and DB2.
-For PostgreSQL, MySQL, SQLite, H2, HSQLDB, Derby, and JTDS,
-this can use the jdbc-* gem, for the others you need to have the .jar in your CLASSPATH
+For PostgreSQL, MySQL, SQLite, H2, HSQLDB, Derby, AS400 and JTDS,
+this can use the `jdbc-*` gem, for the others you need to have the `.jar` in your CLASSPATH
 or load the Java class manually before calling Sequel.connect.
 
 You just use the JDBC connection string directly, which can be specified


### PR DESCRIPTION
I wrapped this up some week ago, for our own convenience: https://rubygems.org/gems/jdbc-jt400

(Feel free to rephrase as you see fit.)