### PR TITLE
Fix link to bin/sequel guide

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -73,7 +73,7 @@ Sequel includes an IRB console for quick access to databases (usually referred t
 
 You get an IRB session with the Sequel::Database object stored in DB.
 
-In addition to providing an IRB shell (the default behavior), bin/sequel also has support for migrating databases, dumping schema migrations, and copying databases.  See the {bin/sequel guide}[rdoc-ref:doc/bin_sequel.rdoc] for more details.
+In addition to providing an IRB shell (the default behavior), bin/sequel also has support for migrating databases, dumping schema migrations, and copying databases.  See the [bin/sequel guide](rdoc-ref:doc/bin_sequel.rdoc) for more details.
 
 == An Introduction
 


### PR DESCRIPTION
Fix README, because `{bin/sequel guide}[rdoc-ref:doc/bin_sequel.rdoc] ` isn't converted to a link.