### PR TITLE
Extract logging guard to own method

### DIFF
--- a/lib/sequel/database/logging.rb
+++ b/lib/sequel/database/logging.rb
@@ -35,7 +35,7 @@ module Sequel
     # Yield to the block, logging any errors at error level to all loggers,
     # and all other queries with the duration at warn or info level.
     def log_connection_yield(sql, conn, args=nil)
-      return yield if @loggers.empty?
+      return yield if skip_logging?
       sql = "#{connection_info(conn) if conn && log_connection_info}#{sql}#{"; #{args.inspect}" if args}"
       timer = Sequel.start_timer
 
@@ -57,6 +57,12 @@ module Sequel
     end
 
     private
+
+    # Determine if logging should be skipped. Defaults to true if no loggers
+    # have been specified.
+    def skip_logging?
+      @loggers.empty?
+    end
 
     # String including information about the connection, for use when logging
     # connection info.

--- a/spec/core/database_spec.rb
+++ b/spec/core/database_spec.rb
@@ -264,6 +264,25 @@ describe "Database#log_connection_yield" do
     @o.logs.first.first.must_equal :info
     @o.logs.first.last.must_match(/\A\(\d\.\d{6}s\) blah; \[1, 2\]\z/)
   end
+
+  it "should log without a logger defined by forcing skip_logging? to return false" do
+    @db.logger = nil
+    @db.extend(Module.new do
+      def skip_logging?
+        false
+      end
+
+      def log_duration(*)
+        self.did_log = true
+      end
+
+      attr_accessor :did_log
+    end)
+
+    @db.log_connection_yield('some sql', @conn) {}
+
+    @db.did_log.must_equal true
+  end
 end
 
 describe "Database#uri" do


### PR DESCRIPTION
Allows extensions to hook into logging methods (ie. log_duration)
without having to force a logger or monkeypatch log_connection_yield.