### PR TITLE
Generated columns support

### DIFF
--- a/lib/sequel/database/features.rb
+++ b/lib/sequel/database/features.rb
@@ -44,6 +44,12 @@ module Sequel
       respond_to?(:foreign_key_list)
     end
 
+    # Whether the database supports generated columns, false by default.
+    # SQL-2003 feature T-175.
+    def supports_generated_columns?
+      false
+    end
+
     # Whether the database supports Database#indexes for parsing indexes.
     def supports_index_parsing?
       respond_to?(:indexes)

--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -109,6 +109,8 @@ module Sequel
       #                yet exist on referenced table (but will exist before the transaction commits).
       #                Basically it adds DEFERRABLE INITIALLY DEFERRED on key creation.
       #                If you use :immediate as the value, uses DEFERRABLE INITIALLY IMMEDIATE.
+      # :generated_always_as :: Specify a GENERATED ALWAYS AS column expression,
+      #                         if generated columns are supported (MySQL and MariaDB).
       # :index :: Create an index on this column.  If given a hash, use the hash as the
       #           options for the index.
       # :key :: For foreign key columns, the column in the associated table


### PR DESCRIPTION
Generated Columns feature is [`T175`](https://ronsavage.github.io/SQL/sql-2003-noncore-features.html) in the SQL-2003 standard.
Supported by [MariaDB 5.2.0+](https://mariadb.com/kb/en/library/generated-columns/) and [MySQL 5.7.6+](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-6.html).

The standard BNF grammar for a [`<generation clause>`](https://ronsavage.github.io/SQL/sql-2003-2.bnf.html#generation%20clause) is
`GENERATED ALWAYS AS (`[`<value expression>`](https://ronsavage.github.io/SQL/sql-2003-2.bnf.html#value%20expression)`)`.

This PR adds:
- `:generated_always_as` option to column definition to add a `GENERATED ALWAYS AS column expression` to column definition statements;
- `#supports_generated_columns?` method that specifies whether the database supports generated columns based on the database server version;
- `:generated` key on the schema-hash parser for the MySQL adapter.

MySQL's [`CREATE TABLE` syntax](https://dev.mysql.com/doc/refman/5.7/en/create-table.html) makes the `GENERATED ALWAYS` part optional for brevity e.g., `AS (expr)`, but it also supports the standard syntax implemented in this PR.