### PR TITLE
Re-add truffleruby-head to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.4, 2.5, 2.6, 2.7, jruby-9.1.17.0, jruby-9.2.13.0 ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, jruby-9.1.17.0, jruby-9.2.13.0, truffleruby-head ]
     name: ${{ matrix.ruby }}
     env:
       BUNDLE_GEMFILE: .ci.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: sudo apt-get -yqq install libpq-dev mysql-client libmysqlclient-dev
+    - run: sudo apt-get -yqq install libxml2-dev libxslt-dev
+      if: startsWith(matrix.ruby, 'truffleruby')
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     name: ${{ matrix.ruby }}
     env:
       BUNDLE_GEMFILE: .ci.gemfile
+    continue-on-error: ${{ startsWith(matrix.ruby, 'truffleruby') }}
     steps:
     - uses: actions/checkout@v2
     - run: sudo apt-get -yqq install libpq-dev mysql-client libmysqlclient-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     name: ${{ matrix.ruby }}
     env:
       BUNDLE_GEMFILE: .ci.gemfile
-    continue-on-error: ${{ startsWith(matrix.ruby, 'truffleruby') }}
     steps:
     - uses: actions/checkout@v2
     - run: sudo apt-get -yqq install libpq-dev mysql-client libmysqlclient-dev
@@ -42,3 +41,4 @@ jobs:
       env:
         DEFAULT_DATABASE: 1
         MYSQL_ROOT_PASSWORD: 1
+      continue-on-error: ${{ startsWith(matrix.ruby, 'truffleruby') }}


### PR DESCRIPTION
Same as https://github.com/jeremyevans/roda/pull/200 but for Sequel.

I guess truffleruby was removed unintentionally in https://github.com/jeremyevans/sequel/commit/c11fbeb56c5ab83e74f03a17c8edc5a014b237b4