### PR TITLE
Skip unnecessary database lookup of macaddr's oid

### DIFF
--- a/lib/sequel/extensions/pg_inet.rb
+++ b/lib/sequel/extensions/pg_inet.rb
@@ -46,7 +46,7 @@ module Sequel
           if respond_to?(:register_array_type)
             register_array_type('inet', :oid=>1041, :scalar_oid=>869)
             register_array_type('cidr', :oid=>651, :scalar_oid=>650)
-            register_array_type('macaddr', :oid=>1040)
+            register_array_type('macaddr', :oid=>1040, :scalar_oid=>829)
           end
           @schema_type_classes[:ipaddr] = IPAddr
         end


### PR DESCRIPTION
Since we do not parse PostgreSQL's macaddr type in the pg_inet extension
there is no reason for us to look up the oid of macaddr when specifying
a conversion proc for macaddr[], and the avoid this lookup we have to
explicitly specify a noop conversion proc.