### PR TITLE
Feature/warning void var

### DIFF
--- a/lib/sequel/model.rb
+++ b/lib/sequel/model.rb
@@ -141,7 +141,7 @@ module Sequel
       end
     end
       
-    ANONYMOUS_MODEL_CLASSES = @Model_cache # :nodoc:
+    ANONYMOUS_MODEL_CLASSES = (@Model_cache ||= {}) # :nodoc:
     Sequel::Deprecation.deprecate_constant(self, :ANONYMOUS_MODEL_CLASSES)
 
     ANONYMOUS_MODEL_CLASSES_MUTEX = Mutex.new # :nodoc:

--- a/lib/sequel/model/associations.rb
+++ b/lib/sequel/model/associations.rb
@@ -1782,7 +1782,6 @@ module Sequel
           opts.merge!(orig_opts)
           opts.merge!(:type => type, :name => name, :cache=>({} if cache_associations), :model => self)
 
-          opts
           opts[:block] = block if block
           if !opts.has_key?(:instance_specific) && (block || orig_opts[:block] || orig_opts[:dataset])
             # It's possible the association is instance specific, in that it depends on


### PR DESCRIPTION
Two warnings issued when including sequel. Both seem valid concerns and are fixed in this PR.

To reproduce run `ruby -w -e "require 'sequel'"`