### PR TITLE
Support single_value type in prepared statements

### DIFF
--- a/lib/sequel/dataset/prepared_statements.rb
+++ b/lib/sequel/dataset/prepared_statements.rb
@@ -91,7 +91,7 @@ module Sequel
       end
       
       # The type of prepared statement, should be one of :select, :first,
-      # :insert, :update, or :delete
+      # :insert, :update, :delete, or :single_value
       def prepared_type
         @opts[:prepared_type]
       end
@@ -144,7 +144,7 @@ module Sequel
         when :select, :all, :each
           # Most common scenario, so listed first.
           select_sql
-        when :first
+        when :first, :single_value
           clone(:limit=>1).select_sql
         when :insert_select
           insert_select_sql(*prepared_modify_values)
@@ -205,6 +205,8 @@ module Sequel
           when :map, :as_hash, :to_hash, :to_hash_groups
             public_send(*prepared_type, &block) 
           end
+        when :single_value
+          single_value
         else
           raise Error, "unsupported prepared statement type used: #{prepared_type.inspect}"
         end
@@ -290,7 +292,7 @@ module Sequel
           ds = ds.clone(:recorder=>pl)
 
           case type
-          when :first
+          when :first, :single_value
             ds.limit(1)
           when :update, :insert, :insert_select, :delete
             ds.with_sql(:"#{type}_sql", *values)
@@ -339,7 +341,7 @@ module Sequel
       clone(:bind_vars=>bind_vars)
     end
     
-    # For the given type (:select, :first, :insert, :insert_select, :update, or :delete),
+    # For the given type (:select, :first, :insert, :insert_select, :update, :delete, or :single_value),
     # run the sql with the bind variables specified in the hash.  +values+ is a hash passed to
     # insert or update (if one of those types is used), which may contain placeholders.
     #

--- a/spec/integration/prepared_statement_test.rb
+++ b/spec/integration/prepared_statement_test.rb
@@ -21,6 +21,7 @@ describe "Prepared Statements and Bound Arguments" do
     @ds.filter(:numb=>:$n).call(:select, :n=>10).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).call(:all, :n=>10).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).call(:first, :n=>10).must_equal(:id=>1, :numb=>10)
+    @ds.select(:numb).filter(:numb=>:$n).call(:single_value, :n=>10).must_equal(10)
     @ds.filter(:numb=>:$n).call([:map, :numb], :n=>10).must_equal [10]
     @ds.filter(:numb=>:$n).call([:as_hash, :id, :numb], :n=>10).must_equal(1=>10)
     @ds.filter(:numb=>:$n).call([:to_hash, :id, :numb], :n=>10).must_equal(1=>10)
@@ -39,20 +40,24 @@ describe "Prepared Statements and Bound Arguments" do
     @ds.filter(:numb=>:$n).bind(:n=>10).call(:select).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).bind(:n=>10).call(:all).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).bind(:n=>10).call(:first).must_equal(:id=>1, :numb=>10)
+    @ds.select(:numb).filter(:numb=>:$n).bind(:n=>10).call(:single_value).must_equal(10)
     
     @ds.bind(:n=>10).filter(:numb=>:$n).call(:select).must_equal [{:id=>1, :numb=>10}]
     @ds.bind(:n=>10).filter(:numb=>:$n).call(:all).must_equal [{:id=>1, :numb=>10}]
     @ds.bind(:n=>10).filter(:numb=>:$n).call(:first).must_equal(:id=>1, :numb=>10)
+    @ds.bind(:n=>10).select(:numb).filter(:numb=>:$n).call(:single_value).must_equal(10)
   end
   
   it "should allow overriding variables specified with #bind" do
     @ds.filter(:numb=>:$n).bind(:n=>1).call(:select, :n=>10).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).bind(:n=>1).call(:all, :n=>10).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).bind(:n=>1).call(:first, :n=>10).must_equal(:id=>1, :numb=>10)
+    @ds.select(:numb).filter(:numb=>:$n).bind(:n=>1).call(:single_value, :n=>10).must_equal(10)
     
     @ds.filter(:numb=>:$n).bind(:n=>1).bind(:n=>10).call(:select).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).bind(:n=>1).bind(:n=>10).call(:all).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).bind(:n=>1).bind(:n=>10).call(:first).must_equal(:id=>1, :numb=>10)
+    @ds.select(:numb).filter(:numb=>:$n).bind(:n=>1).bind(:n=>10).call(:single_value).must_equal(10)
   end
 
   it "should support placeholder literal strings with call" do
@@ -160,6 +165,8 @@ describe "Prepared Statements and Bound Arguments" do
     @db.call(:select_n, :n=>10).must_equal [{:id=>1, :numb=>10}]
     @ds.filter(:numb=>:$n).prepare(:first, :select_n)
     @db.call(:select_n, :n=>10).must_equal(:id=>1, :numb=>10)
+    @ds.select(:numb).filter(:numb=>:$n).prepare(:single_value, :select_n)
+    @db.call(:select_n, :n=>10).must_equal(10)
     @ds.filter(:numb=>:$n).prepare([:map, :numb], :select_n)
     @db.call(:select_n, :n=>10).must_equal [10]
     @ds.filter(:numb=>:$n).prepare([:as_hash, :id, :numb], :select_n)


### PR DESCRIPTION
This pull request adds `:single_value` as a supported type for prepared statements, allowing single-column queries for counts, averages, etc. to be prepared.