### PR TITLE
Ruby 2.6 Error when DEFAULT_PROXY_TO_DATASET sends :filter to an array

### DIFF
--- a/lib/sequel/plugins/association_proxies.rb
+++ b/lib/sequel/plugins/association_proxies.rb
@@ -63,9 +63,15 @@ module Sequel
       class AssociationProxy < BasicObject
         array = []
 
-        # Default proc used to determine whether to sent the method to the dataset.
+        # Default proc used to determine whether to send the method to the dataset.
         # If the array would respond to it, sends it to the array instead of the dataset.
-        DEFAULT_PROXY_TO_DATASET = proc{|opts| !array.respond_to?(opts[:method])}
+        DEFAULT_PROXY_TO_DATASET = proc do |opts|
+          array_method = array.respond_to?(opts[:method])
+          if !array_method && opts[:method] == :filter
+            warn "The behavior of the :filter method will change in Ruby 2.6. Switch to calling :where to conserve current behavior."
+          end
+          !array_method
+        end
 
         # Set the association reflection to use, and whether the association should be
         # reloaded if an array method is called.


### PR DESCRIPTION
2.6 introduces `Enumerable#filter` which is the same as `:select`. https://github.com/ruby/ruby/commit/b1a8c64483b5ba5e4a391aa68234e7bde6355034

Here's how I've stumbled thisupon:
```
sequel]$ ruby -v
ruby 2.6.0dev (2018-04-04 trunk 63085) [x86_64-linux]

]$ ruby spec/extensions/association_proxies_spec.rb 
Run options: --seed 1426

# Running:

EEE...

Finished in 0.009946s, 603.2618 runs/s, 2815.2216 assertions/s.

  1) Error:
Sequel::Plugins::AssociationProxies#test_0002_should send method calls to the association dataset if sent a non-array method:
ArgumentError: wrong number of arguments (given 1, expected 0)
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `filter'
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `public_send'
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `method_missing'
    spec/extensions/association_proxies_spec.rb:28:in `block (2 levels) in <main>'

  2) Error:
Sequel::Plugins::AssociationProxies#test_0004_should reload the cached association if sent an array method and the reload flag was given:
ArgumentError: wrong number of arguments (given 1, expected 0)
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `filter'
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `public_send'
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `method_missing'
    spec/extensions/association_proxies_spec.rb:66:in `block (2 levels) in <main>'

  3) Error:
Sequel::Plugins::AssociationProxies#test_0006_should work correctly in subclasses:
ArgumentError: wrong number of arguments (given 1, expected 0)
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `filter'
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `public_send'
    /$HOME/code/sequel/lib/sequel/plugins/association_proxies.rb:87:in `method_missing'
    spec/extensions/association_proxies_spec.rb:83:in `block (2 levels) in <main>'

6 runs, 28 assertions, 0 failures, 3 errors, 0 skips
```
I imagine you'd have a cleaner solution, but was happy to try.

Does this change in Ruby also raise the breaking-change notion to dispose of `:filter` as an alias of `where`? I'd be happy to try that too ;)
If so, 