### PR TITLE
Add ORA-02396 as a connection error

### DIFF
--- a/lib/sequel/adapters/oracle.rb
+++ b/lib/sequel/adapters/oracle.rb
@@ -11,9 +11,10 @@ module Sequel
 
       # ORA-00028: your session has been killed
       # ORA-01012: not logged on
+      # ORA-02396: exceeded maximum idle time, please connect again
       # ORA-03113: end-of-file on communication channel
       # ORA-03114: not connected to ORACLE
-      CONNECTION_ERROR_CODES = [ 28, 1012, 3113, 3114 ].freeze
+      CONNECTION_ERROR_CODES = [ 28, 1012, 2396, 3113, 3114 ].freeze
       
       ORACLE_TYPES = {
         :blob=>lambda{|b| Sequel::SQL::Blob.new(b.read)},


### PR DESCRIPTION
ORA-02396, which is an idle timeout, should be considered a connection error.

`ORA-02396: exceeded maximum idle time, please connect again`

Existing tests pass, but there are no tests that deal with oracle connection errors.