### PR TITLE
Remove JRuby check from excluded dedup spec.

### DIFF
--- a/spec/core/schema_spec.rb
+++ b/spec/core/schema_spec.rb
@@ -1679,7 +1679,7 @@ describe "Schema Parser" do
     sch = @db.schema(:x)
     sch.must_equal [[:a, {:db_type=>"x", :ruby_default=>nil}], [:b, {:db_type=>"x", :ruby_default=>nil}]]
     sch[0][1][:db_type].must_be_same_as(sch[1][1][:db_type])
-  end if RUBY_VERSION >= '2.5' && !defined?(JRUBY_VERSION)
+  end if RUBY_VERSION >= '2.5'
 
   it "should set :auto_increment to true by default if unset and a single integer primary key is used" do
     @db.define_singleton_method(:schema_parse_table){|*| [[:a, {:primary_key=>true, :db_type=>'integer'}]]}


### PR DESCRIPTION
This spec passes fine on JRuby since jruby/jruby#5190.