### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - jruby-18mode
   - jruby-19mode
   - jruby-9.0.5.0
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
   - jruby-head
   - ruby-head
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html