### PR TITLE
Add ability to have Sequel not log errors

### DIFF
--- a/lib/sequel/database/logging.rb
+++ b/lib/sequel/database/logging.rb
@@ -11,6 +11,9 @@ module Sequel
     # level instead of info level.
     attr_accessor :log_warn_duration
 
+    # Whether to log errors or not
+    attr_accessor :log_errors
+
     # Array of SQL loggers to use for this database.
     attr_accessor :loggers
     
@@ -42,7 +45,7 @@ module Sequel
       begin
         yield
       rescue => e
-        log_exception(e, sql)
+        log_exception(e, sql) if log_errors
         raise
       ensure
         log_duration(Sequel.elapsed_seconds_since(timer), sql) unless e

--- a/lib/sequel/database/misc.rb
+++ b/lib/sequel/database/misc.rb
@@ -135,6 +135,7 @@ module Sequel
       @schema_type_classes = SCHEMA_TYPE_CLASSES.dup
 
       self.sql_log_level = @opts[:sql_log_level] ? @opts[:sql_log_level].to_sym : :info
+      self.log_errors = @opts.fetch(:log_errors, true)
       self.log_warn_duration = @opts[:log_warn_duration]
       self.log_connection_info = typecast_value_boolean(@opts[:log_connection_info])
 

--- a/spec/core/database_spec.rb
+++ b/spec/core/database_spec.rb
@@ -257,6 +257,13 @@ describe "Database#log_connection_yield" do
     @o.logs.first.last.must_match(/\ASequel::Error: adsf: blah\z/)
   end
 
+  it "should not log message at error level if block raises and error and log_errors is false" do
+    @db.log_warn_duration = 0
+    @db.log_errors = false
+    proc{@db.log_connection_yield('blah', @conn){raise Sequel::Error, 'adsf'}}.must_raise Sequel::Error
+    @o.logs.length.must_equal 0
+  end
+
   it "should include args with message if args passed" do
     @db.log_connection_yield('blah', @conn, [1, 2]){}
     @o.logs.length.must_equal 1


### PR DESCRIPTION
Currently when a logger is configured and an error occurs it will log the error and then also re-raise.

For me I want to handle these errors at a higher level and not have Sequel log the error also, this change adds the ability to turn off error logging which will now only re-raise the error where it is handled by my application.

The default behavior has not changed and it will continue to log errors if a logger is configured.