### PR TITLE
Recognize timestamps with precision as timestamps

### DIFF
--- a/lib/sequel/database/query.rb
+++ b/lib/sequel/database/query.rb
@@ -325,7 +325,7 @@ module Sequel
         :integer
       when /\Adate\z/io
         :date
-      when /\A((small)?datetime|timestamp(\(\d\))?( with(out)? time zone)?)(\(\d+\))?\z/io
+      when /\A((small)?datetime|timestamp(\(\d\))?( with(out)? time zone)?)\z/io
         :datetime
       when /\Atime( with(out)? time zone)?\z/io
         :time

--- a/lib/sequel/database/query.rb
+++ b/lib/sequel/database/query.rb
@@ -325,7 +325,7 @@ module Sequel
         :integer
       when /\Adate\z/io
         :date
-      when /\A((small)?datetime|timestamp( with(out)? time zone)?)(\(\d+\))?\z/io
+      when /\A((small)?datetime|timestamp(\(\d\))?( with(out)? time zone)?)(\(\d+\))?\z/io
         :datetime
       when /\Atime( with(out)? time zone)?\z/io
         :time

--- a/spec/extensions/pg_row_spec.rb
+++ b/spec/extensions/pg_row_spec.rb
@@ -168,6 +168,7 @@ describe "pg_row extension" do
     p1.oid.must_equal 1
     @db.send(:schema_column_type, 'foo').must_equal :pg_row_foo
     @db.send(:schema_column_type, 'integer').must_equal :integer
+    @db.send(:schema_column_type, 'timestamp(6) without time zone').must_equal :datetime
 
     c = p1.converter
     c.superclass.must_equal @m::HashRow


### PR DESCRIPTION
Since version 6, Rails generates timestamp columns with a specific precision (https://github.com/rails/rails/pull/34970).
At the moment Sequel doesn't recognise those columns as timestamp because of the added precision.