### PR TITLE
Use postgres:latest during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.5
+        image: postgres:latest
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       mysql:


### PR DESCRIPTION
I think it makes sense to run tests using a newer version of PostgreSQL.

Thank you very much.