### PR TITLE
Fix buffer length passed on to writeToCopy (JRuby)

### DIFF
--- a/lib/sequel/adapters/jdbc/postgresql.rb
+++ b/lib/sequel/adapters/jdbc/postgresql.rb
@@ -65,10 +65,14 @@ module Sequel
               copier = copy_manager.copy_in(copy_into_sql(table, opts))
               if block_given?
                 while buf = yield
-                  copier.writeToCopy(buf.to_java_bytes, 0, buf.length)
+                  java_bytes = buf.to_java_bytes
+                  copier.writeToCopy(java_bytes, 0, java_bytes.length)
                 end
               else
-                data.each { |d| copier.writeToCopy(d.to_java_bytes, 0, d.length) }
+                data.each do |d|
+                  java_bytes = d.to_java_bytes
+                  copier.writeToCopy(java_bytes, 0, java_bytes.length)
+                end
               end
             rescue Exception => e
               copier.cancelCopy if copier

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -1748,6 +1748,31 @@ if uses_pg_or_jdbc && DB.server_version >= 90000
     end
   end
 
+  describe "Postgres::Database#copy_into using UTF-8 encoding" do
+    before(:all) do
+      @db = DB
+      @db.create_table!(:test_copy){Text :t}
+      @ds = @db[:test_copy].order(:t)
+    end
+    before do
+      @db[:test_copy].delete
+    end
+    after(:all) do
+      @db.drop_table?(:test_copy)
+    end
+
+    it "should work with UTF-8 characters using the :data option" do
+      @db.copy_into(:test_copy, :data=>["ä\n", "ä\n"])
+      @ds.select_map([:t]).must_equal [["ä"], ["ä"]]
+    end
+
+    it "should work with UTF-8 characters using a block" do
+      buf = ["ä\n", "ä\n"]
+      @db.copy_into(:test_copy){buf.shift}
+      @ds.select_map([:t]).must_equal [["ä"], ["ä"]]
+    end
+  end
+
   describe "Postgres::Database#copy_table" do
     before(:all) do
       @db = DB


### PR DESCRIPTION
Up until now the length of the original input was passed on as length of the buffer. However a call to `to_java_bytes` might return several bytes for a single character depending on the encoding. In the end only part of the actual data would have been sent to the PostgreSQL server either leading to missing line endings and thus mixing several rows into one or finding invalid bytes for certain encodings.

It would be really great to also backport this to the v4 branch. If we can help in any way, just get back to us. Thanks.