### PR TITLE
remove additional/unused variable assignment

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -2075,7 +2075,7 @@ module Sequel
 
       # Get the row of column data from the database.
       def _refresh_get(dataset)
-        if (sql = (m = model).fast_pk_lookup_sql) && !dataset.opts[:lock]
+        if (sql = model.fast_pk_lookup_sql) && !dataset.opts[:lock]
           sql = sql.dup
           ds = use_server(dataset)
           ds.literal_append(sql, pk)


### PR DESCRIPTION
Ruby (with warning option) warns about it:
```
/Users/tagomoris/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/sequel-4.43.0/lib/sequel/model/base.rb:2045: warning: assigned but unused variable - m
```
