### PR TITLE
Add TypeConvertor jdbc/sqlserver DateTimeOffset

### DIFF
--- a/lib/sequel/adapters/jdbc/sqlserver.rb
+++ b/lib/sequel/adapters/jdbc/sqlserver.rb
@@ -22,6 +22,12 @@ module Sequel
           Sequel.string_to_time("#{v}")
         end
       end
+
+      def MSSQLDateTimeOffset(r, i)
+        if v = r.getDateTimeOffset(i)
+          Sequel.database_to_application_timestamp("#{v}")
+        end
+      end
     end
 
     # Database and Dataset instance methods for SQLServer specific
@@ -35,7 +41,9 @@ module Sequel
           super
           map = @type_convertor_map
           types = Java::JavaSQL::Types
+          ms_types = Java::MicrosoftSql::Types
           map[types.const_get(:TIME)] = TypeConvertor::INSTANCE.method(:MSSQLRubyTime)
+          map[ms_types.const_get(:DATETIMEOFFSET)] = TypeConvertor::INSTANCE.method(:MSSQLDateTimeOffset)
         end
 
         # Work around a bug in SQL Server JDBC Driver 3.0, where the metadata

--- a/spec/adapters/mssql_spec.rb
+++ b/spec/adapters/mssql_spec.rb
@@ -76,6 +76,13 @@ describe "MSSQL" do
     pr = lambda{|x| [:hour, :min, :sec, :usec].map{|m| x.send(m)}}
     pr[v].must_equal(pr[t])
   end
+
+  it "should get datetimeoffset values as Time with fractional seconds" do
+    t = Time.local(2010, 11, 12, 10, 20, 30, 999000)
+    v = @db.get(Sequel.cast(t, 'datetimeoffset'))
+    pr = lambda{|x| [:year, :month, :day, :hour, :min, :sec, :usec].map{|m| x.send(m)}}
+    pr[v].must_equal(pr[t])
+  end
 end
 
 # This spec is currently disabled as the SQL Server 2008 R2 Express doesn't support


### PR DESCRIPTION
DateTimeOffset should be returned as a ruby Time instead of the raw jdbc type.