### PR TITLE
Add `Sequel::Model.dataset?` method

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -264,6 +264,11 @@ module Sequel
         @dataset || raise(Error, "No dataset associated with #{self}")
       end
 
+      # Whether or not the dataset exists
+      def has_dataset?
+        !@dataset.nil?
+      end
+
       # Alias of set_dataset
       def dataset=(ds)
         set_dataset(ds)

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -100,6 +100,44 @@ describe Sequel::Model, "dataset" do
   end
 end
   
+describe Sequel::Model, "has_dataset?" do
+  before do
+    @a = Class.new(Sequel::Model(:items))
+    @b = Class.new(Sequel::Model)
+    @c = Class.new(@b)
+    class ::Elephant < Sequel::Model(:ele1); end
+    class ::Maggot < Sequel::Model; end
+    class ::ShoeSize < Sequel::Model; end
+    class ::BootSize < ShoeSize; end
+  end
+
+  after do
+    [:Elephant, :Maggot, :ShoeSize, :BootSize].each{|x| Object.send(:remove_const, x)}
+  end
+
+  it "should return true if dataset from the class name" do
+    Maggot.has_dataset?.must_equal true
+    ShoeSize.has_dataset?.must_equal true
+  end
+
+  it "should return true if dataset from the superclass" do
+    BootSize.has_dataset?.must_equal true
+  end
+
+  it "should return true if dataset set explicitly" do
+    Elephant.has_dataset?.must_equal true
+    @a.has_dataset?.must_equal true
+  end
+
+  it "should return false if no dataset is explicitly set and the class is anonymous" do
+    @b.has_dataset?.must_equal false
+  end
+
+  it "should return false if no dataset is explicitly set and the class and its parent are anonymous" do
+    @c.has_dataset?.must_equal false
+  end
+end
+
 describe Sequel::Model, "implicit table names" do
   after do
     Object.send(:remove_const, :BlahBlah)


### PR DESCRIPTION
Because `.dataset` raises error if there is no dataset,
and there is no quiet way to check dataset existing, except `rescue`.

Useful for multiple-inherited abstract classes.

Reference: https://groups.google.com/d/msg/sequel-talk/OG5ti9JAJIE/G8ncUsT4BAAJ