### PR TITLE
Add Fork Safety guide

### DIFF
--- a/doc/code_order.rdoc
+++ b/doc/code_order.rdoc
@@ -100,15 +100,3 @@ and freezing them can easily be achieved through the plugin:
   # ... setup models
   # Now finalize associations & freeze models by calling the plugin:
   Sequel::Model.freeze_descendents
-
-== Disconnect If Using Forking Webserver with Code Preloading
-
-If you are using a forking webserver such as unicorn or passenger, with
-a feature that loads your Sequel code before forking connections (code
-preloading), then you must disconnect your database connections before
-forking.  If you don't do this, you can end up with child processes
-sharing database connections and all sorts of weird behavior.  Sequel
-will automatically reconnect on an as needed basis in the child
-processes, so you only need to do the following in the parent process:
-
-  DB.disconnect

--- a/doc/fork_safety.doc
+++ b/doc/fork_safety.doc
@@ -1,0 +1,72 @@
+= Fork Safety
+
+If you are forking or using a library that forks after your Sequel code is
+loaded, then you must disconnect database connections before forking. If you
+don't do this, you can end up with child processes sharing database connections
+and all sorts of weird behavior.  Sequel will automatically reconnect on an as
+needed basis in the child processes, so you only need to do the following in
+the parent process:
+
+  DB.disconnect
+
+Or if you have connections to multiple databases:
+
+  Sequel::DATABASES.each(&:disconnect)
+
+== Puma
+
+In Puma web server, you can disconnect inside the `before_fork` hook in your
+Puma config:
+
+  before_fork do
+    Sequel::DATABASES.each(&:disconnect)
+  end
+
+Note that you only need this if you're using Puma's clustered mode.
+
+== Unicorn
+
+In Unicorn web server, you can disconnect inside the `before_fork` hook in your
+Unicorn config:
+
+  before_fork do
+    Sequel::DATABASES.each(&:disconnect)
+  end
+
+== Passenger
+
+In Passenger web server, you can disconnect inside the
+`starting_worker_process` event hook:
+
+  if defined?(PhusionPassenger)
+    PhusionPassenger.on_event(:starting_worker_process) do |forked|
+      Sequel::DATABASES.each(&:disconnect) if forked
+    end
+  end
+
+== Spring
+
+In Spring application preloader, you can disconnect inside the `after_fork`
+hook:
+
+  if defined?(Spring)
+    Spring.after_fork do
+      Sequel::DATABASES.each(&:disconnect)
+    end
+  end
+
+== Resque
+
+In Resque, you can disconnect inside the `before_fork` hook:
+
+  Resque.before_fork do |job|
+    Sequel::DATABASES.each(&:disconnect)
+  end
+
+== Parallel
+
+If you're using the Parallel gem with processes, you can disconnect before
+calling it:
+
+  Sequel::DATABASES.each(&:disconnect)
+  Parallel.map(['a','b','c'], in_processes: 3) { |one_letter| ... }

--- a/www/pages/documentation.html.erb
+++ b/www/pages/documentation.html.erb
@@ -39,6 +39,7 @@
     <li><a href="rdoc/files/doc/code_order_rdoc.html">Code Order</a></li>
     <li><a href="rdoc/files/doc/reflection_rdoc.html">Reflection</a></li>
     <li><a href="rdoc/files/doc/thread_safety_rdoc.html">Thread Safety</a></li>
+    <li><a href="rdoc/files/doc/fork_safety_rdoc.html">Fork Safety</a></li>
     <li><a href="rdoc/files/doc/testing_rdoc.html">Testing With Sequel</a></li>
     <li><a href="rdoc/files/doc/extensions_rdoc.html">Sequel Extensions</a></li>
     <li><a href="rdoc/files/doc/core_extensions_rdoc.html">Core Extensions</a></li>


### PR DESCRIPTION
Closing database connections before forking is very important, otherwise weird errors can happen. So, we add a dedicated Fork Safety guide to bring this to people's attention, which also includes instructions for common libraries (currently Puma, Unicorn, Passenger, Spring, Resque, and Parallel).
