### PR TITLE
Add sequel-activerecord_connection and remove sequel-jsonapi_eager

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -263,7 +263,6 @@
 <li><a href='https://github.com/jeremyevans/sequel-annotate'>sequel-annotate</a>: Generates model annotations for Sequel models, including constraint and trigger information on PostgreSQL.</li>
 <li><a href='http://github.com/gyordanov/sequel_extjs'>sequel_extjs</a>: Generates JSON from datasets that is consumable by the ExtJS JsonStore.</li>
 <li><a href='https://github.com/nickgartmann/sequel-location'>sequel-location</a>: Easy setup and syntax for doing geolocation search on PostgreSQL.</li>
-<li><a href='https://github.com/janko-m/sequel-jsonapi_eager'>sequel-jsonapi_eager</a>: Helps properly eager load associations when exposing objects in a JSON API.</li>
 <li><a href='http://github.com/jeremyevans/sequel_pg'>sequel_pg</a>: Faster SELECTs when using Sequel with pg.</li>
 <li><a href='https://github.com/celsworth/sequel-pg_advisory_locking'>sequel-pg_advisory_locking</a>: Adds PostreSQL advisory locking support.</li>
 <li><a href='http://github.com/mpalmer/sequel-pg-comment'>sequel-pg-comment</a>: Document your schema by setting comments on all your PgSQL objects.</li>

--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -259,6 +259,7 @@
 <li><a href='http://github.com/pusewicz/rails_sequel/'>rails_sequel</a>: Rails 2 plugin that allows you to use Sequel instead of ActiveRecord.</li>
 <li><a href='https://github.com/refile/refile-sequel'>refile-sequel</a>: Provides an extension for using Refile with Sequel.</li>
 <li><a href='http://github.com/openhood/rspec_sequel_matchers'>rspec_sequel_matchers</a>: RSpec matchers for Sequel validations, associations, and columns.</li>
+<li><a href='https://github.com/janko/sequel-activerecord_connection'>sequel-activerecord_connection</a>: Allows Sequel to use ActiveRecord's connection for database interaction.</li>
 <li><a href='https://github.com/jeremyevans/sequel-annotate'>sequel-annotate</a>: Generates model annotations for Sequel models, including constraint and trigger information on PostgreSQL.</li>
 <li><a href='http://github.com/gyordanov/sequel_extjs'>sequel_extjs</a>: Generates JSON from datasets that is consumable by the ExtJS JsonStore.</li>
 <li><a href='https://github.com/nickgartmann/sequel-location'>sequel-location</a>: Easy setup and syntax for doing geolocation search on PostgreSQL.</li>


### PR DESCRIPTION
This adds `sequel-activerecord_connection` gem to the list of external extensions.

It also removes `sequel-jsonapi_eager` gem because we've established that it's unsafe and that `tactical_eager_loading` plugin is better anyway (I've archived that repo already).
