### PR TITLE
Fix typo in `pg_hstore` docs

### DIFF
--- a/lib/sequel/extensions/pg_hstore.rb
+++ b/lib/sequel/extensions/pg_hstore.rb
@@ -76,7 +76,7 @@
 #
 # This extension integrates with the pg_array extension.  If you plan
 # to use arrays of hstore types, load the pg_array extension before the
-# pg_interval extension:
+# pg_hstore extension:
 #
 #   DB.extension :pg_array, :pg_hstore
 #


### PR DESCRIPTION
Typo introduced in https://github.com/jeremyevans/sequel/commit/60795802a37c680c76d3aff33aa118bd3994aa0e but the other case was already fixed by https://github.com/jeremyevans/sequel/commit/697f2ed77015518b75ee4c36f686e0bc155f745a