### PR TITLE
Resolve PG deprecation warnings

### DIFF
--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -305,7 +305,7 @@ The following additional options are supported:
                     if using the pg library).
 :driver_options :: A hash of options to pass to the underlying driver (only respected if using the pg library)
 :encoding :: Set the client_encoding to the given string
-:notice_receiver :: A proc that be called with the PGresult objects that have notice or warning messages.
+:notice_receiver :: A proc that be called with the PG::Result objects that have notice or warning messages.
                     The default notice receiver just prints the messages to stderr, but this can be used
                     to handle notice/warning messages differently.  Only respected if using the pg library).
 :sslmode :: Set to 'disable', 'allow', 'prefer', 'require' to choose how to treat SSL (only

--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -46,7 +46,7 @@ module Sequel
     end
 
     # Array of exceptions that need to be converted.  JDBC
-    # uses NativeExceptions, the native adapter uses PGError.
+    # uses NativeExceptions, the native adapter uses PG::Error.
     CONVERTED_EXCEPTIONS = []
 
     @client_min_messages = :warning


### PR DESCRIPTION
Substitute `PGconn`, `PGresult`, and `PGError` for `PG::Connection`, `PG::Result`, and `PG::Error` respectively.

Fixes #1376 #1377 