### PR TITLE
Timestamp plugin: Protect against nil create_timestamp_field

### DIFF
--- a/lib/sequel/plugins/timestamps.rb
+++ b/lib/sequel/plugins/timestamps.rb
@@ -92,7 +92,7 @@ module Sequel
         def set_create_timestamp(time=nil)
           field = model.create_timestamp_field
           meth = :"#{field}="
-          set_column_value(meth, time||=model.dataset.current_datetime) if respond_to?(field) && respond_to?(meth) && (model.create_timestamp_overwrite? || get_column_value(field).nil?)
+          set_column_value(meth, time||=model.dataset.current_datetime) if field && respond_to?(field) && respond_to?(meth) && (model.create_timestamp_overwrite? || get_column_value(field).nil?)
           set_update_timestamp(time) if model.set_update_timestamp_on_create?
         end
         


### PR DESCRIPTION
Hi,

"What could make that field `nil`?" 

This is a change which tries to avoid a test failure which happened in about 10% of the runs in my test suite. 

The code then raised an error "nil is not a symbol or a string" on `#respond_to?()`.

I added some diagnostic checks:

<details>

From: /Users/olle/.rvm/gems/ruby-2.5.1/gems/sequel-5.9.0/lib/sequel/plugins/timestamps.rb @ line 96 Sequel::Plugins::Timestamps::InstanceMethods#set_create_timestamp:

         92: def set_create_timestamp(time=nil)
         93:   field = model.create_timestamp_field
         94:   meth = :"#{field}="
         95:   unless field && meth
     =>  96:     require 'pry';binding.pry
         97:   end
         98:   set_column_value(meth, time||=model.dataset.current_datetime) if ((field && meth) && respond_to?(field) && respond_to?(meth)) && (model.create_timestamp_overwrite? || get_column_value(field).nil?)
         99:   set_update_timestamp(time) if model.set_update_timestamp_on_create?
        100: end

```
[1] pry(#<User>)> self
=> #<User @values={:username=>"foo", :password=>"$2a$10$2W9Hx.imxr4w9p.s7uMN.uWUv7DYtF.t/6D8Ki.y1JzKp0/JDRVhm"}>
[2] pry(#<User>)> field
=> nil
[3] pry(#<User>)> meth
=> :"="
[4] pry(#<User>)> model
=> User
[5] pry(#<User>)> model.create_timestamp_field
=> nil
[6] pry(#<User>)> User.ancestors
=> [User,
 CamelAttributes,
 #<Module:0x00007fa3acb83178>,
 Sequel::Model,
 Sequel::Plugins::Timestamps::InstanceMethods,
 Sequel::Model::Associations::InstanceMethods,
 Sequel::Model::InstanceMethods,
 Object,
 PP::ObjectMixin,
 ActiveSupport::Tryable,
 JSON::Ext::Generator::GeneratorMethods::Object,
 Kernel,
 BasicObject]
 ```

 </details>