### PR TITLE
Travis: update to latest JRuby, jruby-9.1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - jruby-18mode
   - jruby-19mode
   - jruby-9.0.5.0
-  - jruby-9.1.8.0
+  - jruby-9.1.10.0
   - jruby-head
   - ruby-head
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.