### PR TITLE
Forward `sslrootcert` option through to pg driver

### DIFF
--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -218,7 +218,8 @@ module Sequel
             :user => opts[:user],
             :password => opts[:password],
             :connect_timeout => opts[:connect_timeout] || 20,
-            :sslmode => opts[:sslmode]
+            :sslmode => opts[:sslmode],
+            :sslrootcert => opts[:sslrootcert]
           }.delete_if { |key, value| blank_object?(value) }
           connection_params.merge!(opts[:driver_options]) if opts[:driver_options]
           conn = Adapter.connect(connection_params)


### PR DESCRIPTION
Right now it is being swallowed:

```ruby
dsn = "postgres://u:p@host.com/db?sslmode=verify-full&sslrootcert=path-to-bundle.pem"

# PG
PG.connect(str).exec('select 1').to_a # works

# Sequel
Sequel.connect(dsn)['select 1'].to_a 
# Sequel::DatabaseConnectionError: PG::ConnectionBad: root certificate file "/xyz/.postgresql/root.crt" does not exist
# Either provide the file or change sslmode to disable server certificate verification.
```