### PR TITLE
Fix Sequel::SQL::Window RDoc links

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1693,8 +1693,8 @@ module Sequel
       end
 
       # Return a clone of the dataset with an addition named window that can be
-      # referenced in window functions. See {SQL::Window} for a list of options
-      # that can be passed in.
+      # referenced in window functions. See Sequel::SQL::Window for a list of
+      # options that can be passed in.
       def window(name, opts)
         clone(:window=>(@opts[:window]||[]) + [[name, SQL::Window.new(opts)]])
       end

--- a/lib/sequel/sql.rb
+++ b/lib/sequel/sql.rb
@@ -1366,7 +1366,7 @@ module Sequel
       end
 
       # Return a new function with an OVER clause (making it a window function).
-      # See {SQL::Window} for the list of options +over+ can receive.
+      # See Sequel::SQL::Window for the list of options +over+ can receive.
       #
       #   Sequel.function(:row_number).over(partition: :col) # row_number() OVER (PARTITION BY col)
       def over(window=OPTS)


### PR DESCRIPTION
It seems that `{SomeClass}` isn't the right way to link classes in RDoc, because it doesn't work (probably mixed it up with YARD). So I changed it to the full class name, and that works. In that case the link text will be the full constant name (`Sequel::SQL::Window`).