### PR TITLE
Add type conversion for MS SQL DATETIMEOFFSET

### DIFF
--- a/lib/sequel/adapters/jdbc/mssql.rb
+++ b/lib/sequel/adapters/jdbc/mssql.rb
@@ -6,6 +6,15 @@ module Sequel
   module JDBC
     # Database and Dataset instance methods for MSSQL specific
     # support via JDBC.
+
+    class TypeConvertor
+      def MSSQLDateTimeOffset(r, i)
+        if v = r.getDateTimeOffset(i)
+          Sequel.string_to_time("#{v.to_string}.#{sprintf('%03i', v.getTime.divmod(1000).last)}")
+        end
+      end
+    end
+    
     module MSSQL
       # Database instance methods for MSSQL databases accessed via JDBC.
       module DatabaseMethods
@@ -30,6 +39,11 @@ module Sequel
         # Primary key indexes appear to start with pk__ on MSSQL
         def primary_key_index_re
           PRIMARY_KEY_INDEX_RE
+        end
+        
+        def setup_type_convertor_map
+          super
+          @type_convertor_map[Java::MicrosoftSql::Types::DATETIMEOFFSET] = TypeConvertor::INSTANCE.method(:MSSQLDateTimeOffset)
         end
       end
     end


### PR DESCRIPTION
MS SQL Server with a jdbc connection has a type microsoft.sql.Types.DATETIMEOFFSET which currently is not mapped to a ruby type.
This pull request adds a mapping for this type to ruby Time.