### PR TITLE
Run specs also on TruffleRuby on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,12 @@ rvm:
   - jruby-9.1.17.0
   - jruby-9.2.0.0
   - jruby-head
+  - truffleruby
   - ruby-head
 matrix:
   allow_failures:
     - rvm: jruby-head
+    - rvm: truffleruby
     - rvm: ruby-head
     - rvm: jruby-19mode
     - rvm: jruby-9.0.5.0


### PR DESCRIPTION
TruffleRuby works on Travis finally. https://github.com/travis-ci/travis-build/pull/1604 It always installs the latest version of TruffleRuby.

Sequel specs don't pass now. One of the reasons why not passing `Object#clone(freeze)` is not supported yet but the fix is coming soon in the next release https://github.com/oracle/truffleruby/issues/1454

I believe running specs on TruffleRuby would help its developers