### PR TITLE
Added note about the sequel-jdbc-as400 gem

### DIFF
--- a/lib/sequel/adapters/jdbc/as400.rb
+++ b/lib/sequel/adapters/jdbc/as400.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::Deprecation.deprecate("The jdbc/as400 adapter", "Please consider maintaining it yourself as an external gem if you want to continue using it")
+Sequel::Deprecation.deprecate("The jdbc/as400 adapter", "This gem will replace it: https://github.com/ecraft/sequel-jdbc-as400")
 
 Sequel::JDBC.load_driver('com.ibm.as400.access.AS400JDBCDriver')
 Sequel.require 'adapters/jdbc/transactions'


### PR DESCRIPTION
I just read this message when running a Sequel-based app and realized it could make sense to change this, to avoid people doing multiple versions of the adapter when the work has already been started there.