### PR TITLE
Preserve encoding when parsing PostgreSQL arrays

### DIFF
--- a/lib/sequel/extensions/pg_array.rb
+++ b/lib/sequel/extensions/pg_array.rb
@@ -424,7 +424,7 @@ module Sequel
           super(source)
           @converter = converter 
           @stack = [[]]
-          @recorded = String.new
+          @recorded = new_entry_buffer
         end
 
         # Take the buffer of recorded characters and add it to the array
@@ -438,7 +438,7 @@ module Sequel
               entry = @converter.call(entry)
             end
             @stack.last.push(entry)
-            @recorded = String.new
+            @recorded = new_entry_buffer
           end
         end
 
@@ -496,6 +496,18 @@ module Sequel
           end
 
           raise Sequel::Error, "array parsing finished with array unclosed"
+        end
+
+        private
+
+        if RUBY_VERSION < '1.9.0'
+          def new_entry_buffer
+            String.new
+          end
+        else
+          def new_entry_buffer
+            String.new.force_encoding(string.encoding)
+          end
         end
       end unless Sequel::Postgres.respond_to?(:parse_pg_array)
 

--- a/spec/extensions/pg_array_spec.rb
+++ b/spec/extensions/pg_array_spec.rb
@@ -34,6 +34,11 @@ describe "pg_array extension" do
     c.call('{a,b}').to_a.must_equal ['a', 'b']
   end
 
+  it "should preserve encoding when parsing text arrays" do
+    c = @converter[1009]
+    c.call("{a,\u00E4}".encode('ISO-8859-1')).map(&:encoding).must_equal [Encoding::ISO_8859_1, Encoding::ISO_8859_1]
+  end
+
   it "should parse multi-dimensional text arrays" do
     c = @converter[1009]
     c.call("{{}}").to_a.must_equal [[]]


### PR DESCRIPTION
When parsing a PostgreSQL text array we want to have the same encoding
set for the members of the array as we had for the array literal, rather
than having them use Ruby's ASCII-8BIT encoding.

I encountered this issue when another gem, simpleidn, turned out to be picky about receiving ASCII-8BIT encoded input. That could be a bug in simpleidn, but I still think this should be fixed in Sequel.