### PR TITLE
schema_methods: Added support for Bignum columns

### DIFF
--- a/lib/sequel/database/schema_methods.rb
+++ b/lib/sequel/database/schema_methods.rb
@@ -964,6 +964,11 @@ module Sequel
       type_literal_generic_numeric(column)
     end
 
+    # Sequel uses the bigint type by default for Bignums.
+    def type_literal_generic_bignum(column)
+      :bigint
+    end
+    
     # Sequel uses the bigint type by default for :Bignum symbol.
     def type_literal_generic_bignum_symbol(column)
       :bigint


### PR DESCRIPTION
Before this change, this code would work:

```ruby
db = Sequel.connect('jdbc:postgresql://localhost/foo')
db.create_table(:columns_types) do
  column :d, :Bignum
end
```

...but this could would fail:

```ruby
db = Sequel.connect('jdbc:postgresql://localhost/foo')
db.create_table(:columns_types) do
  # Fails with Unsupported ruby class used as database type: Bignum
  column :d, Bignum
end
```

This was also inconsistent with the migration support, where this code would actually work (the example comes from https://github.com/jeremyevans/sequel/blob/master/doc/schema_modification.rdoc which is what got me confused in the first place):

```ruby
Sequel.migration do
  change do
    create_table(:columns_types) do
      Bignum :d                           # bigint
    end
  end
end
```

This commit adds support for the failing `Bignum` types when creating tables in a non-migration scenario as well.