### PR TITLE
Fix a warning: assigned but unused variable

### DIFF
--- a/lib/sequel/model/associations.rb
+++ b/lib/sequel/model/associations.rb
@@ -2543,7 +2543,7 @@ module Sequel
 
           begin
             cbs.each do |cb|
-              res = case cb
+              case cb
               when Symbol
                 # Allow calling private methods in association callbacks
                 send(cb, object)


### PR DESCRIPTION
Fix this warning:

```
~/.gem/ruby/2.4.1/gems/sequel-5.0.0/lib/sequel/model/associations.rb:2546:
warning: assigned but unused variable - res
```

I also saw this one:

```
~/.gem/ruby/2.4.1/gems/sequel-5.0.0/lib/sequel/dataset/query.rb:84: warning:
statement not reached
```

not sure how to suppress it 🤔 