### PR TITLE
Don't eager load all result sets in ODBC adapter.

### DIFF
--- a/lib/sequel/adapters/odbc.rb
+++ b/lib/sequel/adapters/odbc.rb
@@ -92,12 +92,10 @@ module Sequel
           cols = s.columns(true).map{|c| [output_identifier(c.name), c.type, i+=1]}
           columns = cols.map{|c| c[0]}
           self.columns = columns
-          if rows = s.fetch_all
-            rows.each do |row|
-              hash = {}
-              cols.each{|n,t,j| hash[n] = convert_odbc_value(row[j], t)}
-              yield hash
-            end
+          s.each do |row|
+            hash = {}
+            cols.each{|n,t,j| hash[n] = convert_odbc_value(row[j], t)}
+            yield hash
           end
         end
         self


### PR DESCRIPTION
At the moment ODBC connection will try to fetch all results and store
in memory before letting the caller access to any record.

This behaviour doesn't allow for streaming, makes some operation slower, and can lead to
OOM errors if someone tries to fetch a lot of records.