### PR TITLE
Use ‘{}’ instead of ARRAY[] when array is empty in postgres

### DIFF
--- a/lib/sequel/extensions/pg_array.rb
+++ b/lib/sequel/extensions/pg_array.rb
@@ -446,7 +446,7 @@ module Sequel
       # database array type.
       def sql_literal_append(ds, sql)
         at = array_type
-        if empty? && at
+        if empty?
           sql << "'{}'"
         else
           sql << "ARRAY"

--- a/spec/extensions/pg_array_associations_spec.rb
+++ b/spec/extensions/pg_array_associations_spec.rb
@@ -648,7 +648,7 @@ describe Sequel::Model, "pg_array_associations" do
     @o1.tag_ids.must_equal []
     @db.sqls.must_equal []
     @o1.save_changes
-    @db.sqls.must_equal ["UPDATE artists SET tag_ids = ARRAY[] WHERE (id = 1)"]
+    @db.sqls.must_equal ["UPDATE artists SET tag_ids = '{}' WHERE (id = 1)"]
 
     @o2.remove_all_artists
     @db.sqls.must_equal ["UPDATE artists SET tag_ids = array_remove(tag_ids, CAST(2 AS integer)) WHERE (tag_ids @> ARRAY[2]::integer[])"]
@@ -660,7 +660,7 @@ describe Sequel::Model, "pg_array_associations" do
     @o1.tag_ids.must_equal []
     @db.sqls.must_equal []
     @o1.save_changes
-    @db.sqls.must_equal ["UPDATE artists SET tag_ids = ARRAY[] WHERE (id = 1)"]
+    @db.sqls.must_equal ["UPDATE artists SET tag_ids = '{}' WHERE (id = 1)"]
 
     @o2.remove_all_artists
     @db.sqls.must_equal ["UPDATE artists SET tag_ids = array_remove(tag_ids, CAST(2 AS bigint)) WHERE (tag_ids @> ARRAY[2]::bigint[])"]
@@ -691,7 +691,7 @@ describe Sequel::Model, "pg_array_associations" do
 
     @o1.remove_all_tags
     @o1.tag_ids.must_equal []
-    @db.sqls.must_equal ["UPDATE artists SET tag_ids = ARRAY[] WHERE (id = 1)"]
+    @db.sqls.must_equal ["UPDATE artists SET tag_ids = '{}' WHERE (id = 1)"]
   end
 
   it "should have association modification methods deal with nil values" do

--- a/spec/extensions/pg_array_spec.rb
+++ b/spec/extensions/pg_array_spec.rb
@@ -144,7 +144,7 @@ describe "pg_array extension" do
   end
 
   it "should literalize arrays without types correctly" do
-    @db.literal(@m::PGArray.new([])).must_equal 'ARRAY[]'
+    @db.literal(@m::PGArray.new([])).must_equal "'{}'"
     @db.literal(@m::PGArray.new([1])).must_equal 'ARRAY[1]'
     @db.literal(@m::PGArray.new([nil])).must_equal 'ARRAY[NULL]'
     @db.literal(@m::PGArray.new([nil, 1])).must_equal 'ARRAY[NULL,1]'
@@ -395,6 +395,6 @@ describe "pg_array extension" do
 
   it "should convert ruby arrays to pg arrays as :default option values" do
     @db.create_table('a'){column :b, 'c[]', :default=>[]; Integer :d}
-    @db.sqls.must_equal ['CREATE TABLE a (b c[] DEFAULT (ARRAY[]::c[]), d integer)']
+    @db.sqls.must_equal ["CREATE TABLE a (b c[] DEFAULT ('{}'::c[]), d integer)"]
   end
 end


### PR DESCRIPTION
I have a few columns with array type in my postgres DB. However, if I insert to those columns using empty array, the result SQL is invalid:

```ruby
DB.create_table :items do
  column :id, Integer, primary: true
  column :tags, 'text[]', null: false
end

DB[:items].insert(id: 1, tags: Sequel.pg_array([]))
# raise Sequel::DatabaseError: PG::IndeterminateDatatype: ERROR:  cannot determine type of empty array
# LINE 1: INSERT INTO "items" ("id", "tags") VALUES (1, ARRAY[]) RETUR...
#                                                       ^
# HINT:  Explicitly cast to the desired type, for example ARRAY[]::integer[].
```

This can be worked around by adding type to `pg_array` like this:

```ruby
DB[:items].insert(id: 1, tags: Sequel.pg_array([], 'text'))
```

However, that's quite tedious for big application to create mapping for all array columns. Since Postgres supports empty array literal `'{}'`, if Sequel could convert to that when no type is passed in, that would be great.

## Testing

After applying this fix, the original code works

```ruby
DB.create_table :items do
  column :id, Integer, primary: true
  column :tags, 'text[]', null: false
end

DB[:items].insert(id: 1, tags: Sequel.pg_array([]))
=> nil
```

I also run my applications with this patch and everything seems ok (the test suite passed, most functionality works). However, I've only tested with posgres 13 & 14.

Please let me know if there are problems with this PR.