### PR TITLE
Resolve warnings caused by undefined instance variables

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -778,7 +778,7 @@ module Sequel
 
       # The version of the PostgreSQL server, used for determining capability.
       def server_version(server=nil)
-        return @server_version if @server_version
+        return @server_version if defined?(@server_version)
         ds = dataset
         ds = ds.server(server) if server
         @server_version ||= ds.with_sql("SELECT CAST(current_setting('server_version_num') AS integer) AS v").single_value rescue 0

--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -284,7 +284,7 @@ module Sequel
       end
 
       def begin_new_transaction(conn, opts)
-        mode = opts[:mode] || @transaction_mode
+        mode = opts[:mode] || transaction_mode
         sql = TRANSACTION_MODE[mode] or raise Error, "transaction :mode must be one of: :deferred, :immediate, :exclusive, nil"
         log_connection_execute(conn, sql)
         set_transaction_isolation(conn, opts)


### PR DESCRIPTION
I encountered a couple warnings originating in `sequel` when running a test suite with warnings enabled. These two commits resolve the warnings and best I can tell leave the underlying behavior unchanged.