### PR TITLE
Schema dump ignoring database schema

### DIFF
--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -245,7 +245,7 @@ END_MIG
     # Return a Schema::Generator object that will recreate the
     # table's schema.  Takes the same options as dump_schema_migration.
     def dump_table_generator(table, options=OPTS)
-      s = schema(table).dup
+      s = schema(table, options).dup
       pks = s.find_all{|x| x.last[:primary_key] == true}.map(&:first)
       options = options.merge(:single_pk=>true) if pks.length == 1
       m = method(:recreate_column)

--- a/spec/extensions/schema_dumper_spec.rb
+++ b/spec/extensions/schema_dumper_spec.rb
@@ -254,7 +254,7 @@ END_MIG
 
   it "should sort table names topologically when dumping a migration with foreign keys" do
     @d.meta_def(:tables){|o| [:t1, :t2]}
-    @d.meta_def(:schema) do |t|
+    @d.meta_def(:schema) do |t, *o|
       t == :t1 ? [[:c2, {:db_type=>'integer'}]] : [[:c1, {:db_type=>'integer', :primary_key=>true, :auto_increment=>true}]]
     end
     @d.meta_def(:supports_foreign_key_parsing?){true}
@@ -278,7 +278,7 @@ END_MIG
 
   it "should handle circular dependencies when dumping a migration with foreign keys" do
     @d.meta_def(:tables){|o| [:t1, :t2]}
-    @d.meta_def(:schema) do |t|
+    @d.meta_def(:schema) do |t, *o|
       t == :t1 ? [[:c2, {:db_type=>'integer'}]] : [[:c1, {:db_type=>'integer'}]]
     end
     @d.meta_def(:supports_foreign_key_parsing?){true}
@@ -306,7 +306,7 @@ END_MIG
 
   it "should sort topologically even if the database raises an error when trying to parse foreign keys for a non-existent table" do
     @d.meta_def(:tables){|o| [:t1, :t2]}
-    @d.meta_def(:schema) do |t|
+    @d.meta_def(:schema) do |t, *o|
       t == :t1 ? [[:c2, {:db_type=>'integer'}]] : [[:c1, {:db_type=>'integer', :primary_key=>true, :auto_increment=>true}]]
     end
     @d.meta_def(:supports_foreign_key_parsing?){true}
@@ -587,7 +587,7 @@ END_MIG
 
   it "should support dumping just foreign_keys as a migration" do
     @d.meta_def(:tables){|o| [:t1, :t2, :t3]}
-    @d.meta_def(:schema) do |t|
+    @d.meta_def(:schema) do |t, *o|
       t == :t1 ? [[:c2, {:db_type=>'integer'}]] : [[:c1, {:db_type=>'integer'}]]
     end
     @d.meta_def(:supports_foreign_key_parsing?){true}


### PR DESCRIPTION
Passing options from schema_dump method to schema method, so database
can differ from schemas

A database with multi schemas don't diff the schema that must be filtered.
As schema method already accept schema options, just passing from
method caller