### PR TITLE
Cache calls to Dataset#nullify.

### DIFF
--- a/lib/sequel/extensions/null_dataset.rb
+++ b/lib/sequel/extensions/null_dataset.rb
@@ -41,7 +41,9 @@ module Sequel
     module Nullifiable
       # Return a cloned nullified dataset.
       def nullify
-        with_extend(NullDataset)
+        cached_dataset(:_nullify_ds) do
+          with_extend(NullDataset)
+        end
       end
     end
 

--- a/spec/extensions/null_dataset_spec.rb
+++ b/spec/extensions/null_dataset_spec.rb
@@ -21,6 +21,11 @@ describe "null_dataset extension" do
     @i.must_equal 0
   end
 
+  it "nullify should be a cached dataset" do
+    ds = @db[:table]
+    ds.nullify.object_id.must_equal(ds.nullify.object_id)
+  end
+
   it "should make insert be a noop" do
     @ds.insert(1).must_be_nil
   end


### PR DESCRIPTION
I use Dataset#nullify a fair amount in an app (it winds up being very helpful for resolving GraphQL requests, where the pagination logic is often very removed from the filtering logic), and it'd be nice if it were be able to chain cached datasets off of it.