### PR TITLE
Adds support for cross-database and linked server models

### DIFF
--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -401,6 +401,7 @@ options that you may want to set are :login_timeout, :timeout, :tds_version, :az
 
 Other Sequel specific options:
 
+:ansi :: Set to true to enable the ANSI compatibility settings when connecting.
 :server_version :: Override the server version to use (9000000 = SQL Server 2005).
                    This also works on any other adapter that connects to Microsoft
                    SQL Server.

--- a/lib/sequel/adapters/tinytds.rb
+++ b/lib/sequel/adapters/tinytds.rb
@@ -16,6 +16,18 @@ module Sequel
         c = TinyTds::Client.new(opts)
         c.query_options.merge!(:cache_rows=>false)
 
+        if opts[:ansi]
+          sql = %w(
+            ANSI_NULLS
+            ANSI_PADDING
+            ANSI_WARNINGS
+            ANSI_NULL_DFLT_ON
+            QUOTED_IDENTIFIER
+            CONCAT_NULL_YIELDS_NULL
+          ).map{|v| "SET #{v} ON"}.join(";")
+          log_connection_yield(sql, c){c.execute(sql)}
+        end
+
         if (ts = opts[:textsize])
           sql = "SET TEXTSIZE #{typecast_value_integer(ts)}"
           log_connection_yield(sql, c){c.execute(sql)}


### PR DESCRIPTION
I have an overall goal of improving support for MSSQL linked servers, and this patch is a first step in that direction. 

### ANSI Connection Parameters
Per the [SQL Server documentation](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-ansi-defaults-transact-sql?view=sql-server-2017), setting the parameters outlined in this patch causes SQL Server to behave in a more standardized / mainstream manner (and also coincidentally paves the way for linked server support) when the `:ansi` connection parameter is set on a tinytds connection.

One added benefit is that it is no longer necessary to work around column nullability when creating new columns thanks to the new connection parameters when `:ansi` is enabled.

### Linked Server / Cross-Database Support
`#schema_parse_table` has been patched to parse the schema of cross-database or linked server models. 

The following are now supported in the MSSQL drivers:
```ruby
# Models that use an explicit database name
Sequel::Model(Sequel[:database_name][:schema_name][:table_name])

# Models that use an explicit linked server connection
Sequel::Model(Sequel[:linked_server_name][:database_name][:schema_name][:table_name])
```

Models generated using the above syntax will now properly source their metadata from the `information_schema` and `sys` catalogs from the relevant linked server / database.