### PR TITLE
Replace abandoned gem sequel-savepoints-hooks

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -270,7 +270,7 @@
 <li><a href='http://github.com/jeremyevans/sequel_postgresql_triggers'>sequel_postgresql_triggers</a>: Database enforced timestamps, immutable columns, and counter/sum caches.</li>
 <li><a href='http://github.com/brasten/sequel-rails'>sequel-rails</a>: Rails 3 plugin that allows you to use Sequel instead of ActiveRecord.</li>
 <li><a href='http://github.com/gucki/sequel_rails3'>sequel_rails3</a>: Another Rails 3 plugin that allows you to use Sequel instead of ActiveRecord.</li>
-<li><a href='https://github.com/chanks/sequel-savepoint-hooks'>sequel-savepoint-hooks</a>: Have after_commit/after_rollback hooks apply to current savepoint instead of transaction.</li>
+<li><a href='https://github.com/pabloh/sequel-force-hooks'>sequel-force-hooks</a>: Have after_commit/after_rollback hooks apply to current savepoint instead of transaction.</li>
 <li><a href='https://github.com/earaujoassis/sequel-seed'>sequel-seed</a>: A Sequel extension to make seeds/fixtures manageable like migrations.</li>
 <li><a href='http://github.com/jsvd/sequel_vectorized'>sequel_vectorized</a>: Allows Sequel::Dataset to be exported as an Hash of Arrays and NArrays.</li>
 </ul>


### PR DESCRIPTION
Replace `sequel-savepoints-hooks` gem with `sequel-force-hooks` since the former one has been abandoned