### PR TITLE
Call `super` in `#log_connection_yield` in sql_log_normalizer without loggers

### DIFF
--- a/lib/sequel/extensions/sql_log_normalizer.rb
+++ b/lib/sequel/extensions/sql_log_normalizer.rb
@@ -46,9 +46,10 @@ module Sequel
 
     # Normalize the SQL before calling super.
     def log_connection_yield(sql, conn, args=nil)
-      return yield if skip_logging?
-      sql = normalize_logged_sql(sql)
-      args = nil
+      unless skip_logging?
+        sql = normalize_logged_sql(sql)
+        args = nil
+      end
       super
     end
 


### PR DESCRIPTION
When using Sequel with the sequel-activerecord_connection gem, the gem's database extension [overrides `#log_connection_yield`](https://github.com/janko/sequel-activerecord_connection/blob/06e893c0343dcf1f57bfd1e07611e5975d24a787/lib/sequel/extensions/activerecord_connection.rb#L43-L47) to send SQL queries to Active Record's instrumenter, so that Sequel queries appear in the Rails logs together with Active Record queries.

This *almost* works with the new sql_log_normalizer extension, except that with sequel-activerecord_connection people typically won't have any loggers assigned to Sequel itself (since its queries are already sent to Rails logs), which causes sql_log_normalizer extension not to call the `#log_connection_yield` of descendants. Here I'm assuming the sql_log_normalizer extension is loaded after activerecord_connection extension, because the latter needs to be loaded on connecting anyway, so for me it's a reasonable requirement.

We fix this by ensuring `super` is called even when no loggers are assigned, which should keep the same behaviour and performance. I didn't know how to write a test for it, though.
