### PR TITLE
Expect symbols from Object#instance_variables

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -484,7 +484,7 @@ module Sequel
           subclass.instance_variable_set(iv, sup_class_value)
         end
 
-        unless ivs.include?("@dataset")
+        unless ivs.include?(:@dataset)
           if @dataset && self != Model
             subclass.set_dataset(@dataset.clone, :inherited=>true)
           elsif (n = subclass.name) && !n.to_s.empty?

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -381,6 +381,25 @@ describe "A model inheriting from a model" do
   end
 end
 
+describe "A model inheriting from a custom base that sets @dataset" do
+  before do
+    ::Feline = Class.new(Sequel::Model)
+    def Feline.inherited(subclass)
+      subclass.instance_variable_set(:@dataset, nil)
+      superclass.inherited(subclass)
+    end
+    class ::Leopard < Feline; end
+  end
+  after do
+    Object.send(:remove_const, :Leopard)
+    Object.send(:remove_const, :Feline)
+  end
+
+  it "should not infer the dataset of the subclass" do
+    proc{Leopard.dataset}.must_raise(Sequel::Error)
+  end
+end
+
 describe "Model.primary_key" do
   before do
     @c = Class.new(Sequel::Model)


### PR DESCRIPTION
That method stopped returning strings some time before 1.9.3, so `instance_variables.include?("@dataset")` couldn't ever be true on any interpreter currently listed in `.travis.yml`.