### PR TITLE
Multiple migration directories

### DIFF
--- a/bin/sequel
+++ b/bin/sequel
@@ -9,7 +9,7 @@ dump_migration = nil
 dump_schema = nil
 dump_indexes = nil
 env = nil
-migrate_dir = nil
+migrate_dirs = []
 migrate_ver = nil
 backtrace = nil
 show_version = false
@@ -78,8 +78,8 @@ options = OptionParser.new do |opts|
     load_dirs << v
   end
   
-  opts.on("-m", "--migrate-directory DIR", "run the migrations in directory") do |v|
-    migrate_dir = v
+  opts.on("-m", "--migrate-directory DIR", Array, "run the migrations in given directories, separated by comma (`,`)") do |v|
+    migrate_dirs = v
     exclusive_options << :m
   end
   
@@ -126,7 +126,7 @@ extra_proc = lambda do
   $stderr.puts("Warning: last #{ARGV.length} arguments ignored") unless ARGV.empty?
 end
 
-error_proc["Error: Must specify -m if using -M"] if migrate_ver && !migrate_dir
+error_proc["Error: Must specify -m if using -M"] if migrate_ver && migrate_dirs.empty?
 error_proc["Error: Cannot specify #{exclusive_options.map{|v| "-#{v}"}.join(' and ')} together"] if exclusive_options.length > 1
 
 connect_proc = lambda do |database|
@@ -157,10 +157,10 @@ begin
 
   DB = connect_proc[db]
   load_dirs.each{|d| d.is_a?(Array) ? require(d.first) : Dir["#{d}/**/*.rb"].each{|f| load(f)}}
-  if migrate_dir
+  unless migrate_dirs.empty?
     extra_proc.call
     Sequel.extension :migration, :core_extensions
-    Sequel::Migrator.apply(DB, migrate_dir, migrate_ver)
+    Sequel::Migrator.apply(DB, migrate_dirs, migrate_ver)
     exit
   end
   if dump_migration

--- a/doc/migration.rdoc
+++ b/doc/migration.rdoc
@@ -227,6 +227,11 @@ For example:
 will look in the <tt>db/migrations</tt> folder relative to the current directory,
 and run unapplied migrations on the PostgreSQL database sequel_test running on localhost.
 
+If your migrations are spread across multiple folders, then you can supply
+those by separating them with a comma:
+
+  sequel -m db/migrations,db/migrations_old postgres://localhost/sequel_test
+
 == Two separate migrators
 
 Sequel actually ships with two separate migrators.  One is the +IntegerMigrator+, the other is

--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -406,6 +406,7 @@ module Sequel
     # if the version number is greater than 20000101, otherwise uses the IntegerMigrator.
     def self.migrator_class(directory)
       if self.equal?(Migrator)
+        raise(Error, "Must supply a valid migration path") unless File.directory?(directory)
         Dir.new(directory).each do |file|
           next unless MIGRATION_FILE_PATTERN.match(file)
           return TimestampMigrator if file.split('_', 2).first.to_i > 20000101
@@ -520,7 +521,6 @@ module Sequel
       raise(Error, "No current version available") unless current
 
       latest_version = latest_migration_version
-
       @target = if opts[:target]
         opts[:target]
       elsif opts[:relative]
@@ -529,7 +529,7 @@ module Sequel
         latest_version
       end
 
-      raise(Error, "No target version available, probably because no migration files found or filenames don't follow the migration filename convention") unless target
+      raise(Error, "No target and/or latest version available, probably because no migration files found or filenames don't follow the migration filename convention") unless target && latest_version
 
       if @target > latest_version
         @target = latest_version

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -390,7 +390,16 @@ describe "Sequel::IntegerMigrator" do
     @db.version.must_equal 3
     @db.sqls.map{|x| x =~ /\AUPDATE.*(\d+)/ ? $1.to_i : nil}.compact.must_equal [1, 2, 3]
   end
-  
+
+  it "should support migrations spread across multiple directories" do
+    migration_dirs = ["spec/files/multi_directory_migrations_1", "spec/files/multi_directory_migrations_2"]
+    Sequel::Migrator.apply(@db, migration_dirs)
+
+    @db.creates.must_equal [1111, 2222, 3333]
+    @db.version.must_equal 3
+    @db.sqls.map{|x| x =~ /\AUPDATE.*(\d+)/ ? $1.to_i : nil}.compact.must_equal [1, 2, 3]
+  end
+
   it "should be able to tell whether there are outstanding migrations" do
     Sequel::Migrator.is_current?(@db, @dirname).must_equal false
     Sequel::Migrator.apply(@db, @dirname)

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -284,18 +284,18 @@ describe "Sequel::IntegerMigrator" do
     Object.send(:remove_const, "CreateSessions") if Object.const_defined?("CreateSessions")
   end
   
-  it "should raise and error if there is a missing integer migration version" do
+  it "should raise an error if there is a missing integer migration version" do
     proc{Sequel::Migrator.apply(@db, "spec/files/missing_integer_migrations")}.must_raise(Sequel::Migrator::Error)
   end
   
-  it "should not raise and error if there is a missing integer migration version and allow_missing_migration_files is true" do
+  it "should not raise an error if there is a missing integer migration version and allow_missing_migration_files is true" do
     Sequel::Migrator.run(@db, "spec/files/missing_integer_migrations", :allow_missing_migration_files => true)
     @db.sqls.last.must_equal "UPDATE schema_info SET version = 3"
     Sequel::Migrator.run(@db, "spec/files/missing_integer_migrations", :allow_missing_migration_files => true, :target=>0)
     @db.sqls.last.must_equal "UPDATE schema_info SET version = 0"
   end
 
-  it "should raise and error if there is a duplicate integer migration version" do
+  it "should raise an error if there is a duplicate integer migration version" do
     proc{Sequel::Migrator.apply(@db, "spec/files/duplicate_integer_migrations")}.must_raise(Sequel::Migrator::Error)
   end
 

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -237,6 +237,11 @@ describe "Sequel::Migrator.migrator_class" do
     Sequel::IntegerMigrator.migrator_class("spec/files/timestamped_migrations").must_equal Sequel::IntegerMigrator
     Sequel::TimestampMigrator.migrator_class("spec/files/integer_migrations").must_equal Sequel::TimestampMigrator
   end
+
+  it "should raise an error if the migration folder does not exist" do
+    proc{Sequel::Migrator.apply(@db, "spec/files/nonexistant_migration_path")}.must_raise(Sequel::Migrator::Error)
+  end
+  
 end
 
 describe "Sequel::IntegerMigrator" do
@@ -283,7 +288,7 @@ describe "Sequel::IntegerMigrator" do
   after do
     Object.send(:remove_const, "CreateSessions") if Object.const_defined?("CreateSessions")
   end
-  
+
   it "should raise an error if there is a missing integer migration version" do
     proc{Sequel::Migrator.apply(@db, "spec/files/missing_integer_migrations")}.must_raise(Sequel::Migrator::Error)
   end
@@ -305,6 +310,12 @@ describe "Sequel::IntegerMigrator" do
 
   it "should raise an error if there is a migration file with multiple migrations" do
     proc{Sequel::Migrator.apply(@db, "spec/files/double_migration")}.must_raise(Sequel::Migrator::Error)
+  end
+
+  it "should raise an error if the most recent migration can't be detected" do
+    # Have to specify a target version, otherwise an earlier check (inability
+    # to detect the target) would raise an error, falsely matching the check.
+    proc{Sequel::Migrator.apply(@db, "spec/files/empty_migration_folder", 2)}.must_raise(Sequel::Migrator::Error)
   end
 
   it "should add a column name if it doesn't already exist in the schema_info table" do

--- a/spec/files/multi_directory_migrations_1/001_create_sessions.rb
+++ b/spec/files/multi_directory_migrations_1/001_create_sessions.rb
@@ -1,0 +1,9 @@
+class CreateSessions < Sequel::Migration
+  def up
+    create_table(:sm1111){Integer :smc1}
+  end
+  
+  def down
+    drop_table(:sm1111)
+  end
+end

--- a/spec/files/multi_directory_migrations_1/003_3_create_users.rb
+++ b/spec/files/multi_directory_migrations_1/003_3_create_users.rb
@@ -1,0 +1,4 @@
+Sequel.migration do
+  up{create_table(:sm3333){Integer :smc3}}
+  down{drop_table(:sm3333)}
+end

--- a/spec/files/multi_directory_migrations_2/002_create_nodes.rb
+++ b/spec/files/multi_directory_migrations_2/002_create_nodes.rb
@@ -1,0 +1,9 @@
+Class.new(Sequel::Migration) do
+  def up
+    create_table(:sm2222){Integer :smc2}
+  end
+    
+  def down
+    drop_table(:sm2222)
+  end
+end


### PR DESCRIPTION
This PR allows the two migrator classes to look for migration files in multiple directories.

This might be used for either organizational purposes, where - if a project has many migrations - the user might want to group them. Alternatively (as is the case for me) it can be useful if there is a common framework-like core, which is used by many separate applications.

All previous restrictions - ie migration names needing to be unique, and no missing migrations being allowed unless specifically configured - still apply.

I have attempted to guarantee full backwards-compatability - both for users of `bin/sequel` as well as for those using the `IntegerMigrator` / `TimestampMigrator` / `Migrator` classes directly. According to my manual testing this also works - and tests still pass. :)

During development I have also encountered two bugs related to specifying non-existent or empty migration directories, and a few minor typos in test descriptions. These have been fixed in separate commits (`855f98b` and `a4e8467` respectively), should you chose to merge them, but not the main change.