### PR TITLE
Fix warning for last argument as keyword param

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -756,6 +756,7 @@ module Sequel
         else
           define_singleton_method(meth){|*args, &block| dataset.public_send(meth, *args, &block)}
         end
+        singleton_class.send(:ruby2_keywords, meth) if respond_to?(:ruby2_keywords, true)
       end
 
       # Get the schema from the database, fall back on checking the columns

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -413,6 +413,11 @@ describe Sequel::Model, ".dataset_module" do
   it "should raise error if called with both an argument and a block" do
     proc{@c.dataset_module(Module.new{def return_3() 3 end}){}}.must_raise(Sequel::Error)
   end
+
+  it "should have dataset_module support a method with keyword arguments" do
+    @c.dataset_module { eval('def with_foo(name: (raise)); end') }
+    proc{@c.with_foo}.must_raise(StandardError)
+  end if RUBY_VERSION >= '2.0'
 end
 
 describe "A model class with implicit table name" do


### PR DESCRIPTION
Only appears when calling methods on the class and not the dataset.

```
lib/sequel/model/base.rb:755: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
spec/model/base_spec.rb:418: warning: The called method `with_foo' is defined here
```