### PR TITLE
Add rake to development dependecies

### DIFF
--- a/sequel.gemspec
+++ b/sequel.gemspec
@@ -17,6 +17,7 @@ SEQUEL_GEMSPEC = Gem::Specification.new do |s|
   s.require_path = "lib"
   s.bindir = 'bin'
   s.executables << 'sequel'
+  s.add_development_dependency "rake"
   s.add_development_dependency "minitest", '>=5.7.0'
   s.add_development_dependency "minitest-hooks"
   s.add_development_dependency "minitest-shared_description"


### PR DESCRIPTION
Hard to imagine finding oneself rake-less, but it happens.

Before:

```
$ bundle install
Using concurrent-ruby 1.0.5
Using i18n 0.9.1
Using minitest 5.10.3
Using thread_safe 0.3.6
Using tzinfo 1.2.4
Using activesupport 5.1.4
Using activemodel 5.1.4
Using bundler 1.16.1
Using mini_portile2 2.3.0
Using minitest-hooks 1.4.2
Using minitest-shared_description 1.0.0
Using nokogiri 1.8.1
Using sequel 5.7.0 from source at `.`
Bundle complete! 7 Gemfile dependencies, 13 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

$ rake
Traceback (most recent call last):
	2: from ~/.rbenv/versions/2.5.1/bin/rake:23:in `<main>'
	1: from ~/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
~/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem rake (>= 0.a) with executable rake (Gem::GemNotFoundException)

```