### PR TITLE
Fix uninitialized warning for @server_version

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -524,7 +524,7 @@ module Sequel
 
       # The version of the PostgreSQL server, used for determining capability.
       def server_version(server=nil)
-        return @server_version if @server_version
+        return @server_version if defined?(@server_version)
         @server_version = synchronize(server) do |conn|
           (conn.server_version rescue nil) if conn.respond_to?(:server_version)
         end


### PR DESCRIPTION
This patch fixes this warning when running Sequel on Postgres

> .rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/sequel-5.1.0/lib/sequel/adapters/shared/postgres.rb:527: warning: instance variable @server_version not initialized