### PR TITLE
Fix CsvSerializer-association_join compatibility

### DIFF
--- a/lib/sequel/plugins/csv_serializer.rb
+++ b/lib/sequel/plugins/csv_serializer.rb
@@ -186,7 +186,7 @@ module Sequel
 
           CsvSerializer.csv_call(:generate, opts) do |csv|
             items.each do |object|
-              csv << headers.map{|header| object.public_send(header)}
+              csv << headers.map{|header| object[header]}
             end
           end
         end


### PR DESCRIPTION
Prior to this commit, the CsvSerializer plugin
converted model instances (records) into CSV rows
using the getter methods defined on the model class
corresponding to its DB table's attributes / column names.

This approach fails when combining #to_csv with #association_join,
because the latter can introduce unexpected attributes
for which no getter methods exist. For instance,

    Album
      .select(Sequel[:artist][:name].as(:artist_name), :name)
      .association_join(:artist)
      .where(name: /california/i)
      .to_csv

raises

    NoMethodError: undefined method `artist_name' for #<Album:0x0000563a50e013f8>
    Did you mean? artist
    from /path/to/sequel-5.38.0/lib/sequel/plugins/csv_serializer.rb:189:in `public_send'

This commit adopts `Model#[]` over `#public_send` to avoid this problem.