### PR TITLE
Mention :include in add_index docs (PostgreSQL)

### DIFF
--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -478,6 +478,8 @@ module Sequel
       #             custom SQL).
       # :type :: Set the index type (e.g. full_text, spatial, hash, gin, gist, btree).
       # :if_not_exists :: Only create the index if an index of the same name doesn't already exists
+      # :include :: Include additional column values in the index, without
+      #             actually indexing on those values (PostgreSQL 11+).
       #
       # MySQL specific options:
       #


### PR DESCRIPTION
Hello! I wanted to create a covering index for an existing PostgreSQL table, but the docs don't mention this option in `AlterTableGenerator#add_index` (`CreateTableGenerator#index` docs have it, though, so I copy-pasted it).