### PR TITLE
New ForeignKeyConstraintViolation errno in MySQL 8

### DIFF
--- a/lib/sequel/adapters/utils/mysql_mysql2.rb
+++ b/lib/sequel/adapters/utils/mysql_mysql2.rb
@@ -55,7 +55,7 @@ module Sequel
             NotNullConstraintViolation
           when 1062
             UniqueConstraintViolation
-          when 1451, 1452
+          when 1451, 1452, 1216, 1217
             ForeignKeyConstraintViolation
           when 4025
             CheckConstraintViolation


### PR DESCRIPTION
MySQL 8.0.13 returns different error numbers for foreign key constraint errors under some conditions:
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html#mysqld-8-0-13-errors

Sequel should recognise these as `ForeignKeyConstraintViolation` errors too.