### PR TITLE
Separate out selecting class logic in sti plugin

### DIFF
--- a/lib/sequel/plugins/single_table_inheritance.rb
+++ b/lib/sequel/plugins/single_table_inheritance.rb
@@ -182,7 +182,12 @@ module Sequel
         # Return an instance of the class specified by sti_key,
         # used by the row_proc.
         def sti_load(r)
-          sti_class(sti_model_map[r[sti_key]]).call(r)
+          sti_class_from_sti_key(r[sti_key]).call(r)
+        end
+
+        # Return the sti class based on one of the keys from sti_model_map.
+        def sti_class_from_sti_key(key)
+          sti_class(sti_model_map[key])
         end
 
         # Make sure that all subclasses of the parent class correctly include 

--- a/spec/extensions/single_table_inheritance_spec.rb
+++ b/spec/extensions/single_table_inheritance_spec.rb
@@ -19,6 +19,22 @@ describe Sequel::Model, "single table inheritance plugin" do
     Object.send(:remove_const, :StiTest)
   end
 
+  describe "#sti_load" do
+    it "should load instances of the correct type" do
+      StiTest.sti_load(id: 3).must_be_instance_of StiTest
+      StiTest.sti_load(id: 3, kind: 'StiTestSub1').must_be_instance_of StiTestSub1
+      StiTest.sti_load(id: 3, kind: 'StiTestSub2').must_be_instance_of StiTestSub2
+    end
+  end
+
+  describe "#sti_class_from_sti_key" do
+    it "should load the correct subclass based on the key" do
+      StiTest.sti_class_from_sti_key('StiTest').must_equal StiTest
+      StiTest.sti_class_from_sti_key('StiTestSub1').must_equal StiTestSub1
+      StiTest.sti_class_from_sti_key('StiTestSub2').must_equal StiTestSub2
+    end
+  end
+
   it "should freeze sti metadata when freezing model class" do
     StiTest.freeze
     StiTest.sti_dataset.frozen?.must_equal true

--- a/spec/extensions/single_table_inheritance_spec.rb
+++ b/spec/extensions/single_table_inheritance_spec.rb
@@ -19,7 +19,7 @@ describe Sequel::Model, "single table inheritance plugin" do
     Object.send(:remove_const, :StiTest)
   end
 
-  describe "#sti_load" do
+  describe ".sti_load" do
     it "should load instances of the correct type" do
       StiTest.sti_load(id: 3).must_be_instance_of StiTest
       StiTest.sti_load(id: 3, kind: 'StiTestSub1').must_be_instance_of StiTestSub1
@@ -27,7 +27,7 @@ describe Sequel::Model, "single table inheritance plugin" do
     end
   end
 
-  describe "#sti_class_from_sti_key" do
+  describe ".sti_class_from_sti_key" do
     it "should load the correct subclass based on the key" do
       StiTest.sti_class_from_sti_key('StiTest').must_equal StiTest
       StiTest.sti_class_from_sti_key('StiTestSub1').must_equal StiTestSub1


### PR DESCRIPTION
Now you can select the subclass based on the type value.
This is useful in APIs and other places where you don't
know which subclass to instantiate.