### PR TITLE
Add `#rename_enum_value` method for `pg_enum` extension

### DIFF
--- a/lib/sequel/extensions/pg_enum.rb
+++ b/lib/sequel/extensions/pg_enum.rb
@@ -17,6 +17,12 @@
 #
 #   DB.rename_enum(:enum_type_name, :enum_type_another_name)
 #
+# If you want to rename an enum value, you can use rename_enum_value:
+#
+#   DB.rename_enum_value(
+#     :enum_type_name, :enum_value_name, :enum_value_another_name
+#   )
+#
 # If you want to drop an enum type, you can use drop_enum:
 #
 #   DB.drop_enum(:enum_type_name)
@@ -103,6 +109,15 @@ module Sequel
       # to the another given name.
       def rename_enum(enum, new_name)
         sql = "ALTER TYPE #{quote_schema_table(enum)} RENAME TO #{quote_schema_table(new_name)}"
+        run sql
+        parse_enum_labels
+        nil
+      end
+
+      # Run the SQL to rename the enum value with the given name
+      # to the another given name.
+      def rename_enum_value(enum, old_name, new_name)
+        sql = "ALTER TYPE #{quote_schema_table(enum)} RENAME VALUE #{literal(old_name.to_s)} TO #{literal(new_name.to_s)}"
         run sql
         parse_enum_labels
         nil

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -3930,6 +3930,14 @@ describe 'PostgreSQL enum types' do
     @db.schema(:test_enumt, :reload=>true).first.last[:enum_values].must_equal @initial_enum_values
     @db.rename_enum(:new_enum, :test_enum)
   end
+
+  it "should rename enum values" do
+    @db.rename_enum_value(:test_enum, :b, :x)
+    new_enum_values = @initial_enum_values
+    new_enum_values[new_enum_values.index('b')] = 'x'
+    @db.schema(:test_enumt, :reload=>true).first.last[:enum_values].must_equal new_enum_values
+    @db.rename_enum_value(:test_enum, :x, :b)
+  end
 end
 
 describe "PostgreSQL stored procedures for datasets" do

--- a/spec/extensions/pg_enum_spec.rb
+++ b/spec/extensions/pg_enum_spec.rb
@@ -49,6 +49,11 @@ describe "pg_enum extension" do
     @db.sqls.first.must_equal "ALTER TYPE sch.foo RENAME TO sch.bar"
   end
 
+  it "should support #rename_enum_value method for renameing an enum value" do
+    @db.rename_enum_value(:foo, :b, :x)
+    @db.sqls.first.must_equal "ALTER TYPE foo RENAME VALUE 'b' TO 'x'"
+  end
+
   it "should support #drop_enum method for dropping an enum" do
     @db.drop_enum(:foo)
     @db.sqls.first.must_equal "DROP TYPE foo"


### PR DESCRIPTION
This ability was added into PostgreSQL 10: https://commitfest.postgresql.org/10/588/