### PR TITLE
Support renaming multiple tables at once in MySQL

### DIFF
--- a/doc/schema_modification.rdoc
+++ b/doc/schema_modification.rdoc
@@ -627,6 +627,12 @@ the first argument is the current name, and the second is the new name:
 
   rename_table(:artist, :artists)
 
+=== +rename_tables+
+
+You can rename multiple tables using +rename_tables+. All the tables will be
+renamed atomically. This is only supported for MySQL as other databases do not
+have a +RENAME+ statement.
+
 === <tt>create_table!</tt>
 
 <tt>create_table!</tt> drops the table if it exists

--- a/lib/sequel/adapters/shared/mysql.rb
+++ b/lib/sequel/adapters/shared/mysql.rb
@@ -187,6 +187,16 @@ module Sequel
       def views(opts=OPTS)
         full_tables('VIEW', opts)
       end
+
+      # Renames multiple tables:
+      #
+      #   DB.tables #=> [:items, :other_items]
+      #   DB.rename_tables [:items, :old_items], [:other_items, :old_other_items]
+      #   DB.tables #=> [:old_items, :old_other_items]
+      def rename_tables(*renames)
+        execute_ddl(rename_tables_sql(*renames))
+        renames.each { |rename| remove_cached_schema(rename.first) }
+      end
       
       private
       
@@ -715,6 +725,14 @@ module Sequel
       def full_text_sql(cols, terms, opts = OPTS)
         terms = terms.join(' ') if terms.is_a?(Array)
         SQL::PlaceholderLiteralString.new((opts[:boolean] ? MATCH_AGAINST_BOOLEAN : MATCH_AGAINST), [Array(cols), terms])
+      end
+
+      # SQL statement for renaming multiple tables.
+      def rename_tables_sql(*renames)
+        rename_tos = renames.map do |from, to|
+            "#{quote_schema_table(from)} TO #{quote_schema_table(to)}"
+        end.join(', ')
+        "RENAME TABLE #{rename_tos}"
       end
 
       # Sets up the insert methods to use INSERT IGNORE.

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -1059,3 +1059,18 @@ describe "MySQL joined datasets" do
     @db[:b].select_order_map(:id).must_equal [5]
   end
 end
+
+describe "MySQL::Database#rename_tables" do
+  before do
+    @db = DB
+  end
+
+  it "should rename multiple tables" do
+    @db.create_table!(:posts1){primary_key :a}
+    @db.create_table!(:messages1){primary_key :a}
+
+    @db.rename_tables([:posts1, :posts], [:messages1, :messages])
+    @db.table_exists?(:posts).must_equal true
+    @db.table_exists?(:messages).must_equal true
+  end
+end


### PR DESCRIPTION
MySQL has the `RENAME TABLE` statement that allows us to atomically
rename multiple tables. This doesn't appear to be supported in other
RDBMS's so I've only added it to the database methods for the MySQL
adapters (as recommended when I posted in the Google Group).