### PR TITLE
Check if server_version is defined

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -778,7 +778,7 @@ module Sequel
 
       # The version of the PostgreSQL server, used for determining capability.
       def server_version(server=nil)
-        return @server_version if @server_version
+        return @server_version if defined?(@server_version) and @server_version
         ds = dataset
         ds = ds.server(server) if server
         @server_version = swallow_database_error{ds.with_sql("SELECT CAST(current_setting('server_version_num') AS integer) AS v").single_value} || 0


### PR DESCRIPTION
If running ruby with warnings enabled, the postgresql adapter complains that:

/home/showmax/bundle/ruby/2.7.0/gems/sequel-5.45.0/lib/sequel/adapters/shared/postgres.rb:781: warning: instance variable @server_version not initialized

Adding defined? into the condition resolved the warning.