### PR TITLE
Postgres JDBC adapter - code breaks inside rescue

### DIFF
--- a/lib/sequel/adapters/jdbc/postgresql.rb
+++ b/lib/sequel/adapters/jdbc/postgresql.rb
@@ -73,7 +73,7 @@ module Sequel
                 data.each { |d| copier.writeToCopy(d.to_java_bytes, 0, d.length) }
               end
             rescue Exception => e
-              copier.cancelCopy
+              copier.cancelCopy if copier
               raise
             ensure
               unless e


### PR DESCRIPTION
If bad params are provided to the copy_into command, copier object doesn't get instantiated. This causes an error (NoMethodError Exception: undefined method `cancelCopy' for nil:NilClass) at [line: 76](https://github.com/jeremyevans/sequel/blob/1c409a402257095cf2d0f936404f1fa25182f0fe/lib/sequel/adapters/jdbc/postgresql.rb#L76).
This masks the original error being raised.