### PR TITLE
Fix typo in pg_enum documentation

### DIFF
--- a/lib/sequel/extensions/pg_enum.rb
+++ b/lib/sequel/extensions/pg_enum.rb
@@ -42,7 +42,7 @@
 #
 # This extension integrates with the pg_array extension.  If you plan
 # to use arrays of enum types, load the pg_array extension before the
-# pg_interval extension:
+# pg_enum extension:
 #
 #   DB.extension :pg_array, :pg_enum
 #


### PR DESCRIPTION
Trivial documentation fix I spotted today.