### PR TITLE
Update plugins.html.erb

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -1086,6 +1086,10 @@
 <span class="ul__span">ODBC and JDBC subadapters for OpenEdge database</span>
 </li>
 <li class="ul__li ul__li--grid">
+<a class="a" href="https://github.com/Yesware/sequel-snowflake">snowflake </a>
+<span class="ul__span">ODBC subadapter for <a class="a" href="https://www.snowflake.com">Snowflake</a> databases</span>
+</li>
+<li class="ul__li ul__li--grid">
 <a class="a" href="https://github.com/camilo/sequel-vertica">vertica </a>
 <span class="ul__span">Vertica adapter using <a class="a" href="https://github.com/wvanbergen/vertica">vertica</a> driver</span>
 </li>


### PR DESCRIPTION
Adds a reference to the `sequel-snowflake` adapter, to be used with Snowflake, the cloud-based database service.