### PR TITLE
Indicate in error message which is the file with the empty migration

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -482,7 +482,7 @@ module Sequel
     def load_migration_file(file)
       n = Migration.descendants.length
       load(file)
-      raise Error, "Migration file not containing a single migration detected" unless n + 1 == Migration.descendants.length
+      raise Error, "Migration file #{file.inspect} not containing a single migration detected" unless n + 1 == Migration.descendants.length
     end
 
     # Remove all migration classes.  Done by the migrator to ensure that

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -290,7 +290,8 @@ describe "Sequel::IntegerMigrator" do
   end
 
   it "should raise an error if there is an empty migration file" do
-    proc{Sequel::Migrator.apply(@db, "spec/files/empty_migration")}.must_raise(Sequel::Migrator::Error)
+    err = proc{Sequel::Migrator.apply(@db, "spec/files/empty_migration")}.must_raise(Sequel::Migrator::Error)
+    err.message.must_equal "Migration file not containing a single migration detected"
   end
 
   it "should raise an error if there is a migration file with multiple migrations" do
@@ -530,7 +531,8 @@ describe "Sequel::TimestampMigrator" do
   end
   
   it "should raise an error if there is an empty migration file" do
-    proc{Sequel::TimestampMigrator.apply(@db, "spec/files/empty_migration")}.must_raise(Sequel::Migrator::Error)
+    err = proc{Sequel::TimestampMigrator.apply(@db, "spec/files/empty_migration")}.must_raise(Sequel::Migrator::Error)
+    err.message.must_equal "Migration file not containing a single migration detected"
   end
 
   it "should raise an error if there is a migration file with multiple migrations" do

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -291,7 +291,7 @@ describe "Sequel::IntegerMigrator" do
 
   it "should raise an error if there is an empty migration file" do
     err = proc{Sequel::Migrator.apply(@db, "spec/files/empty_migration")}.must_raise(Sequel::Migrator::Error)
-    err.message.must_equal "Migration file not containing a single migration detected"
+    err.message.must_equal "Migration file \"spec/files/empty_migration/002_create_nodes.rb\" not containing a single migration detected"
   end
 
   it "should raise an error if there is a migration file with multiple migrations" do
@@ -532,7 +532,7 @@ describe "Sequel::TimestampMigrator" do
   
   it "should raise an error if there is an empty migration file" do
     err = proc{Sequel::TimestampMigrator.apply(@db, "spec/files/empty_migration")}.must_raise(Sequel::Migrator::Error)
-    err.message.must_equal "Migration file not containing a single migration detected"
+    err.message.must_equal "Migration file \"spec/files/empty_migration/002_create_nodes.rb\" not containing a single migration detected"
   end
 
   it "should raise an error if there is a migration file with multiple migrations" do


### PR DESCRIPTION
Helps pinpointing issues in migrations. At least for me.

Many thanks for Sequel.