### PR TITLE
RDoc fixes

### DIFF
--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -81,7 +81,8 @@ module Sequel
         constraint(nil, *args, &block)
       end
 
-      # Add a column with the given name, type, and opts      #
+      # Add a column with the given name, type, and opts:
+      #
       #   column :num, :integer
       #   # num INTEGER
       #

--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -159,7 +159,7 @@ module Sequel
         nil
       end
       
-      # Add a foreign key in the table that references another table. See column
+      # Add a foreign key in the table that references another table. See #column
       # for available options.
       #
       #   foreign_key(:artist_id) # artist_id INTEGER
@@ -242,7 +242,7 @@ module Sequel
         nil
       end
       
-      # Add a column with the given type, name, and opts.  See +column+ for available
+      # Add a column with the given type, name, and opts.  See #column for available
       # options.
       def method_missing(type, name = nil, opts = OPTS)
         name ? column(name, type, opts) : super


### PR DESCRIPTION
The first commit fixes a typo in RDocs. Second commit makes some references to the `#column` method links that you can follow, which I found I'd like to have.