### PR TITLE
describe connection validation query

### DIFF
--- a/lib/sequel/database/connecting.rb
+++ b/lib/sequel/database/connecting.rb
@@ -326,7 +326,7 @@ module Sequel
 
     # The SQL query to issue to check if a connection is valid.
     def valid_connection_sql
-      @valid_connection_sql ||= select(nil).sql
+      @valid_connection_sql ||= select("/* from Ruby Sequel */").sql
     end
   end
 end


### PR DESCRIPTION
Hey,

i saw a crazy amount of `SELECT NULL` in our database activity log and it took me a while to figure out where it came from. This will change the query to include a SQL comment stating where it's coming from. This also makes it easy to take the message and grep the Sequel code to find it's location.

This would have saved me some time.

Let me know what you think :)