### PR TITLE
Add PlaceholderCheckout dataset extension for MySQL

### DIFF
--- a/lib/sequel/extensions/synchronize_sql.rb
+++ b/lib/sequel/extensions/synchronize_sql.rb
@@ -1,0 +1,48 @@
+# frozen-string-literal: true
+#
+# The synchronize_sql extension exists to work around some connection- pool
+# performance considerations in a number of adapters where escaping a string
+# as part of placeholder substitution requires an actual database connection.
+# These adapters include amalgalite, mysql2, postgres, tinytds, and JDBC
+# postgres. In these adapters, `literal_string_append` includes a call to
+# `db.synchronize` to obtain a real connection object do use for escaping the
+# passed-in string.
+#
+# This has the effect of checking out a connection from the pool for _every_
+# placeholder that needs substitution in a query. For queries with lots of
+# placeholders (e.g. IN queries with long lists), this can cause the query to
+# spend longer waiting for a connection than the actual pool timeout (since
+# every individual acquisition will take less than the timeout, but the sum of
+# all of them can be greater)
+#
+# This dataset wraps all the _sql methods with a connection acquisition, so
+# there will be no need to checkout/return connections continuously during the
+# placeholder substitution.
+#
+# While this extension might solve some problems for heavily-loaded connection
+# pools with queries containing lots of placeholders, it also creates some new
+# ones. Now _every_ query is going to call `synchronize` twice, even queries
+# that have no actual placeholders, and the total time spent holding a
+# connection is going to be higher, since it's not released during the parts
+# of query preparation that are not placeholder substitution.
+
+
+module Sequel
+    class Dataset
+        module SynchronizeSQL
+            %w(
+                insert_sql
+                select_sql
+                update_sql
+                delete_sql
+            ).each do |method_name|
+                define_method(method_name) do |*args|
+                    db.synchronize(@opts[:server]) do
+                        super *args
+                    end
+                end
+            end
+        end
+        register_extension(:synchronize_sql, SynchronizeSQL)
+    end
+end

--- a/spec/extensions/synchronize_sql_spec.rb
+++ b/spec/extensions/synchronize_sql_spec.rb
@@ -1,0 +1,152 @@
+require_relative 'spec_helper'
+
+describe "Sequel::Dataset::SynchronizeSQL" do
+
+    # Simulates an adapter which calls synchronize around literal_string_append,
+    # like the MySQL & Postgres ones do
+    # The adapter also tracks how many times a connection was removed from the pool
+    class SynchronizedMockAdapter < ::Sequel::Mock::Database
+        def initialize(*args)
+            @times_checkedout = 0
+            super
+            pool.extend(TrackCallsToAcquireConnection)
+        end
+
+        def dataset_class_default
+            SynchronizedMockDataset
+        end
+    end
+
+    class SynchronizedMockDataset < ::Sequel::Mock::Dataset
+        def literal_string_append(sql, v)
+            db.synchronize { super }
+        end
+    end
+
+    # Extends a connection pool to track how many times a connection was actually checked out
+    # by looking at how many times a `ThreadedConnectionPool#assign_connection` was successful
+    module TrackCallsToAcquireConnection
+        def assign_connection(*args)
+            r = super
+            @times_connection_acquired += 1 if r
+            return r
+        end
+
+        def self.extended(i)
+            i.instance_exec { @times_connection_acquired = 0 }
+        end
+
+        attr_reader :times_connection_acquired
+
+        def clear_times_connection_acquired
+            @times_connection_acquired = 0
+        end
+    end
+
+
+    before(:each) do
+        @db = Sequel.connect(adapter: SynchronizedMockAdapter)
+        @ds = @db[:tab1]
+        @db.pool.clear_times_connection_acquired
+    end
+
+    it 'checks out an extra connection on insert_sql if there are no strings' do
+        @ds.insert_sql(:numeric_foo => 8)
+        @db.pool.times_connection_acquired.must_equal(0)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.insert_sql(:numeric_foo => 8)
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out just one connection on insert_sql if there are multiple strings' do
+        @ds.insert_sql(:string_foo1 => 'eight', :string_foo2 => 'nine', :string_foo3 => 'ten')
+        @db.pool.times_connection_acquired.must_equal(3)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.insert_sql(:string_foo1 => 'eight', :string_foo2 => 'nine', :string_foo3 => 'ten')
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'cheks out an extra connectrion on update_sql if there are no strings' do
+        @ds.where(:numeric_foo => [1, 2, 3, 4, 5]).update_sql(:numeric_foo => 99)
+        @db.pool.times_connection_acquired.must_equal(0)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.where(:numeric_foo => [1, 2, 3, 4, 5]).update_sql(:numeric_foo => 99)
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out just one connection on update_sql if there are multiple strings' do
+        @ds.where(:numeric_foo => [1, 2, 3, 4, 5]).update_sql(:string_foo1 => 'eight', :string_foo2 => 'nine', :string_foo3 => 'ten')
+        @db.pool.times_connection_acquired.must_equal(3)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.where(:numeric_foo => [1, 2, 3, 4, 5]).update_sql(:string_foo1 => 'eight', :string_foo2 => 'nine', :string_foo3 => 'ten')
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out an extra connection on delete_sql if there are no strings' do
+        @ds.where(:numeric_foo => [1, 2, 3]).delete_sql
+        @db.pool.times_connection_acquired.must_equal(0)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.where(:numeric_foo => [1, 2, 3]).delete_sql
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out just one connection on delete_sql if there are multiple strings' do
+        @ds.where(:string_foo => ['one', 'two', 'three', 'four']).delete_sql
+        @db.pool.times_connection_acquired.must_equal(4)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.where(:string_foo => ['one', 'two', 'three', 'four']).delete_sql
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out an extra connection on select_sql if there are no strings' do
+        @ds.where(:numeric_foo => [1, 2, 3]).select_sql
+        @db.pool.times_connection_acquired.must_equal(0)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.where(:numeric_foo => [1, 2, 3]).select_sql
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out just one connection on select_sql if there are multiple strings' do
+        @ds.where(:string_foo => ['one', 'two', 'three', 'four']).select_sql
+        @db.pool.times_connection_acquired.must_equal(4)
+        @db.pool.clear_times_connection_acquired
+
+        extds = @ds.extension(:synchronize_sql)
+        extds.where(:string_foo => ['one', 'two', 'three', 'four']).select_sql
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out an extra connection on fetch if there are no strings' do
+        @db.fetch('SELECT * FROM tab1 WHERE numeric_foo IN (?, ?, ?, ?)', 1, 2, 3, 4).select_sql
+        @db.pool.times_connection_acquired.must_equal(0)
+        @db.pool.clear_times_connection_acquired
+
+        @db.extension(:synchronize_sql)
+        @db.fetch('SELECT * FROM tab1 WHERE numeric_foo IN (?, ?, ?, ?)', 1, 2, 3, 4).select_sql
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+
+    it 'checks out just one connection on fetch if there are multiple strings' do
+        @db.fetch('SELECT * FROM tab1 WHERE string_foo IN (?, ?, ?, ?)', 'one', 'two', 'three', 'four').select_sql
+        @db.pool.times_connection_acquired.must_equal(4)
+        @db.pool.clear_times_connection_acquired
+
+        @db.extension(:synchronize_sql)
+        @db.fetch('SELECT * FROM tab1 WHERE string_foo IN (?, ?, ?, ?)', 'one', 'two', 'three', 'four').select_sql
+        @db.pool.times_connection_acquired.must_equal(1)
+    end
+end


### PR DESCRIPTION
The MySQL adapter checks out a connection in order to do placeholder
escaping; this means that for queries with large numbers of placeholders
in them, a large amount of time can be spent checking out/checking in
connections while building up the SQL test.

This PR adds a dataset extension which wraps the _sql generation methods
with `db.synchronize`, so that only one connection is checked out for
the entire SQL generation process.

This should resolve jeremyevans/sequel#1319