### PR TITLE
need to be the same type for comparison

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -761,7 +761,7 @@ module Sequel
         f = File.basename(path)
         fi = f.downcase
         if target
-          if migration_version_from_file(f) > target
+          if migration_version_from_file(f) > target.to_i
             if applied_migrations.include?(fi)
               load_migration_file(path)
               down_mts << [ms.last, f, :down]


### PR DESCRIPTION
Hi, Jeremy. 

When using time model for migrations like `20180515172737_add_description_e_exchange_rate.rb` and exact step, like `20180515172737` with this code:

`Sequel::Migrator.run(dbconn, "db/migrations", target: '20180515172737' )`

I get the error:

`vendor/ruby/2.5.0/gems/sequel-5.6.0/lib/sequel/extensions/migration.rb:746:in '>': comparison of Integer with String failed (ArgumentError)`

Looks like working after that change.