### PR TITLE
Fix document about virtual row where regular block got wrong calculation

### DIFF
--- a/doc/virtual_rows.rdoc
+++ b/doc/virtual_rows.rdoc
@@ -54,7 +54,7 @@ methods in the surrounding scope. For example:
   
   # Regular block
   ds.where{|o| o.c > a - b + @d}
-  # WHERE (c > 100)
+  # WHERE (c > 110)
   
   # Instance-evaled block
   ds.where{c > a - b + @d}


### PR DESCRIPTION
Clearly 42 - 32 + 100 = 110. In case there is any magic here that I am not aware of, it should also be documented as the result 100 is very uncertain.

For reference, here's the result from one of my machine:
```irb
>> Sequel.version
=> "5.2.0"
>> ds = DB[:features]
=> #<Sequel::Postgres::Dataset: "SELECT * FROM \"features\"">
>> def self.a
|  42
|  end
=> :a
>> b=32
=> 32
>> @d=100
=> 100
>> ds.where{|o| o.c > a - b + @d}
# WHERE (c > 100)
=> #<Sequel::Postgres::Dataset: "SELECT * FROM \"features\" WHERE (\"c\" > 110)">
```