### PR TITLE
Add development dependency for warning gem

### DIFF
--- a/sequel.gemspec
+++ b/sequel.gemspec
@@ -23,4 +23,5 @@ SEQUEL_GEMSPEC = Gem::Specification.new do |s|
   s.add_development_dependency "tzinfo"
   s.add_development_dependency "activemodel"
   s.add_development_dependency "nokogiri"
+  s.add_development_dependency "warning"
 end


### PR DESCRIPTION
Running the specs with warnings e.g. `rake spec_core_w` requires the warning gem, which isn't specified as a development dependency in the gemspec.