### PR TITLE
Fix warning: instance variable @transaction_mode not initialized

### DIFF
--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -243,7 +243,7 @@ module Sequel
       end
 
       def begin_new_transaction(conn, opts)
-        mode = opts[:mode] || @transaction_mode
+        mode = opts[:mode] || transaction_mode
         sql = TRANSACTION_MODE[mode] or raise Error, "transaction :mode must be one of: :deferred, :immediate, :exclusive, nil"
         log_connection_execute(conn, sql)
         set_transaction_isolation(conn, opts)


### PR DESCRIPTION
Fixes `warning: instance variable @transaction_mode not initialized`

This warning doesn't show up in the specs at the moment because of the way the relevant specs are setup/structured, but it can be shown by running the following Ruby script with warnings enabled:

```ruby
$:.unshift('lib')
require 'sequel'
Sequel.sqlite.transaction {}
```
