### PR TITLE
Added support for 'float unsigned' in the schema_dumper extension.

### DIFF
--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -37,7 +37,7 @@ module Sequel
         {:type =>schema[:type] == :boolean ? TrueClass : Integer}
       when /\Abigint(?:\((?:\d+)\))?(?: unsigned)?\z/
         {:type=>:Bignum}
-      when /\A(?:real|float|double(?: precision)?|double\(\d+,\d+\)(?: unsigned)?)\z/
+      when /\A(?:real|float(?: unsigned)?|double(?: precision)?|double\(\d+,\d+\)(?: unsigned)?)\z/
         {:type=>Float}
       when 'boolean', 'bit', 'bool'
         {:type=>TrueClass}

--- a/spec/extensions/schema_dumper_spec.rb
+++ b/spec/extensions/schema_dumper_spec.rb
@@ -800,12 +800,13 @@ END_MIG
   it "should convert mysql types to ruby types" do
     def @d.schema(t, *o)
       i = 0
-      ['double(15,2)', 'double(7,1) unsigned'].map{|x| [:"c#{i+=1}", {:db_type=>x, :allow_null=>true}]}
+      ['float unsigned' 'double(15,2)', 'double(7,1) unsigned'].map{|x| [:"c#{i+=1}", {:db_type=>x, :allow_null=>true}]}
     end
     @d.dump_table_schema(:x).must_equal((<<END_MIG).chomp)
 create_table(:x) do
   Float :c1
   Float :c2
+  Float :c3
   
   check Sequel::SQL::BooleanExpression.new(:>=, Sequel::SQL::Identifier.new(:c2), 0)
 end

--- a/spec/extensions/schema_dumper_spec.rb
+++ b/spec/extensions/schema_dumper_spec.rb
@@ -800,7 +800,7 @@ END_MIG
   it "should convert mysql types to ruby types" do
     def @d.schema(t, *o)
       i = 0
-      ['float unsigned' 'double(15,2)', 'double(7,1) unsigned'].map{|x| [:"c#{i+=1}", {:db_type=>x, :allow_null=>true}]}
+      ['float unsigned', 'double(15,2)', 'double(7,1) unsigned'].map{|x| [:"c#{i+=1}", {:db_type=>x, :allow_null=>true}]}
     end
     @d.dump_table_schema(:x).must_equal((<<END_MIG).chomp)
 create_table(:x) do


### PR DESCRIPTION
I was playing around with the "schema_dumper" earlier today and I noticed that some of my "float unsigned" column (coming from MySQL) were wrongly converted into strings because it didn't match the regexp for the Float type so fixed it.