### PR TITLE
Fix Rdoc indent

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1287,11 +1287,11 @@ module Sequel
       #     a.update(:name=>'A')
       #   end
       #
-      #  a = Artist[2]
-      #  Artist.db.transaction do
-      #    a.lock!('FOR NO KEY UPDATE')
-      #    a.update(:name=>'B')
-      #  end
+      #   a = Artist[2]
+      #   Artist.db.transaction do
+      #     a.lock!('FOR NO KEY UPDATE')
+      #     a.update(:name=>'B')
+      #   end
       def lock!(style=:update)
         _refresh(this.lock_style(style)) unless new?
         self


### PR DESCRIPTION
This removes an extra indent that was probably unintentional.

<img width="741" alt="screen shot 2018-09-04 at 04 19 29" src="https://user-images.githubusercontent.com/795488/45006549-cf092280-aff9-11e8-9194-53f34970597d.png">
