### PR TITLE
Remove redundant #freeze calls

### DIFF
--- a/lib/sequel/adapters/shared/access.rb
+++ b/lib/sequel/adapters/shared/access.rb
@@ -86,7 +86,7 @@ module Sequel
 
       EXTRACT_MAP = {:year=>"'yyyy'", :month=>"'m'", :day=>"'d'", :hour=>"'h'", :minute=>"'n'", :second=>"'s'"}.freeze
       EXTRACT_MAP.each_value(&:freeze)
-      OPS = {:'%'=>' Mod '.freeze, :'||'=>' & '.freeze}.freeze
+      OPS = {:'%'=>' Mod ', :'||'=>' & '}.freeze
       CAST_TYPES = {String=>:CStr, Integer=>:CLng, Date=>:CDate, Time=>:CDate, DateTime=>:CDate, Numeric=>:CDec, BigDecimal=>:CDec, File=>:CStr, Float=>:CDbl, TrueClass=>:CBool, FalseClass=>:CBool}.freeze
 
       # Access doesn't support CASE, so emulate it with nested IIF function calls.

--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -504,7 +504,7 @@ module Sequel
       end)
       include EmulateOffsetWithRowNumber
 
-      CONSTANT_MAP = {:CURRENT_DATE=>'CAST(CURRENT_TIMESTAMP AS DATE)'.freeze, :CURRENT_TIME=>'CAST(CURRENT_TIMESTAMP AS TIME)'.freeze}.freeze
+      CONSTANT_MAP = {:CURRENT_DATE=>'CAST(CURRENT_TIMESTAMP AS DATE)', :CURRENT_TIME=>'CAST(CURRENT_TIMESTAMP AS TIME)'}.freeze
       EXTRACT_MAP = {:year=>"yy", :month=>"m", :day=>"d", :hour=>"hh", :minute=>"n", :second=>"s"}.freeze
       EXTRACT_MAP.each_value(&:freeze)
       LIMIT_ALL = Object.new.freeze

--- a/lib/sequel/adapters/shared/oracle.rb
+++ b/lib/sequel/adapters/shared/oracle.rb
@@ -250,10 +250,10 @@ module Sequel
         super
       end
       
-      TRANSACTION_ISOLATION_LEVELS = {:uncommitted=>'READ COMMITTED'.freeze,
-        :committed=>'READ COMMITTED'.freeze,
-        :repeatable=>'SERIALIZABLE'.freeze,
-        :serializable=>'SERIALIZABLE'.freeze}.freeze
+      TRANSACTION_ISOLATION_LEVELS = {:uncommitted=>'READ COMMITTED',
+        :committed=>'READ COMMITTED',
+        :repeatable=>'SERIALIZABLE',
+        :serializable=>'SERIALIZABLE'}.freeze
       # Oracle doesn't support READ UNCOMMITTED OR REPEATABLE READ transaction
       # isolation levels, so upgrade to the next highest level in those cases.
       def set_transaction_isolation_sql(level)

--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -985,7 +985,7 @@ module Sequel
         (super || op[:op] == :validate_constraint) && op[:op] != :rename_column
       end
 
-      VALID_CLIENT_MIN_MESSAGES = %w'DEBUG5 DEBUG4 DEBUG3 DEBUG2 DEBUG1 LOG NOTICE WARNING ERROR FATAL PANIC'.freeze.each(&:freeze)
+      VALID_CLIENT_MIN_MESSAGES = %w'DEBUG5 DEBUG4 DEBUG3 DEBUG2 DEBUG1 LOG NOTICE WARNING ERROR FATAL PANIC'.freeze
       # The SQL queries to execute when starting a new connection.
       def connection_configuration_sqls(opts=@opts)
         sqls = []
@@ -1519,7 +1519,7 @@ module Sequel
       include UnmodifiedIdentifiers::DatasetMethods
 
       NULL = LiteralString.new('NULL').freeze
-      LOCK_MODES = ['ACCESS SHARE', 'ROW SHARE', 'ROW EXCLUSIVE', 'SHARE UPDATE EXCLUSIVE', 'SHARE', 'SHARE ROW EXCLUSIVE', 'EXCLUSIVE', 'ACCESS EXCLUSIVE'].each(&:freeze).freeze
+      LOCK_MODES = ['ACCESS SHARE', 'ROW SHARE', 'ROW EXCLUSIVE', 'SHARE UPDATE EXCLUSIVE', 'SHARE', 'SHARE ROW EXCLUSIVE', 'EXCLUSIVE', 'ACCESS EXCLUSIVE'].freeze
 
       Dataset.def_sql_method(self, :delete, [['if server_version >= 90100', %w'with delete from using where returning'], ['else', %w'delete from using where returning']])
       Dataset.def_sql_method(self, :insert, [['if server_version >= 90500', %w'with insert into columns values conflict returning'], ['elsif server_version >= 90100', %w'with insert into columns values returning'], ['else', %w'insert into columns values returning']])

--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -28,10 +28,10 @@ module Sequel
       SYNCHRONOUS = [:off, :normal, :full].freeze
       TEMP_STORE = [:default, :file, :memory].freeze
       TRANSACTION_MODE = {
-        :deferred => "BEGIN DEFERRED TRANSACTION".freeze,
-        :immediate => "BEGIN IMMEDIATE TRANSACTION".freeze,
-        :exclusive => "BEGIN EXCLUSIVE TRANSACTION".freeze,
-        nil => "BEGIN".freeze
+        :deferred => "BEGIN DEFERRED TRANSACTION",
+        :immediate => "BEGIN IMMEDIATE TRANSACTION",
+        :exclusive => "BEGIN EXCLUSIVE TRANSACTION",
+        nil => "BEGIN"
       }.freeze
 
       # Whether to use integers for booleans in the database.  SQLite recommends
@@ -552,9 +552,9 @@ module Sequel
       include UnmodifiedIdentifiers::DatasetMethods
 
       # The allowed values for insert_conflict
-      INSERT_CONFLICT_RESOLUTIONS = %w'ROLLBACK ABORT FAIL IGNORE REPLACE'.each(&:freeze).freeze
+      INSERT_CONFLICT_RESOLUTIONS = %w'ROLLBACK ABORT FAIL IGNORE REPLACE'.freeze
 
-      CONSTANT_MAP = {:CURRENT_DATE=>"date(CURRENT_TIMESTAMP, 'localtime')".freeze, :CURRENT_TIMESTAMP=>"datetime(CURRENT_TIMESTAMP, 'localtime')".freeze, :CURRENT_TIME=>"time(CURRENT_TIMESTAMP, 'localtime')".freeze}.freeze
+      CONSTANT_MAP = {:CURRENT_DATE=>"date(CURRENT_TIMESTAMP, 'localtime')", :CURRENT_TIMESTAMP=>"datetime(CURRENT_TIMESTAMP, 'localtime')", :CURRENT_TIME=>"time(CURRENT_TIMESTAMP, 'localtime')"}.freeze
       EXTRACT_MAP = {:year=>"'%Y'", :month=>"'%m'", :day=>"'%d'", :hour=>"'%H'", :minute=>"'%M'", :second=>"'%f'"}.freeze
       EXTRACT_MAP.each_value(&:freeze)
 

--- a/lib/sequel/adapters/sqlite.rb
+++ b/lib/sequel/adapters/sqlite.rb
@@ -5,7 +5,7 @@ require_relative 'shared/sqlite'
 
 module Sequel
   module SQLite
-    FALSE_VALUES = (%w'0 false f no n'.each(&:freeze) + [0]).freeze
+    FALSE_VALUES = (%w'0 false f no n' + [0]).freeze
 
     blob = Object.new
     def blob.call(s)

--- a/lib/sequel/database/misc.rb
+++ b/lib/sequel/database/misc.rb
@@ -394,11 +394,11 @@ module Sequel
       nil
     end
     
-    NOT_NULL_CONSTRAINT_SQLSTATES = %w'23502'.freeze.each(&:freeze)
-    FOREIGN_KEY_CONSTRAINT_SQLSTATES = %w'23503 23506 23504'.freeze.each(&:freeze)
-    UNIQUE_CONSTRAINT_SQLSTATES = %w'23505'.freeze.each(&:freeze)
-    CHECK_CONSTRAINT_SQLSTATES = %w'23513 23514'.freeze.each(&:freeze)
-    SERIALIZATION_CONSTRAINT_SQLSTATES = %w'40001'.freeze.each(&:freeze)
+    NOT_NULL_CONSTRAINT_SQLSTATES = %w'23502'.freeze
+    FOREIGN_KEY_CONSTRAINT_SQLSTATES = %w'23503 23506 23504'.freeze
+    UNIQUE_CONSTRAINT_SQLSTATES = %w'23505'.freeze
+    CHECK_CONSTRAINT_SQLSTATES = %w'23513 23514'.freeze
+    SERIALIZATION_CONSTRAINT_SQLSTATES = %w'40001'.freeze
     # Given the SQLState, return the appropriate DatabaseError subclass.
     def database_specific_error_class_from_sqlstate(sqlstate)
       case sqlstate

--- a/lib/sequel/database/transactions.rb
+++ b/lib/sequel/database/transactions.rb
@@ -9,10 +9,10 @@ module Sequel
     # them do.
     # ---------------------
 
-    TRANSACTION_ISOLATION_LEVELS = {:uncommitted=>'READ UNCOMMITTED'.freeze,
-      :committed=>'READ COMMITTED'.freeze,
-      :repeatable=>'REPEATABLE READ'.freeze,
-      :serializable=>'SERIALIZABLE'.freeze}.freeze
+    TRANSACTION_ISOLATION_LEVELS = {:uncommitted=>'READ UNCOMMITTED',
+      :committed=>'READ COMMITTED',
+      :repeatable=>'REPEATABLE READ',
+      :serializable=>'SERIALIZABLE'}.freeze
     
     # The default transaction isolation level for this database,
     # used for all future transactions.  For MSSQL, this should be set

--- a/lib/sequel/dataset/prepared_statements.rb
+++ b/lib/sequel/dataset/prepared_statements.rb
@@ -10,11 +10,11 @@ module Sequel
     
     PREPARED_ARG_PLACEHOLDER = LiteralString.new('?').freeze
 
-    DEFAULT_PREPARED_STATEMENT_MODULE_METHODS = %w'execute execute_dui execute_insert'.freeze.each(&:freeze)
+    DEFAULT_PREPARED_STATEMENT_MODULE_METHODS = %w'execute execute_dui execute_insert'.freeze
     PREPARED_STATEMENT_MODULE_CODE = {
-      :bind => "opts = Hash[opts]; opts[:arguments] = bind_arguments".freeze,
-      :prepare => "sql = prepared_statement_name".freeze,
-      :prepare_bind => "sql = prepared_statement_name; opts = Hash[opts]; opts[:arguments] = bind_arguments".freeze
+      :bind => "opts = Hash[opts]; opts[:arguments] = bind_arguments",
+      :prepare => "sql = prepared_statement_name",
+      :prepare_bind => "sql = prepared_statement_name; opts = Hash[opts]; opts[:arguments] = bind_arguments"
     }.freeze
 
     def self.prepared_statements_module(code, mods, meths=DEFAULT_PREPARED_STATEMENT_MODULE_METHODS, &block)

--- a/lib/sequel/extensions/pg_row_ops.rb
+++ b/lib/sequel/extensions/pg_row_ops.rb
@@ -88,10 +88,10 @@ module Sequel
   module Postgres
     # This class represents a composite type expression reference.
     class PGRowOp < SQL::PlaceholderLiteralString
-      ROW = ['(', '.*)'].freeze.each(&:freeze)
-      ROW_CAST = ['(', '.*)::'].freeze.each(&:freeze)
-      QUALIFY = ['(', ').'].freeze.each(&:freeze)
-      WRAP = [""].freeze.each(&:freeze)
+      ROW = ['(', '.*)'].freeze
+      ROW_CAST = ['(', '.*)::'].freeze
+      QUALIFY = ['(', ').'].freeze
+      WRAP = [""].freeze
 
       # Wrap the expression in a PGRowOp, without changing the
       # SQL it would use.


### PR DESCRIPTION
## Summary
This PR removes redundant `#freeze` calls on string literals. The calls are redundant as we are using `# frozen_string_literal: true`.

NOTE: If this PR feels more of a cosmetic change, please do close it. Thank you!