### PR TITLE
Call before_retry when retrying indefinitely

### DIFF
--- a/lib/sequel/database/transactions.rb
+++ b/lib/sequel/database/transactions.rb
@@ -185,12 +185,7 @@ module Sequel
           transaction(opts, &block)
         rescue *retry_on => e
           num_retries += 1
-          if tot_retries
-            if num_retries <= tot_retries
-              opts[:before_retry].call(num_retries, e) if opts[:before_retry]
-              retry
-            end
-          else
+          if tot_retries.nil? || num_retries <= tot_retries
             opts[:before_retry].call(num_retries, e) if opts[:before_retry]
             retry
           end

--- a/lib/sequel/database/transactions.rb
+++ b/lib/sequel/database/transactions.rb
@@ -142,7 +142,7 @@ module Sequel
     # :num_retries :: The number of times to retry if the :retry_on option is used.
     #                 The default is 5 times.  Can be set to nil to retry indefinitely,
     #                 but that is not recommended.
-    # :before_retry :: Proc to execute before rertrying if the :retry_on option is used.
+    # :before_retry :: Proc to execute before retrying if the :retry_on option is used.
     #                  Called with two arguments: the number of retry attempts (counting
     #                  the current one) and the error the last attempt failed with.
     # :prepare :: A string to use as the transaction identifier for a
@@ -178,19 +178,20 @@ module Sequel
       opts = Hash[opts]
       if retry_on = opts[:retry_on]
         tot_retries = opts.fetch(:num_retries, 5)
-        num_retries = 0 unless tot_retries.nil?
+        num_retries = 0
         begin
           opts[:retry_on] = nil
           opts[:retrying] = true
           transaction(opts, &block)
         rescue *retry_on => e
-          if num_retries
-            num_retries += 1
+          num_retries += 1
+          if tot_retries
             if num_retries <= tot_retries
               opts[:before_retry].call(num_retries, e) if opts[:before_retry]
               retry
             end
           else
+            opts[:before_retry].call(num_retries, e) if opts[:before_retry]
             retry
           end
           raise


### PR DESCRIPTION
The problem with conditionals and execution paths... not adding any spec to cover this feels wrong, but adding one tells more about the code than the intended behavior (feels like a regression test). I saw it failing by modifying https://github.com/uhoh-itsmaciek/sequel/blob/master/spec/core/database_spec.rb#L704-L706 adding the option `:num_retries => nil`. Feedback?

Taking the chance to thank you for this awesome piece of kit and all your other contributions to the ruby community 🙌 .