### PR TITLE
Add ability to dump UUID columns

### DIFF
--- a/lib/sequel/database/query.rb
+++ b/lib/sequel/database/query.rb
@@ -12,12 +12,12 @@ module Sequel
 
     # The prepared statement object hash for this database, keyed by name symbol
     attr_reader :prepared_statements
-    
+
     # Whether the schema should be cached for this database.  True by default
     # for performance, can be set to false to always issue a database query to
     # get the schema.
     attr_accessor :cache_schema
-    
+
     # Runs the supplied SQL statement string on the database server.
     # Returns self so it can be safely chained:
     #
@@ -26,7 +26,7 @@ module Sequel
       run(sql)
       self
     end
-    
+
     # Call the prepared statement with the given name with the given hash
     # of arguments.
     #
@@ -35,7 +35,7 @@ module Sequel
     def call(ps_name, hash=OPTS, &block)
       prepared_statement(ps_name).call(hash, &block)
     end
-    
+
     # Method that should be used when submitting any DDL (Data Definition
     # Language) SQL, such as +create_table+.  By default, calls +execute_dui+.
     # This method should not be called directly by user code.
@@ -65,7 +65,7 @@ module Sequel
     def get(*args, &block)
       @default_dataset.get(*args, &block)
     end
-    
+
     # Runs the supplied SQL statement string on the database server. Returns nil.
     # Options:
     # :server :: The server to run the SQL on.
@@ -76,7 +76,7 @@ module Sequel
       execute_ddl(sql, opts)
       nil
     end
-    
+
     # Returns the schema for the given table as an array with all members being arrays of length 2,
     # the first member being the column name, and the second member being a hash of column information.
     # The table argument can also be a dataset, as long as it only has one table.
@@ -201,13 +201,13 @@ module Sequel
     end
 
     private
-    
+
     # Should raise an error if the table doesn't not exist,
     # and not raise an error if the table does exist.
     def _table_exists?(ds)
       ds.get(SQL::AliasedExpression.new(Sequel::NULL, :nil))
     end
-    
+
     # Whether the type should be treated as a string type when parsing the
     # column schema default value.
     def column_schema_default_string_type?(type)
@@ -219,7 +219,7 @@ module Sequel
     def column_schema_default_to_ruby_value(default, type)
       case type
       when :boolean
-        case default 
+        case default
         when /[f0]/i
           false
         when /[t1]/i
@@ -241,9 +241,13 @@ module Sequel
         Sequel.string_to_time(default)
       when :decimal
         BigDecimal(default)
+      else
+        case default
+        when /uuid_/ then Sequel.function(default.delete('()').to_sym)
+        end
       end
     end
-   
+
     # Normalize the default value string for the given type
     # and return the normalized value.
     def column_schema_normalize_default(default, type)
@@ -286,7 +290,7 @@ module Sequel
     def input_identifier_meth(ds=nil)
       (ds || dataset).method(:input_identifier)
     end
-    
+
     # Uncached version of metadata_dataset, designed for overriding.
     def _metadata_dataset
       dataset
@@ -313,7 +317,7 @@ module Sequel
       k = quote_schema_table(table)
       Sequel.synchronize{@schemas.delete(k)}
     end
-    
+
     # Match the database's column type to a ruby type via a
     # regular expression, and return the ruby type as a symbol
     # such as :integer or :string.
@@ -342,7 +346,7 @@ module Sequel
       end
     end
 
-    # Post process the schema values.  
+    # Post process the schema values.
     def schema_post_process(cols)
       # :nocov:
       if RUBY_VERSION >= '2.5'

--- a/lib/sequel/extensions/schema_dumper.rb
+++ b/lib/sequel/extensions/schema_dumper.rb
@@ -64,6 +64,8 @@ module Sequel
         {:type=>File, :size=>($1.to_i if $1)}
       when /\A(?:year|(?:int )?identity)\z/
         {:type=>Integer}
+      when 'uuid'
+        {:type=>:uuid}
       else
         {:type=>String}
       end
@@ -154,9 +156,9 @@ END_MIG
     end
 
     private
-        
+
     # If a database default exists and can't be converted, and we are dumping with :same_db,
-    # return a string with the inspect method modified a literal string is created if the code is evaled.  
+    # return a string with the inspect method modified a literal string is created if the code is evaled.
     def column_schema_to_ruby_default_fallback(default, options)
       if default.is_a?(String) && options[:same_db] && use_column_schema_to_ruby_default_fallback?
         default = default.dup
@@ -267,7 +269,7 @@ END_MIG
 
       if options[:foreign_keys] != false && supports_foreign_key_parsing?
         fk_list = foreign_key_list(table)
-        
+
         if (sfk = options[:skipped_foreign_keys]) && (sfkt = sfk[table])
           fk_list.delete_if{|fk| sfkt.has_key?(fk[:columns])}
         end
@@ -314,7 +316,7 @@ END_MIG
       gen.dump_indexes(meth=>table, :ignore_errors=>!options[:same_db])
     end
 
-    # Convert the parsed index information into options to the CreateTableGenerator's index method. 
+    # Convert the parsed index information into options to the CreateTableGenerator's index method.
     def index_to_generator_opts(table, name, index_opts, options=OPTS)
       h = {}
       if options[:index_names] != false && default_index_name(table, index_opts[:columns]) != name.to_s
@@ -352,7 +354,7 @@ END_MIG
     def sort_dumped_tables_topologically(table_fks, sorted_tables)
       skipped_foreign_keys = {}
 
-      until table_fks.empty? 
+      until table_fks.empty?
         this_loop = []
 
         table_fks.each do |table, fks|
@@ -381,7 +383,7 @@ END_MIG
 
       [sorted_tables, skipped_foreign_keys]
     end
-    
+
     # Don't use a literal string fallback on MySQL, since the defaults it uses aren't
     # valid literal SQL values.
     def use_column_schema_to_ruby_default_fallback?
@@ -491,7 +493,7 @@ END_MIG
       def opts_inspect(opts)
         if opts[:default]
           opts = opts.dup
-          de = Sequel.eval_inspect(opts.delete(:default)) 
+          de = Sequel.eval_inspect(opts.delete(:default))
           ", :default=>#{de}#{", #{opts.inspect[1...-1]}" if opts.length > 0}"
         else
           ", #{opts.inspect[1...-1]}" if opts.length > 0

--- a/spec/extensions/schema_dumper_spec.rb
+++ b/spec/extensions/schema_dumper_spec.rb
@@ -12,6 +12,7 @@ describe "Sequel::Schema::CreateTableGenerator dump methods" do
       varchar :b
       column :dt, DateTime
       column :vc, :varchar
+      column :uuid, :uuid, default: 'uuid_generate_v4()'
       primary_key :c
       foreign_key :d, :a
       foreign_key :e
@@ -692,13 +693,14 @@ END_MIG
        [:c9, {:db_type=>'time', :default=>"'10:20:30'", :type=>:time, :allow_null=>true}],
        [:c10, {:db_type=>'foo', :default=>"'6 weeks'", :type=>nil, :allow_null=>true}],
        [:c11, {:db_type=>'date', :default=>"CURRENT_DATE", :type=>:date, :allow_null=>true}],
-       [:c12, {:db_type=>'timestamp', :default=>"now()", :type=>:datetime, :allow_null=>true}]]
+       [:c12, {:db_type=>'timestamp', :default=>"now()", :type=>:datetime, :allow_null=>true}],
+       [:c13, {:db_type=>'uuid', :default=>"uuid_generate_v4()", :type=>:uuid, :allow_null=>true}]]
       s.each{|_, c| c[:ruby_default] = column_schema_to_ruby_default(c[:default], c[:type])}
       s
     end
     e = RUBY_VERSION >= '2.4' ? 'e' : 'E'
-    @d.dump_table_schema(:t4).gsub(/[+-]\d\d\d\d"\)/, '")').gsub(/\.0+/, '.0').must_equal "create_table(:t4) do\n  TrueClass :c1, :default=>false\n  String :c2, :default=>\"blah\"\n  Integer :c3, :default=>-1\n  Float :c4, :default=>1.0\n  BigDecimal :c5, :default=>Kernel::BigDecimal(\"0.1005#{e}3\")\n  File :c6, :default=>Sequel::SQL::Blob.new(\"blah\")\n  Date :c7, :default=>Date.new(2008, 10, 29)\n  DateTime :c8, :default=>DateTime.parse(\"2008-10-29T10:20:30.0\")\n  Time :c9, :default=>Sequel::SQLTime.parse(\"10:20:30.0\"), :only_time=>true\n  String :c10\n  Date :c11, :default=>Sequel::CURRENT_DATE\n  DateTime :c12, :default=>Sequel::CURRENT_TIMESTAMP\nend"
-    @d.dump_table_schema(:t4, :same_db=>true).gsub(/[+-]\d\d\d\d"\)/, '")').gsub(/\.0+/, '.0').must_equal "create_table(:t4) do\n  column :c1, \"boolean\", :default=>false\n  column :c2, \"varchar\", :default=>\"blah\"\n  column :c3, \"integer\", :default=>-1\n  column :c4, \"float\", :default=>1.0\n  column :c5, \"decimal\", :default=>Kernel::BigDecimal(\"0.1005#{e}3\")\n  column :c6, \"blob\", :default=>Sequel::SQL::Blob.new(\"blah\")\n  column :c7, \"date\", :default=>Date.new(2008, 10, 29)\n  column :c8, \"datetime\", :default=>DateTime.parse(\"2008-10-29T10:20:30.0\")\n  column :c9, \"time\", :default=>Sequel::SQLTime.parse(\"10:20:30.0\")\n  column :c10, \"foo\", :default=>Sequel::LiteralString.new(\"'6 weeks'\")\n  column :c11, \"date\", :default=>Sequel::CURRENT_DATE\n  column :c12, \"timestamp\", :default=>Sequel::CURRENT_TIMESTAMP\nend"
+    @d.dump_table_schema(:t4).gsub(/[+-]\d\d\d\d"\)/, '")').gsub(/\.0+/, '.0').must_equal "create_table(:t4) do\n  TrueClass :c1, :default=>false\n  String :c2, :default=>\"blah\"\n  Integer :c3, :default=>-1\n  Float :c4, :default=>1.0\n  BigDecimal :c5, :default=>Kernel::BigDecimal(\"0.1005#{e}3\")\n  File :c6, :default=>Sequel::SQL::Blob.new(\"blah\")\n  Date :c7, :default=>Date.new(2008, 10, 29)\n  DateTime :c8, :default=>DateTime.parse(\"2008-10-29T10:20:30.0\")\n  Time :c9, :default=>Sequel::SQLTime.parse(\"10:20:30.0\"), :only_time=>true\n  String :c10\n  Date :c11, :default=>Sequel::CURRENT_DATE\n  DateTime :c12, :default=>Sequel::CURRENT_TIMESTAMP\n  column :c13, :uuid, :default=>Sequel::SQL::Function.new!(:uuid_generate_v4, [], {})\nend"
+    @d.dump_table_schema(:t4, :same_db=>true).gsub(/[+-]\d\d\d\d"\)/, '")').gsub(/\.0+/, '.0').must_equal "create_table(:t4) do\n  column :c1, \"boolean\", :default=>false\n  column :c2, \"varchar\", :default=>\"blah\"\n  column :c3, \"integer\", :default=>-1\n  column :c4, \"float\", :default=>1.0\n  column :c5, \"decimal\", :default=>Kernel::BigDecimal(\"0.1005#{e}3\")\n  column :c6, \"blob\", :default=>Sequel::SQL::Blob.new(\"blah\")\n  column :c7, \"date\", :default=>Date.new(2008, 10, 29)\n  column :c8, \"datetime\", :default=>DateTime.parse(\"2008-10-29T10:20:30.0\")\n  column :c9, \"time\", :default=>Sequel::SQLTime.parse(\"10:20:30.0\")\n  column :c10, \"foo\", :default=>Sequel::LiteralString.new(\"'6 weeks'\")\n  column :c11, \"date\", :default=>Sequel::CURRENT_DATE\n  column :c12, \"timestamp\", :default=>Sequel::CURRENT_TIMESTAMP\n  column :c13, \"uuid\", :default=>Sequel::SQL::Function.new!(:uuid_generate_v4, [], {})\nend"
   end
   
   it "should not use a literal string as a fallback if using MySQL with the :same_db option" do


### PR DESCRIPTION
Add ability to dump UUID columns using SchemaDumper
migration file:
```ruby
# frozen_string_literal: true
Sequel.migration do
  up do
    run 'CREATE EXTENSION "uuid-ossp"'
    create_table(:users) do
      column :id, :uuid, default: Sequel.function(:uuid_generate_v4), primary_key: true
    end
  end

  down do
    drop_table(:users)
    run 'DROP EXTENSION IF EXISTS "uuid-ossp"'
  end
end

```

before:
```ruby
Sequel.migration do
  change do
    create_table(:schema_migrations) do
      String :filename, :text=>true, :null=>false
      
      primary_key [:filename]
    end
    
    create_table(:users) do
      String :id, :null=>false
      
      primary_key [:id]
    end
  end
end

```

after:
```ruby
Sequel.migration do
  change do
    create_table(:schema_migrations) do
      String :filename, :text=>true, :null=>false
      
      primary_key [:filename]
    end
    
    create_table(:users) do
      column :id, :uuid, :default=>Sequel::SQL::Function.new!(:uuid_generate_v4, [], {}), :null=>false
      
      primary_key [:id]
    end
  end
end

```
