### PR TITLE
Replace sequel_pg's array parser by pg's array parser

### DIFF
--- a/.travis.gemfile
+++ b/.travis.gemfile
@@ -36,7 +36,7 @@ platforms :ruby do
   if RUBY_VERSION < '2.0.0'
     gem "pg", '<0.19.0'
   else
-    gem "pg"
+    gem "pg", git: "https://github.com/ged/ruby-pg/"
   end
 end
 


### PR DESCRIPTION
Caused by the [discussion on ruby-lang](https://bugs.ruby-lang.org/issues/14819) I had a look at the sequal_pg gem and compared it with what we have in pg already. I think sequal_pg could be fully integrated into pg, although it would require some efforts.

The benefit is, that we could combine the best pieces of both extensions together, so that pg could better fit the needs of all ORM libraries. In the long run this could also save some maintenance costs.

The attached patch is a first low hanging fruit, since the array parsers are pretty equal. They currently differ in that pg's parser doesn't raise any errors, but this [behavior is deprecated](https://github.com/ged/ruby-pg/commit/f0a0a2d09d0c0f82fa69a7a43643b34f34047ee7) anyways. This is the reason, why [one spec fails](https://travis-ci.org/larskanis/sequel/jobs/387825926). I could make this behavior configurable, if this is desired.

For now and for the attached patch the only benefits are:
1. The array parser could be removed from sequel_pg
2. Parsing of native types such as `int[]` is faster, since they are cased directly in C, not going through the ruby based converter.

PG has a very [flexible type cast system](https://github.com/ged/ruby-pg/#type-casts), which allows to assign and combine decoders and encoders by OID or columns based. It would be possible to add new specific decoders into PG or make PG's decoders configurable by parameters. One such example is to pass the class to be called for time-only values rather than hardcoding into the C code:
```
deco = PG::TextDecoder::Time.new(class: Sequel::SQLTime)
deco.decode("2018-06-04")
```

Is this a direction you would like to go? Or better keep sequel's `PGresult` handling separately?