### PR TITLE
Add support for qualifying hashes in filters

### DIFF
--- a/lib/sequel/sql.rb
+++ b/lib/sequel/sql.rb
@@ -1088,6 +1088,9 @@ module Sequel
         when ::Array
           r = r.dup.freeze unless r.frozen?
           new(:IN, l, r)
+        when ::Hash
+          r = r.dup.freeze unless r.frozen?
+          Sequel.deep_qualify(l, from_value_pairs(r))
         when ::String
           r = r.dup.freeze unless r.frozen?
           new(:'=', l, r)


### PR DESCRIPTION
If we had a joined dataset where we wanted to filter by many columns on the other table, currently we could explicitly qualify each column using `Sequel[]`:

```rb
Track
  .association_join(:album)
  .where(
    Sequel[:albums][:released_at] => Date.today,
    Sequel[:albums][:name]        => "Back to Black",
    Sequel[:albums][:single]      => true,
  )
```

or virtual rows:

```rb
Track
  .association_join(:album)
  .where{
    (albums[:released_at] =~ Date.today)      &
    (albums[:name]        =~ "Back to Black") &
    (albums[:single]      =~ true)
  }
```

Since that can get a bit repetitive if we have a lot of column filters, and we might want to keep using hashes, we can rewrite it using `Sequel.deep_qualify`:

```rb
Track
  .association_join(:album)
  .where(Sequel.deep_qualify(:albums,
    released_at: Date.today,
    name:        "Back to Black",
    single:      true,
  ))
```

This pull request adds a syntax sugar for the latter `Sequel.deep_qualify` version, allowing us to use a nested hash instead, where the key is the table name and the value is the expression we want to deep qualify (like in Active Record):

```rb
Track
  .association_join(:album)
  .where(albums: {
    released_at: Date.today,
    name:        "Back to Black",
    single:      true,
  })
```

I think it would be a very convenient syntax to have, I found myself wishing to use it. Let me know if you're open to accepting this feature. In that case I'll go ahead and update the documentation.