### PR TITLE
Handle PG::UndefinedTable exceptions

### DIFF
--- a/lib/sequel/database/query.rb
+++ b/lib/sequel/database/query.rb
@@ -198,7 +198,7 @@ module Sequel
       ds = from(name)
       transaction(:savepoint=>:only){_table_exists?(ds)}
       true
-    rescue DatabaseError
+    rescue DatabaseError, PG::UndefinedTable
       false
     end
 


### PR DESCRIPTION
I am getting this exception when trying to use `table_exists?` with MRI 2.4.1, using the `pg` gem.

The upstream error is defined [here](https://github.com/ged/ruby-pg/blob/30d954bd53dcb0d8cd4ab19ab311f41cab9e9974/ext/errorcodes.def#L599).

(It is not completely safe to `rescue` like this even when the `pg` gem is not loaded; if we run into _other_ exceptions than `DatabaseError`, and `PG::UndefinedTable` does not exist, the exception handling will raise a `NameError` unfortunately. So this will likely have to be tweaked a bit before making it into `master`.)