### PR TITLE
Improve dataset filtering documentation when mixing AND and OR

### DIFF
--- a/doc/dataset_filtering.rdoc
+++ b/doc/dataset_filtering.rdoc
@@ -106,6 +106,21 @@ You can also use placeholders with :placeholder and a hash of placeholder values
   items.where(Sequel.lit('category = :category', category: "ruby")).sql
   # "SELECT * FROM items WHERE category = 'ruby'"
 
+In order to combine AND and OR together, you have a few options:
+
+  items.where(category: nil).or(category: "ruby")
+  # SELECT * FROM items WHERE (category IS NULL) OR (category = 'ruby')
+
+This won't work if you add other conditions:
+
+  items.where(name: "Programming in Ruby").where(category: nil).or(category: 'ruby')
+  # SELECT * FROM items WHERE ((name = 'Programming in Ruby') AND (category IS NULL)) OR (category = 'ruby')
+
+The OR applies globally and not locally. To fix this, use & and |:
+
+  items.where(Sequel[name: "Programming in Ruby"] & (Sequel[category: nil] | Sequel[category: "ruby"]))
+  # SELECT * FROM items WHERE ((name = 'Programming in Ruby') AND ((category IS NULL) OR (category = 'ruby')))
+
 === Specifying SQL functions
 
 Sequel also allows you to specify functions by using the Sequel.function method:


### PR DESCRIPTION
I was looking for documentation on how to combine AND and OR filtering in the same dataset, but couldn't find anything on 

* http://sequel.jeremyevans.net/rdoc/files/doc/querying_rdoc.html
* http://sequel.jeremyevans.net/rdoc/files/doc/dataset_filtering_rdoc.html

I did find a recent discussion on the mailing list:

https://groups.google.com/forum/#!searchin/sequel-talk/where$20or%7Csort:date/sequel-talk/sNEUId8J9Vw/1yJteFuwAwAJ

This PR adds the documentation where I would eventually have found it. Hope this helps!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jeremyevans/sequel/1630)
<!-- Reviewable:end -->
