### PR TITLE
Feature: Enable dataset condition inversion using NOT operator

### DIFF
--- a/lib/sequel/dataset/query.rb
+++ b/lib/sequel/dataset/query.rb
@@ -456,15 +456,20 @@ module Sequel
     #
     # See documentation for exclude for how inversion is handled in regards
     # to SQL 3-valued boolean logic.
-    def invert
+    def invert(opts=OPTS)
       cached_dataset(:_invert_ds) do
         having, where = @opts.values_at(:having, :where)
         if having.nil? && where.nil?
           where(false)
         else
           o = {}
-          o[:having] = SQL::BooleanExpression.invert(having) if having
-          o[:where] = SQL::BooleanExpression.invert(where) if where
+          if opts[:not]
+            o[:having] = SQL::BooleanExpression.not(having) if having
+            o[:where] = SQL::BooleanExpression.not(where) if where
+          else
+            o[:having] = SQL::BooleanExpression.invert(having) if having
+            o[:where] = SQL::BooleanExpression.invert(where) if where
+          end
           clone(o)
         end
       end

--- a/lib/sequel/dataset/query.rb
+++ b/lib/sequel/dataset/query.rb
@@ -454,6 +454,12 @@ module Sequel
     #   DB[:items].where(category: 'software', id: 3).invert
     #   # SELECT * FROM items WHERE ((category != 'software') OR (id != 3))
     #
+    # The clauses can also be inverted through wrapping with a NOT clause by
+    # specifying the :not option.
+    #
+    #   DB[:items].where(category: 'software').invert(not: true)
+    #   # SELECT * FROM items WHERE NOT (category = 'software')
+    #
     # See documentation for exclude for how inversion is handled in regards
     # to SQL 3-valued boolean logic.
     def invert(opts=OPTS)

--- a/lib/sequel/sql.rb
+++ b/lib/sequel/sql.rb
@@ -1123,6 +1123,14 @@ module Sequel
         end
       end
 
+      # Invert the expression using a SQL NOT operator.
+      #
+      #   BooleanExpression.not(Sequel[a: :b]) # NOT ("a" = "b")
+      #
+      # Note that this can lead to scenarios where the logic is not the exact
+      # inverse of the original expression.
+      #
+      #   BooleanExpression.not(Sequel.&(:a, :b)) # NOT ("a" AND "b")
       def self.not(ce)
         BooleanExpression.new(:NOT, ce)
       end

--- a/lib/sequel/sql.rb
+++ b/lib/sequel/sql.rb
@@ -1123,6 +1123,10 @@ module Sequel
         end
       end
 
+      def self.not(ce)
+        BooleanExpression.new(:NOT, ce)
+      end
+
       # Always use an AND operator for & on BooleanExpressions
       def &(ce)
         BooleanExpression.new(:AND, self, ce)

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -732,6 +732,10 @@ describe "Dataset#invert" do
   it "should invert both having and where if both are preset" do
     @d.filter(:x).group(:x).having(:x).invert.sql.must_equal 'SELECT * FROM test WHERE NOT x GROUP BY x HAVING NOT x'
   end
+
+  it "should allow inversion using NOT" do
+    @d.filter(:x => 2).invert(:not => true).sql.must_equal 'SELECT * FROM test WHERE NOT (x = 2)'
+  end
 end
 
 describe "Dataset#having" do


### PR DESCRIPTION
Currently when a dataset is inverted via `.invert`, it inverts each individual operator within the condition.  This allows inversion to be completed by wrapping the entire expression in a NOT clause.

I imagine there is more that needs to be done with this prior to merging. I will be adding test cases, but for the moment, is there anything else this needs to do?