### PR TITLE
Allow optional default value in Sequel.case

### DIFF
--- a/lib/sequel/dataset/sql.rb
+++ b/lib/sequel/dataset/sql.rb
@@ -307,8 +307,10 @@ module Sequel
         sql << t
         literal_append(sql, r)
       end
-      sql << " ELSE "
-      literal_append(sql, ce.default)
+      if ce.default?
+        sql << " ELSE "
+        literal_append(sql, ce.default)
+      end
       sql << " END)"
     end
 

--- a/spec/core/expression_filters_spec.rb
+++ b/spec/core/expression_filters_spec.rb
@@ -891,10 +891,13 @@ describe "Sequel core extension replacements" do
   end
 
   it "Sequel.case should use a CASE expression" do
+    l(Sequel.case({:a=>1}), "(CASE WHEN a THEN 1 END)")
     l(Sequel.case({:a=>1}, 2), "(CASE WHEN a THEN 1 ELSE 2 END)")
     l(Sequel.case({:a=>1}, 2, :b), "(CASE b WHEN a THEN 1 ELSE 2 END)")
+    l(Sequel.case([[:a, 1]]), "(CASE WHEN a THEN 1 END)")
     l(Sequel.case([[:a, 1]], 2), "(CASE WHEN a THEN 1 ELSE 2 END)")
     l(Sequel.case([[:a, 1]], 2, :b), "(CASE b WHEN a THEN 1 ELSE 2 END)")
+    l(Sequel.case([[:a, 1], [:c, 3]]), "(CASE WHEN a THEN 1 WHEN c THEN 3 END)")
     l(Sequel.case([[:a, 1], [:c, 3]], 2), "(CASE WHEN a THEN 1 WHEN c THEN 3 ELSE 2 END)")
     l(Sequel.case([[:a, 1], [:c, 3]], 2, :b), "(CASE b WHEN a THEN 1 WHEN c THEN 3 ELSE 2 END)")
   end


### PR DESCRIPTION
The ELSE clause in a CASE statement is optional, but in Sequel it's currently required. This allows omitting the default value.