### PR TITLE
Fix default class table inheritence alias when dataset is qualified

### DIFF
--- a/lib/sequel/plugins/class_table_inheritance.rb
+++ b/lib/sequel/plugins/class_table_inheritance.rb
@@ -207,7 +207,12 @@ module Sequel
           @cti_instance_dataset = @instance_dataset
           @cti_table_columns = columns
           @cti_table_map = opts[:table_map] || {}
-          @cti_alias = opts[:alias] || @dataset.first_source
+          @cti_alias = opts[:alias] || case source = @dataset.first_source
+          when SQL::QualifiedIdentifier
+            @dataset.unqualified_column_for(source)
+          else
+            source
+          end
           @cti_ignore_subclass_columns = opts[:ignore_subclass_columns] || []
         end
       end


### PR DESCRIPTION
From discussion here: https://groups.google.com/forum/#!topic/sequel-talk/Awt--16UGLw

I used your suggestion of setting `@cti_alias` as the unqualified identifier rather than coercing into a string, I think that made more sense than my naive implementation.