### PR TITLE
Bugfix: Handling for Oracle 11g xe schema[:db_type]

### DIFF
--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -21,7 +21,7 @@ module Sequel
     # database type is not recognized, return it as a String type.
     def column_schema_to_ruby_type(schema)
       type = schema[:db_type].downcase
-      if schema[:db_type].downcase.include =~ /\snot\snull\z/
+      if schema[:db_type].downcase =~ /\snot\snull\z/
         type = type.sub(/\snot\snull\z/, '')
       end
       case type

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -55,7 +55,7 @@ module Sequel
         {:type=>String, :size=>($1.to_i if $1), :fixed=>true}
       when /\A(?:n?varchar|character varying|bpchar|string)(?:\((\d+)\))?(?:\snot\snull)?\z/o
         {:type=>String, :size=>($1.to_i if $1)}
-      when /\A(?:small)?money\z/o
+      when /\A(?:small)?money(?:\snot\snull)\z/o
         {:type=>BigDecimal, :size=>[19,2]}
       when /\A(?:decimal|numeric|number)(?:\((\d+)(?:,\s*(\d+))?\))?(?:\snot\snull)?\z/
         s = [($1.to_i if $1), ($2.to_i if $2)].compact

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -22,7 +22,7 @@ module Sequel
     def column_schema_to_ruby_type(schema)
       type = schema[:db_type].downcase
       if :db_type == :oracle
-        type = type.sub(/\snot\snull\z/, '')
+        type = type.sub(/ not null\z/, '')
       end
       case type
       when /\A(medium|small)?int(?:eger)?(?:\((\d+)\))?( unsigned)?\z/o
@@ -53,7 +53,7 @@ module Sequel
         {:type=>Time, :only_time=>true}
       when /\An?char(?:acter)?(?:\((\d+)\))?\z/o
         {:type=>String, :size=>($1.to_i if $1), :fixed=>true}
-      when /\A(?:n?varchar(2)?|character varying|bpchar|string)(?:\((\d+)\))?\z/o
+      when /\A(?:n?varchar2?|character varying|bpchar|string)(?:\((\d+)\))?\z/o
         {:type=>String, :size=>($1.to_i if $1)}
       when /\A(?:small)?money\z/o
         {:type=>BigDecimal, :size=>[19,2]}

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -21,7 +21,7 @@ module Sequel
     # database type is not recognized, return it as a String type.
     def column_schema_to_ruby_type(schema)
       case schema[:db_type].downcase
-      when /\A(medium|small)?int(?:eger)?(?:\((\d+)\))?( unsigned)?\z/o
+      when /\A(medium|small)?int(?:eger)?(?:\((\d+)\))?( unsigned)?(?:\snot\snull)?\z/o
         if !$1 && $2 && $2.to_i >= 10 && $3
           # Unsigned integer type with 10 digits can potentially contain values which
           # don't fit signed integer type, so use bigint type in target database.
@@ -29,36 +29,40 @@ module Sequel
         else
           {:type=>Integer}
         end
-      when /\Atinyint(?:\((\d+)\))?(?: unsigned)?\z/o
+      when /\Atinyint(?:\((\d+)\))?(?: unsigned)?(?:\snot\snull)?\z/o
         {:type =>schema[:type] == :boolean ? TrueClass : Integer}
-      when /\Abigint(?:\((?:\d+)\))?(?: unsigned)?\z/o
+      when /\Abigint(?:\((?:\d+)\))?(?: unsigned)?(?:\snot\snull)?\z/o
         {:type=>:Bignum}
-      when /\A(?:real|float|double(?: precision)?|double\(\d+,\d+\)(?: unsigned)?)\z/o
+      when /\A(?:real|float|double(?: precision)?|double\(\d+,\d+\)(?: unsigned)?)(?:\snot\snull)?\z/o
         {:type=>Float}
       when 'boolean', 'bit', 'bool'
         {:type=>TrueClass}
-      when /\A(?:(?:tiny|medium|long|n)?text|clob)\z/o
+      when /\A(?:boolean|bit|bool)(?:\snot\snull)?\z/o
+        {:type=>TrueClass}
+      when /\A(?:(?:tiny|medium|long|n)?text|clob)(?:\snot\snull)?\z/o
         {:type=>String, :text=>true}
       when 'date'
         {:type=>Date}
-      when /\A(?:small)?datetime\z/o
+      when /\A(?:date)(?:\snot\snull)?\z/o
+        {:type=>Date}
+      when /\A(?:small)?datetime(?:\snot\snull)?\z/o
         {:type=>DateTime}
-      when /\Atimestamp(?:\((\d+)\))?(?: with(?:out)? time zone)?\z/o
+      when /\Atimestamp(?:\((\d+)\))?(?: with(?:out)? time zone)?(?:\snot\snull)?\z/o
         {:type=>DateTime, :size=>($1.to_i if $1)}
-      when /\Atime(?: with(?:out)? time zone)?\z/o
+      when /\Atime(?: with(?:out)? time zone)?(?:\snot\snull)?\z/o
         {:type=>Time, :only_time=>true}
-      when /\An?char(?:acter)?(?:\((\d+)\))?\z/o
+      when /\An?char(?:acter)?(?:\((\d+)\))?(?:\snot\snull)?\z/o
         {:type=>String, :size=>($1.to_i if $1), :fixed=>true}
-      when /\A(?:n?varchar|character varying|bpchar|string)(?:\((\d+)\))?\z/o
+      when /\A(?:n?varchar|character varying|bpchar|string)(?:\((\d+)\))?(?:\snot\snull)?\z/o
         {:type=>String, :size=>($1.to_i if $1)}
       when /\A(?:small)?money\z/o
         {:type=>BigDecimal, :size=>[19,2]}
-      when /\A(?:decimal|numeric|number)(?:\((\d+)(?:,\s*(\d+))?\))?\z/o
+      when /\A(?:decimal|numeric|number)(?:\((\d+)(?:,\s*(\d+))?\))?(?:\snot\snull)?\z/
         s = [($1.to_i if $1), ($2.to_i if $2)].compact
         {:type=>BigDecimal, :size=>(s.empty? ? nil : s)}
-      when /\A(?:bytea|(?:tiny|medium|long)?blob|(?:var)?binary)(?:\((\d+)\))?\z/o
+      when /\A(?:bytea|(?:tiny|medium|long)?blob|(?:var)?binary)(?:\((\d+)\))?(?:\snot\snull)?\z/o
         {:type=>File, :size=>($1.to_i if $1)}
-      when /\A(?:year|(?:int )?identity)\z/o
+      when /\A(?:year|(?:int )?identity)(?:\snot\snull)?\z/o
         {:type=>Integer}
       else
         {:type=>String}

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -21,7 +21,7 @@ module Sequel
     # database type is not recognized, return it as a String type.
     def column_schema_to_ruby_type(schema)
       type = schema[:db_type].downcase
-      if schema[:db_type].downcase =~ /\snot\snull\z/
+      if :db_type == :oracle
         type = type.sub(/\snot\snull\z/, '')
       end
       case type
@@ -53,7 +53,7 @@ module Sequel
         {:type=>Time, :only_time=>true}
       when /\An?char(?:acter)?(?:\((\d+)\))?\z/o
         {:type=>String, :size=>($1.to_i if $1), :fixed=>true}
-      when /\A(?:n?varchar|n?varchar2|character varying|bpchar|string)(?:\((\d+)\))?\z/o
+      when /\A(?:n?varchar(2)?|character varying|bpchar|string)(?:\((\d+)\))?\z/o
         {:type=>String, :size=>($1.to_i if $1)}
       when /\A(?:small)?money\z/o
         {:type=>BigDecimal, :size=>[19,2]}

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -21,7 +21,7 @@ module Sequel
     # database type is not recognized, return it as a String type.
     def column_schema_to_ruby_type(schema)
       type = schema[:db_type].downcase
-      if :db_type == :oracle
+      if :database_type == :oracle
         type = type.sub(/ not null\z/, '')
       end
       case type

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -53,7 +53,7 @@ module Sequel
         {:type=>Time, :only_time=>true}
       when /\An?char(?:acter)?(?:\((\d+)\))?(?:\snot\snull)?\z/o
         {:type=>String, :size=>($1.to_i if $1), :fixed=>true}
-      when /\A(?:n?varchar|character varying|bpchar|string)(?:\((\d+)\))?(?:\snot\snull)?\z/o
+      when /\A(?:n?varchar|n?varchar2|character varying|bpchar|string)(?:\((\d+)\))?(?:\snot\snull)?\z/o
         {:type=>String, :size=>($1.to_i if $1)}
       when /\A(?:small)?money(?:\snot\snull)\z/o
         {:type=>BigDecimal, :size=>[19,2]}

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -21,8 +21,8 @@ module Sequel
     # database type is not recognized, return it as a String type.
     def column_schema_to_ruby_type(schema)
       type = schema[:db_type].downcase
-      if :database_type == :oracle
-        type = type.sub(/ not null\z/, '')
+      if schema[:db_type].downcase =~ /\snot\snull\z/
+        type = type.sub(/\snot\snull\z/, '')
       end
       case type
       when /\A(medium|small)?int(?:eger)?(?:\((\d+)\))?( unsigned)?\z/o

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -57,7 +57,7 @@ module Sequel
         {:type=>String, :size=>($1.to_i if $1)}
       when /\A(?:small)?money\z/o
         {:type=>BigDecimal, :size=>[19,2]}
-      when /\A(?:decimal|numeric|number)(?:\((\d+)(?:,\s*(\d+))?\))?\z/
+      when /\A(?:decimal|numeric|number)(?:\((\d+)(?:,\s*(\d+))?\))?\z/o
         s = [($1.to_i if $1), ($2.to_i if $2)].compact
         {:type=>BigDecimal, :size=>(s.empty? ? nil : s)}
       when /\A(?:bytea|(?:tiny|medium|long)?blob|(?:var)?binary)(?:\((\d+)\))?\z/o

--- a/spec/extensions/schema_dumper_spec.rb
+++ b/spec/extensions/schema_dumper_spec.rb
@@ -802,6 +802,21 @@ end
 END_MIG
   end
 
+  it "should convert oracle special types to ruby types" do
+    types = ['number(38,0) not null', 'date not null', 'varchar2(4 byte) not null']
+    @d.meta_def(:schema) do |t, *o|
+      i = 0
+      types.map{|x| [:"c#{i+=1}", {:db_type=>x, :allow_null=>false}]}
+    end
+    @d.dump_table_schema(:x).must_equal((<<END_MIG).chomp)
+create_table(:x) do
+  BigDecimal :c1, :size=>[38, 0], :null=>false
+  Date :c2, :null=>false
+  String :c3, :null=>false
+end
+END_MIG
+  end
+
   it "should force specify :null option for MySQL timestamp columns when using :same_db" do
     @d.meta_def(:database_type){:mysql}
     @d.meta_def(:schema){|*s| [[:c1, {:db_type=>'timestamp', :primary_key=>true, :allow_null=>true}]]}

--- a/spec/extensions/schema_dumper_spec.rb
+++ b/spec/extensions/schema_dumper_spec.rb
@@ -803,6 +803,7 @@ END_MIG
   end
 
   it "should convert oracle special types to ruby types" do
+    @d.meta_def(:database_type){:oracle}
     types = ['number(38,0) not null', 'date not null', 'varchar2(4 byte) not null']
     @d.meta_def(:schema) do |t, *o|
       i = 0


### PR DESCRIPTION
Unfortunately Oracle 11g XE has been appending 'not null' to db_type, (i.e. `number(38) not null`), causing parsing issues with the method: `column_schema_to_ruby_type(schema)` in `schema_dumper.rb`

Noticed this error while doing migrations from Oracle to Postgresql. Specifically, Number(38,0) and Date fields that weren't nullable had been converted to text fields.

I've added to the regex an optional "not null" string, `(?:\snot\snull)?`, which has resolved my issues locally, and hasn't caused conflicts with the rake spec tasks

Let me know if there's more I can do to improve this solution