### PR TITLE
Add ORA-03135 as a connection error

### DIFF
--- a/lib/sequel/adapters/oracle.rb
+++ b/lib/sequel/adapters/oracle.rb
@@ -14,7 +14,8 @@ module Sequel
       # ORA-02396: exceeded maximum idle time, please connect again
       # ORA-03113: end-of-file on communication channel
       # ORA-03114: not connected to ORACLE
-      CONNECTION_ERROR_CODES = [ 28, 1012, 2396, 3113, 3114 ].freeze
+      # ORA-03135: connection lost contact
+      CONNECTION_ERROR_CODES = [ 28, 1012, 2396, 3113, 3114, 3135 ].freeze
       
       ORACLE_TYPES = {
         :blob=>lambda{|b| Sequel::SQL::Blob.new(b.read)},


### PR DESCRIPTION
Based on the causes given in the Oracle documentation I think `ORA-03135: connection lost contact` should be considered a connection error.

Causes from the oracle documentation (found [here](https://docs.oracle.com/cd/E11882_01/server.112/e17766/e2100.htm)):
1) Server unexpectedly terminated or was forced to terminate.
2) Server timed out the connection