### PR TITLE
 Support :like option in Database#create_table on PostgreSQL, for table copy

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -892,6 +892,10 @@ module Sequel
           sql += " INHERITS (#{Array(inherits).map{|t| quote_schema_table(t)}.join(', ')})"
         end
 
+        if like = options[:like]
+          sql = sql.sub('()', "(LIKE #{quote_schema_table(like)} INCLUDING ALL)")
+        end
+
         if on_commit = options[:on_commit]
           raise(Error, "can't provide :on_commit without :temp to create_table") unless options[:temp]
           raise(Error, "unsupported on_commit option: #{on_commit.inspect}") unless ON_COMMIT.has_key?(on_commit)

--- a/lib/sequel/database/schema_methods.rb
+++ b/lib/sequel/database/schema_methods.rb
@@ -169,6 +169,8 @@ module Sequel
     #             foreign server that was specified in CREATE SERVER.
     # :inherits :: Inherit from a different table.  An array can be
     #              specified to inherit from multiple tables.
+    # :like :: Copy all collum names, data types and constraints from a different
+    #          table into another table.
     # :unlogged :: Create the table as an unlogged table.
     # :options :: The OPTIONS clause to use for foreign tables.  Should be a hash
     #             where keys are option names and values are option values.  Note

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -72,6 +72,17 @@ describe "PostgreSQL", '#create_table' do
     @db.create_table(:unlogged_dolls, :unlogged => true){text :name}
   end
 
+  it "should create a table copying another table" do
+    begin
+      @db.create_table(:some_table) { text :name; index :name }
+      @db.create_table(:another_table, :like => :some_table)
+      @db[:another_table].columns.must_equal [:name]
+      @db.indexes(:another_table).keys.must_equal [:another_table_name_idx]
+    ensure
+      @db.drop_table?(:some_table, :another_table)
+    end
+  end
+
   it "should create a table inheriting from another table" do
     @db.create_table(:unlogged_dolls){text :name}
     @db.create_table(:tmp_dolls, :inherits=>:unlogged_dolls){}


### PR DESCRIPTION
This allows to create a new table using copy of another table.