### PR TITLE
Support objects that quack like a Hash in dataset

### DIFF
--- a/lib/sequel/dataset/sql.rb
+++ b/lib/sequel/dataset/sql.rb
@@ -80,8 +80,8 @@ module Sequel
         end
       when Integer
         sql << literal_integer(v)
-      when Hash
-        literal_hash_append(sql, v)
+      when method(:castable_to_hash?).to_proc
+        literal_hash_append(sql, v.to_hash)
       when SQL::Expression
         literal_expression_append(sql, v)
       when Float
@@ -1529,6 +1529,14 @@ module Sequel
 
     def update_update_sql(sql)
       sql << 'UPDATE'
+    end
+
+    def castable_to_hash?(value)
+      value.respond_to?(:to_hash) && value.method(:to_hash).arity == 0 && !internal_sql_literal?(value)
+    end
+
+    def internal_sql_literal?(object)
+      object.respond_to?(:sql_literal_append) || object.respond_to?(:sql_literal)
     end
   end
 end

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -400,6 +400,16 @@ describe "Dataset#where" do
     @dataset.where(:name => 'xyz', :price => 342).select_sql.must_equal 'SELECT * FROM test WHERE ((name = \'xyz\') AND (price = 342))'
   end
   
+  it "should work with objects that quack like a hash" do
+    object_castable_to_hash = Class.new do
+      def to_hash
+        {:name => 'xyz', :price => 342}
+      end
+    end.new
+  
+    @dataset.where(object_castable_to_hash).select_sql.must_equal 'SELECT * FROM test WHERE ((name = \'xyz\') AND (price = 342))'
+  end
+  
   it "should work with a placeholder literal string" do
     @dataset.where(Sequel.lit('price < ? AND id in ?', 100, [1, 2, 3])).select_sql.must_equal "SELECT * FROM test WHERE (price < 100 AND id in (1, 2, 3))"
   end


### PR DESCRIPTION
First I'd like to thank you for your effort in providing this awesome library!

Let me tell you a short story how I came across the problem.

I'm currently using Hanami.rb framework that uses Sequel gem under the hood. 
Hanami provides some utilities for basic ruby's types. One of them is `Hanami::Utils::Hanami` class which I very often use to take advantage of helpers like `deep_symbolize!`. The instance of this class does not inherit from `Hash` class, though, nevertheless, it 'quacks' like a hash (it's implicitly castable by `to_hash` method). I was very confused when I tried to update the jsonb type column of a record via repository by passing this object mentioned above. There was an exception raised that said:

```
can't express {:foo=>"Bar"} as a SQL literal
```

I spent some time to understand what is actually wrong.  Initially, I thought it's Hanami's bug, but after digging into the issue, I think Sequel should to support objects like this following the duck typing principle, shouldn't it?

Does it make sense for you?