### PR TITLE
Use Ruby 1.9+ Hash syntax in all of the docs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -56,9 +56,9 @@ If you have any comments or suggestions please post to the Google group.
   items = DB[:items] # Create a dataset
   
   # Populate the table
-  items.insert(:name => 'abc', :price => rand * 100)
-  items.insert(:name => 'def', :price => rand * 100)
-  items.insert(:name => 'ghi', :price => rand * 100)
+  items.insert(name: 'abc', price: rand * 100)
+  items.insert(name: 'def', price: rand * 100)
+  items.insert(name: 'ghi', price: rand * 100)
   
   # Print out the number of records
   puts "Item count: #{items.count}"
@@ -84,7 +84,7 @@ Sequel uses the concept of datasets to retrieve data. A Dataset object encapsula
 
 For example, the following one-liner returns the average GDP for countries in the middle east region:
 
-  DB[:countries].where(:region => 'Middle East').avg(:GDP)
+  DB[:countries].where(region: 'Middle East').avg(:GDP)
   
 Which is equivalent to:
 
@@ -92,7 +92,7 @@ Which is equivalent to:
 
 Since datasets retrieve records only when needed, they can be stored and later reused. Records are fetched as hashes, and are accessed using an +Enumerable+ interface:
 
-  middle_east = DB[:countries].where(:region => 'Middle East')
+  middle_east = DB[:countries].where(region: 'Middle East')
   middle_east.order(:name).each{|r| puts r[:name]}
   
 Sequel also offers convenience methods for extracting data from Datasets, such as an extended +map+ method:
@@ -210,12 +210,12 @@ If the dataset is ordered, you can also ask for the last record:
   
 You can also provide a filter when asking for a single record:
 
-  posts.first(:id => 1)
+  posts.first(id: 1)
   # SELECT * FROM posts WHERE id = 1 LIMIT 1
   
 Or retrieve a single value for a specific record:
 
-  posts.where(:id => 1).get(:name)
+  posts.where(id: 1).get(:name)
   # SELECT name FROM posts WHERE id = 1 LIMIT 1
   
 === Filtering Records
@@ -411,9 +411,9 @@ As with +delete+, +update+ affects all rows in the dataset, so +where+ first,
 +update+ second:
 
   # DO THIS:
-  posts.where(Sequel[:stamp] < Date.today - 7).update(:state => 'archived')
+  posts.where(Sequel[:stamp] < Date.today - 7).update(state: 'archived')
   # NOT THIS:
-  posts.update(:state => 'archived').where(Sequel[:stamp] < Date.today - 7)
+  posts.update(state: 'archived').where(Sequel[:stamp] < Date.today - 7)
 
 === Merging records
 
@@ -448,7 +448,7 @@ You can wrap a block of code in a database transaction using the <tt>Database#tr
     # BEGIN
     posts.insert(category: 'ruby', author: 'david')
     # INSERT
-    posts.where(Sequel[:stamp] < Date.today - 7).update(:state => 'archived')
+    posts.where(Sequel[:stamp] < Date.today - 7).update(state: 'archived')
     # UPDATE 
   end
   # COMMIT
@@ -461,9 +461,9 @@ and not raise an exception outside the block, you can raise the
 
   DB.transaction do
     # BEGIN
-    posts.insert(:category => 'ruby', :author => 'david')
+    posts.insert(category: 'ruby', author: 'david')
     # INSERT
-    if posts.where('stamp < ?', Date.today - 7).update(:state => 'archived') == 0
+    if posts.where('stamp < ?', Date.today - 7).update(state: 'archived') == 0
     # UPDATE 
       raise Sequel::Rollback
     end
@@ -706,8 +706,8 @@ You can delete individual records by calling +delete+ or +destroy+. The only dif
 
 Records can also be deleted en-masse by calling <tt>delete</tt> and <tt>destroy</tt> on the model's dataset. As stated above, you can specify filters for the deleted records:
 
-  Post.where(:category => 32).delete # => bypasses hooks
-  Post.where(:category => 32).destroy # => runs hooks
+  Post.where(category: 32).delete # => bypasses hooks
+  Post.where(category: 32).destroy # => runs hooks
 
 Please note that if <tt>destroy</tt> is called, each record is deleted 
 separately, but <tt>delete</tt> deletes all matching records with a single 
@@ -720,9 +720,9 @@ Associations are used in order to specify relationships between model classes th
   class Post < Sequel::Model
     many_to_one :author
     one_to_many :comments
-    one_to_one :first_comment, :class=>:Comment, :order=>:id
+    one_to_one :first_comment, class: :Comment, order: :id
     many_to_many :tags
-    one_through_one :first_tag, :class=>:Tag, :order=>:name, :right_key=>:tag_id
+    one_through_one :first_tag, class: :Tag, order: :name, right_key: :tag_id
   end
 
 +many_to_one+ and +one_to_one+ create a getter and setter for each model object:
@@ -761,7 +761,7 @@ All associations add a dataset method that can be used to further filter or reor
 Associations can be eagerly loaded via +eager+ and the <tt>:eager</tt> association option. Eager loading is used when loading a group of objects. It loads all associated objects for all of the current objects in one query, instead of using a separate query to get the associated objects for each current object. Eager loading requires that you retrieve all model objects at once via +all+ (instead of individually by +each+). Eager loading can be cascaded, loading association's associated objects.
 
   class Person < Sequel::Model
-    one_to_many :posts, :eager=>[:tags]
+    one_to_many :posts, eager: [:tags]
   end
 
   class Post < Sequel::Model

--- a/doc/advanced_associations.rdoc
+++ b/doc/advanced_associations.rdoc
@@ -115,7 +115,7 @@ These two approaches can also be nested, with +eager+ -> +eager_graph+ -> +eager
 
 Or with 2 separate +eager_graph+ queries:
 
-  Artist.eager_graph(:albums).eager_graph_eager([:albums], :tracks=>proc{|ds| ds.eager_graph(:lyric)})
+  Artist.eager_graph(:albums).eager_graph_eager([:albums], tracks: proc{|ds| ds.eager_graph(:lyric)})
   # 2 Queries:
   # SELECT artists.id, artists.name, ...
   #        albums.id AS albums_id, albums.name AS albums_name, ...
@@ -238,9 +238,9 @@ have the following associations
     
 and the following three albums in the database:
 
-  album1 = Album.create(:artist_id=>3) # id: 1
-  album2 = Album.create(:artist_id=>3) # id: 2
-  album3 = Album.create(:artist_id=>2) # id: 3
+  album1 = Album.create(artist_id: 3) # id: 1
+  album2 = Album.create(artist_id: 3) # id: 2
+  album3 = Album.create(artist_id: 2) # id: 3
 
 If you try to eager load this dataset:
 
@@ -256,7 +256,7 @@ the are both in the array related to that key.  album3 has a different
 artist_id, so it is in a different array. Eager loading of artists is
 done by looking for any artist having one of the keys in the hash:
 
-  artists = Artist.where(:id=>id_map.keys).all
+  artists = Artist.where(id: id_map.keys).all
 
 When the artists are retrieved, you can iterate over them, find entries
 with matching keys, and manually associate them to the albums:
@@ -281,7 +281,7 @@ case each array only has a single object, because id is the primary key).  So wh
 looking for tracks to eagerly load, you only need to look for ones that have an
 album_id with one of the keys in the hash:
 
-  tracks = Track.where(:album_id=>id_map.keys).all
+  tracks = Track.where(album_id: id_map.keys).all
 
 When the tracks are retrieved, you can iterate over them, find entries with matching
 keys, and manually associate them to the albums:
@@ -314,10 +314,10 @@ artist or tracks method on the album will not do another database lookup.
 
 So putting everything together, the artist eager loader looks like:
 
-  Album.many_to_one :artist, :eager_loader=>(proc do |eo_opts|
+  Album.many_to_one :artist, eager_loader: (proc do |eo_opts|
     eo_opts[:rows].each{|album| album.associations[:artist] = nil}
     id_map = eo_opts[:id_map]
-    Artist.where(:id=>id_map.keys).all do |artist|
+    Artist.where(id: id_map.keys).all do |artist|
       if albums = id_map[artist.id]
         albums.each do |album|
           album.associations[:artist] = artist
@@ -328,10 +328,10 @@ So putting everything together, the artist eager loader looks like:
 
 and the tracks eager loader looks like:
 
-  Album.one_to_many :tracks, :eager_loader=>(proc do |eo_opts|
+  Album.one_to_many :tracks, eager_loader: (proc do |eo_opts|
     eo_opts[:rows].each{|album| album.associations[:tracks] = []}
     id_map = eo_opts[:id_map]
-    Track.where(:album_id=>id_map.keys).all do |track|
+    Track.where(album_id: id_map.keys).all do |track|
       if albums = id_map[track.album_id]
         albums.each do |album|
           album.associations[:tracks] << track
@@ -405,7 +405,7 @@ the window function strategy:
 
   Artist.one_to_many :first_10_albums, class: :Album, order: :release_date, limit: 10,
     eager_limit_strategy: :window_function
-  Artist.where(:id=>[1,2]).eager(:first_10_albums).all
+  Artist.where(id: [1,2]).eager(:first_10_albums).all
   # SELECT * FROM (
   #   SELECT *, row_number() OVER (PARTITION BY albums.artist_id ORDER BY release_date) AS x_sequel_row_number_x
   #   FROM albums
@@ -483,7 +483,7 @@ function:
 The :correlated_subquery approach JOINs to a nested subquery using a correlated
 subquery:
 
-  Artist.eager_graph_with_options(:first_10_albums, :limit_strategy=>:correlated_subquery).all
+  Artist.eager_graph_with_options(:first_10_albums, limit_strategy: :correlated_subquery).all
   # SELECT artists.id, artists.name, first_10_albums.id AS first_10_albums_id,
   #        first_10_albums.name AS first_10_albums_name, first_10_albums.artist_id,
   #        first_10_albums.release_date
@@ -853,7 +853,7 @@ associated tickets.
   class Project < Sequel::Model
     one_to_many :tickets
     many_to_one :ticket_hours, read_only: true, key: :id,
-     dataset: proc{Ticket.where(:project_id=>id).select{sum(hours).as(hours)}},
+     dataset: proc{Ticket.where(project_id: id).select{sum(hours).as(hours)}},
      eager_loader: (lambda do |eo|
       eo[:rows].each{|p| p.associations[:ticket_hours] = nil}
       Ticket.where(project_id: eo[:id_map].keys).

--- a/doc/association_basics.rdoc
+++ b/doc/association_basics.rdoc
@@ -320,11 +320,11 @@ Associations are cached after being retrieved:
   @album.artists # Cached - No Database Query
   
 You can choose to ignore the cached versions and do a database query to
-retrieve results by passing a :reload=>true option to the association method:
+retrieve results by passing a <tt>reload: true</tt> option to the association method:
 
   @album.artists # Not cached - Database Query
   @album.artists # Cached - No Database Query
-  @album.artists(:reload=>true) # Ignore cache - Database Query
+  @album.artists(reload: true) # Ignore cache - Database Query
 
 If you reload/refresh the object, it will automatically clear the
 associations cache for the object:
@@ -532,14 +532,14 @@ Which could be created using the following Sequel code:
   DB.create_table(:artists) do
     # Primary key must be set explicitly
     primary_key :id
-    String :name, :null=>false, :unique=>true
+    String :name, null: false, unique: true
   end
   DB.create_table(:albums) do
     primary_key :id
     # Table that foreign key references needs to be set explicitly
     # for a database foreign key reference to be created.
-    foreign_key :artist_id, :artists, :null=>false
-    String :name, :null=>false, :unique=>true
+    foreign_key :artist_id, :artists, null: false
+    String :name, null: false, unique: true
   end
 
 If you already had a schema such as:
@@ -552,7 +552,7 @@ If you already had a schema such as:
 Then you just need to add the column:
 
   DB.alter_table(:albums) do
-    add_foreign_key :artist_id, :artists, :null=>false
+    add_foreign_key :artist_id, :artists, null: false
   end
 
 === many_to_many
@@ -588,11 +588,11 @@ wanted to add an albums_artists join table to create the following schema:
 
 You could use the following Sequel code:
 
-  DB.create_join_table(:album_id=>:albums, :artist_id=>:artists)
+  DB.create_join_table(album_id: :albums, artist_id: :artists)
   # or
   DB.create_table(:albums_artists) do
-    foreign_key :album_id, :albums, :null=>false
-    foreign_key :artist_id, :artists, :null=>false
+    foreign_key :album_id, :albums, null: false
+    foreign_key :artist_id, :artists, null: false
     primary_key [:album_id, :artist_id]
     index [:artist_id, :album_id]
   end
@@ -713,7 +713,7 @@ saving the passed in (or newly created) object.  However, to avoid
 silent failures of these methods, they explicitly raise exceptions
 even when raise_on_save_failure is false for the associated model.
 You can disable this behavior (i.e. return nil instead of raising
-exceptions on a save failure) by setting the <tt>:raise_on_save_failure=>false</tt>
+exceptions on a save failure) by setting the <tt>raise_on_save_failure: false</tt>
 option for the association.
 
 === remove_<i>association</i>(object_to_disassociate) (e.g. remove_album) [+one_to_many+ and +many_to_many+]
@@ -981,7 +981,7 @@ If you do not use a hash or array of two element arrays, you should use the
 :graph_conditions, :graph_only_conditions, or :graph_block option or you will not
 be able to use eager_graph or association_join with the association.
 
-  Artist.one_to_many :good_albums, class: :Album, conditions: {:good=>true}
+  Artist.one_to_many :good_albums, class: :Album, conditions: {good: true}
   @artist.good_albums
   # SELECT * FROM albums WHERE ((artist_id = 1) AND (good IS TRUE))
 
@@ -1162,7 +1162,7 @@ join of the join table and the associated table, whereas this option just
 applies to the join table.  It can be used to make sure that filters are used
 when deleting.
 
-  Artist.many_to_many :lead_guitar_albums, class: :Album, :join_table_block=>(lambda do |ds|
+  Artist.many_to_many :lead_guitar_albums, class: :Album, join_table_block: (lambda do |ds|
     ds.where(instrument_id: 5)
   end)
 
@@ -1177,7 +1177,7 @@ access to the join table.
 For example, if the Album class uses a different Sequel::Database than the Artist
 class, and the join table is in the database that the Artist class uses:
 
-  Artist.many_to_many :lead_guitar_albums, class: :Album, :join_table_db=>Artist.db
+  Artist.many_to_many :lead_guitar_albums, class: :Album, join_table_db: Artist.db
 
 This option also affects the add/remove/remove_all methods, by changing
 which database is used for inserts/deletes from the join table (add/remove/remove_all
@@ -1470,7 +1470,7 @@ at least the following keys:
 Example:
 
   Artist.one_to_many :self_title_albums, class: :Album,
-   :eager_grapher=>(lambda do |eo|
+   eager_grapher: (lambda do |eo|
     eo[:self].graph(:albums, {artist_id: :id, name: :name},
       table_alias: eo[:table_alias], implicit_qualifier: eo[:implicit_qualifier])
   end)
@@ -1727,7 +1727,7 @@ support joins.
 If set to false, you cannot use the association when filtering.
 
   Artist.one_to_many :albums, allow_filtering_by: false
-  Artist.where(:albums=>Album.where(:name=>'A')).all # Raises Sequel::Error
+  Artist.where(albums: Album.where(name: 'A')).all # Raises Sequel::Error
 
 This is useful if such filtering cannot work, such as when a subquery cannot
 be used because the necessary tables are not in the same database.

--- a/doc/cheat_sheet.rdoc
+++ b/doc/cheat_sheet.rdoc
@@ -54,8 +54,8 @@ Without a filename argument, the sqlite adapter will setup a new sqlite database
 == Update/Delete rows
 
   dataset.exclude(:active).delete
-  dataset.where{price < 100}.update(:active => true)
-  dataset.where(:active).update(:price => Sequel[:price] * 0.90)
+  dataset.where{price < 100}.update(active: true)
+  dataset.where(:active).update(price: Sequel[:price] * 0.90)
 
 = Merge rows
 
@@ -174,7 +174,7 @@ Without a filename argument, the sqlite adapter will setup a new sqlite database
     String :name, unique: true, null: false
     TrueClass :active, default: true
     foreign_key :category_id, :categories
-    DateTime :created_at, default: Sequel::CURRENT_TIMESTAMP, :index=>true
+    DateTime :created_at, default: Sequel::CURRENT_TIMESTAMP, index: true
     
     index [:category_id, :active]
   end

--- a/doc/model_hooks.rdoc
+++ b/doc/model_hooks.rdoc
@@ -199,7 +199,7 @@ While it's not enforced anywhere, it's a good idea to make +super+ the last expr
 
     def after_save
       super
-      AuditLog.create(:log=>"Album #{name} created")
+      AuditLog.create(log: "Album #{name} created")
     end
   end
 

--- a/doc/object_model.rdoc
+++ b/doc/object_model.rdoc
@@ -36,7 +36,7 @@ schema modification,
 and transactions:
 
   DB.transaction do
-    DB[:table].insert(:column=>value)
+    DB[:table].insert(column: value)
   end
 
 Sequel::Database#literal can be used to take any object that Sequel handles
@@ -468,7 +468,7 @@ objects:
   Sequel.lit(['', ' = '], :a, 1)
 
   '? = ?'.lit(:a, 1) # core_extensions extension
-  ':b = :v'.lit(:b=>:a, :v=>1) # core_extensions extension
+  ':b = :v'.lit(b: :a, v: 1) # core_extensions extension
 
 === Sequel::SQL::OrderedExpression
 
@@ -482,20 +482,20 @@ it ascending or descending:
 Additionally, they take an options hash, which can be used to specify how nulls
 can be sorted:
 
-  Sequel::SQL::OrderedExpression.new(:a, true, :nulls=>:first) # "a" DESC NULLS FIRST
-  Sequel::SQL::OrderedExpression.new(:a, false, :nulls=>:last) # "a" ASC NULLS LAST
+  Sequel::SQL::OrderedExpression.new(:a, true, nulls: :first) # "a" DESC NULLS FIRST
+  Sequel::SQL::OrderedExpression.new(:a, false, nulls: :last) # "a" ASC NULLS LAST
 
 The following shortcuts exist for creating Sequel::SQL::OrderedExpression objects:
 
   Sequel.asc(:a)
   Sequel.desc(:a)
-  Sequel.asc(:a, :nulls=>:first)
-  Sequel.desc(:a, :nulls=>:last)
+  Sequel.asc(:a, nulls: :first)
+  Sequel.desc(:a, nulls: :last)
 
   :a.asc # core_extensions extension
   :a.desc # core_extensions extension
-  :a.asc(:nulls=>:first) # core_extensions extension
-  :a.desc(:nulls=>:last) # core_extensions extension
+  :a.asc(nulls: :first) # core_extensions extension
+  :a.desc(nulls: :last) # core_extensions extension
 
 === Sequel::SQL::Subscript
 

--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -268,7 +268,7 @@ The following additional options are supported:
                        to MySQL.
 :socket :: Can be used to specify a Unix socket file to connect to instead of a TCP host and port.
 :sql_mode :: Set the sql_mode(s) for a given connection.  Can be single symbol or string,
-             or an array of symbols or strings (e.g. <tt>:sql_mode=>[:no_zero_date, :pipes_as_concat]</tt>).
+             or an array of symbols or strings (e.g. <tt>sql_mode: [:no_zero_date, :pipes_as_concat]</tt>).
 :timeout :: Sets the wait_timeout for the connection, defaults to 1 month.
 :read_timeout :: Set the timeout in seconds for reading back results to a query.
 :connect_timeout :: Set the timeout in seconds before a connection attempt is abandoned
@@ -290,13 +290,13 @@ mysql, such as the jdbc/mysql adapter).
 The ODBC adapter allows you to connect to any database with the appropriate ODBC drivers installed.  
 The :database option given ODBC database should be the DSN (Descriptive Service Name) from the ODBC configuration.
 
-  Sequel.odbc('mydb', :user => "user", :password => "password")
+  Sequel.odbc('mydb', user: "user", password: "password")
 
 The :host and :port options are not respected. The following additional options are supported:
 
 :db_type :: Can be specified as 'mssql', 'progress', or 'db2' to use SQL syntax specific to those databases.
 :drvconnect :: Can be given an ODBC connection string, and will use ODBC::Database#drvconnect to
-               do the connection.  Typical usage would be: <tt>Sequel.odbc(:drvconnect=>'driver={...};...')</tt>
+               do the connection.  Typical usage would be: <tt>Sequel.odbc(drvconnect: 'driver={...};...')</tt>
 
 === oracle 
 
@@ -345,7 +345,7 @@ The following additional options are supported:
 :search_path :: Set to the schema search_path.  This can either be a single string containing the schemas
                 separated by commas (for use via a URL: <tt>postgres:///?search_path=schema1,schema2</tt>), or it
                 can be an array of strings (for use via an option:
-                <tt>Sequel.postgres(:search_path=>['schema1', 'schema2'])</tt>).
+                <tt>Sequel.postgres(search_path: ['schema1', 'schema2'])</tt>).
 :use_iso_date_format :: This can be set to false to not force the ISO date format.  Sequel forces
                         it by default to allow for an optimization.
 

--- a/doc/postgresql.rdoc
+++ b/doc/postgresql.rdoc
@@ -295,16 +295,16 @@ option to +foreign_key_list+:
     primary_key :id
     Integer :i
     Integer :j
-    foreign_key :a_id, :a, :foreign_key_constraint_name=>:a_a
+    foreign_key :a_id, :a, foreign_key_constraint_name: :a_a
     unique [:i, :j]
   end
   DB.create_table!(:b) do
-    foreign_key :a_id, :a, :foreign_key_constraint_name=>:a_a
+    foreign_key :a_id, :a, foreign_key_constraint_name: :a_a
     Integer :c
     Integer :d
-    foreign_key [:c, :d], :a, :key=>[:j, :i], :name=>:a_c_d
+    foreign_key [:c, :d], :a, key: [:j, :i], name: :a_c_d
   end
-  DB.foreign_key_list(:a, :reverse=>true)
+  DB.foreign_key_list(:a, reverse: true)
   # => [
   #  {:name=>:a_a, :columns=>[:a_id], :key=>[:id], :on_update=>:no_action, :on_delete=>:no_action, :deferrable=>false, :table=>:a, :schema=>:public},
   #  {:name=>:a_a, :columns=>[:a_id], :key=>[:id], :on_update=>:no_action, :on_delete=>:no_action, :deferrable=>false, :table=>:b, :schema=>:public},
@@ -413,12 +413,12 @@ syntax:
 
   DB.create_table(:table){primary_key :id}
   # Ignore the given value for id, using the identity's sequence value.
-  DB[:table].overriding_user_value.insert(:id=>1)
+  DB[:table].overriding_user_value.insert(id: 1)
 
-  DB.create_table(:table){primary_key :id, :identity=>:always}
+  DB.create_table(:table){primary_key :id, identity: :always}
   # Force the use of the given value for id, because otherwise the insert will
   # raise an error, since GENERATED ALWAYS was used when creating the column.
-  DB[:table].overriding_system_value.insert(:id=>1)
+  DB[:table].overriding_system_value.insert(id: 1)
 
 === Distinct On Specific Columns
 
@@ -561,7 +561,7 @@ such as the related table and column or constraint.
 
   DB.create_table(:test1){primary_key :id}
   DB.create_table(:test2){primary_key :id; foreign_key :test1_id, :test1}
-  DB[:test2].insert(:test1_id=>1) rescue DB.error_info($!)
+  DB[:test2].insert(test1_id: 1) rescue DB.error_info($!)
   # => {
   #  :schema=>"public",
   #  :table=>"test2",

--- a/doc/schema_modification.rdoc
+++ b/doc/schema_modification.rdoc
@@ -377,7 +377,7 @@ Sequel will not add a column, but will add a composite primary key constraint:
 It is possible to specify a name for the primary key constraint: via the :name option:
 
   alter_table(:albums_artists) do
-    add_primary_key [:album_id, :artist_id], :name=>:albums_artists_pkey
+    add_primary_key [:album_id, :artist_id], name: :albums_artists_pkey
   end
 
 If you just want to take an existing single column and make it a primary key, call

--- a/doc/security.rdoc
+++ b/doc/security.rdoc
@@ -127,8 +127,8 @@ a ruby string as raw SQL.  For example:
   DB.literal(Date.today) # "'2013-03-22'"
   DB.literal('a') # "'a'"
   DB.literal(Sequel.lit('a')) # "a"
-  DB.literal(:a => 'a') # "(\"a\" = 'a')"
-  DB.literal(:a => Sequel.lit('a')) # "(\"a\" = a)"
+  DB.literal(a: 'a') # "(\"a\" = 'a')"
+  DB.literal(a: Sequel.lit('a')) # "(\"a\" = a)"
 
 ==== SQL Filter Fragments
 
@@ -178,7 +178,7 @@ user input for function names.
 For backwards compatibility, Sequel supports regular strings in the
 window function :frame option, which will be treated as a literal string:
 
-  DB[:table].select{fun(arg).over(:frame=>'SQL Here')}
+  DB[:table].select{fun(arg).over(frame: 'SQL Here')}
 
 You should make sure the frame argument is not derived from user input,
 or switch to using a hash as the :frame option value.
@@ -237,7 +237,7 @@ or:
 
 Instead, you should do:
 
-  DB[:table].update(:column => params[:value].to_s) # Safe
+  DB[:table].update(column: params[:value].to_s) # Safe
 
 Because using the auto_literal_strings extension makes SQL injection
 so much eaiser, it is recommended to not use it, and instead
@@ -402,29 +402,29 @@ This issue isn't necessarily specific to Sequel, but it is a good general practi
 If you are using values derived from user input, it is best to be explicit about
 their type.  For example:
 
-  Album.where(:id=>params[:id])
+  Album.where(id: params[:id])
 
 is probably a bad idea.  Assuming you are using a web framework, <tt>params[:id]</tt> could
 be a string, an array, a hash, nil, or potentially something else.
 
 Assuming that +id+ is an integer field, you probably want to do:
 
-  Album.where(:id=>params[:id].to_i)
+  Album.where(id: params[:id].to_i)
 
 If you are looking something up by name, you should try to enforce the value to be
 a string:
 
-  Album.where(:name=>params[:name].to_s)
+  Album.where(name: params[:name].to_s)
 
 If you are trying to use an IN clause with a list of id values based on input provided
 on a web form:
 
-  Album.where(:id=>params[:ids].to_a.map(&:to_i))
+  Album.where(id: params[:ids].to_a.map(&:to_i))
 
 Basically, be as explicit as possible. While there aren't any known security issues
 in Sequel when you do:
 
-  Album.where(:id=>params[:id])
+  Album.where(id: params[:id])
 
 It allows the attacker to choose to do any of the following queries:
 

--- a/doc/sql.rdoc
+++ b/doc/sql.rdoc
@@ -223,22 +223,22 @@ If the database supports window functions, Sequel can handle them by calling the
   DB[:albums].select{count.function.*.over}
   # SELECT count(*) OVER () FROM albums
 
-  DB[:albums].select{function(:col1).over(:partition=>col2, :order=>col3)}
+  DB[:albums].select{function(:col1).over(partition: col2, order: col3)}
   # SELECT function(col1) OVER (PARTITION BY col2 ORDER BY col3) FROM albums
 
-  DB[:albums].select{function(c1, c2).over(:partition=>[c3, c4], :order=>[c5, c6.desc])}
+  DB[:albums].select{function(c1, c2).over(partition: [c3, c4], order: [c5, c6.desc])}
   # SELECT function(c1, c2) OVER (PARTITION BY c3, c4 ORDER BY c5, c6 DESC) FROM albums
 
-  DB[:albums].select{function(c1).over(:partition=>c2, :order=>:c3, :frame=>:rows)}
+  DB[:albums].select{function(c1).over(partition: c2, order: :c3, frame: :rows)}
   # SELECT function(c1) OVER (PARTITION BY c2 ORDER BY c3 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM albums
 
-  DB[:albums].select{function(c1).over(:partition=>c2, :order=>:c3, :frame=>{:type=>:range, :start=>1, :end=>1})}
+  DB[:albums].select{function(c1).over(partition: c2, order: :c3, frame: {type: :range, start: 1, end: 1})}
   # SELECT function(c1) OVER (PARTITION BY c2 ORDER BY c3 RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM albums
 
-  DB[:albums].select{function(c1).over(:partition=>c2, :order=>:c3, :frame=>{:type=>:groups, :start=>[2, :preceding], :end=>[1, :preceding]})}
+  DB[:albums].select{function(c1).over(partition: c2, order: :c3, frame: {type: :groups, start: [2, :preceding], end: [1, :preceding]})}
   # SELECT function(c1) OVER (PARTITION BY c2 ORDER BY c3 GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING) FROM albums
 
-  DB[:albums].select{function(c1).over(:partition=>c2, :order=>:c3, :frame=>{:type=>:range, :start=>:preceding, :exclude=>:current})}
+  DB[:albums].select{function(c1).over(partition: c2, order: :c3, frame: {type: :range, start: :preceding, exclude: :current})}
   # SELECT function(c1) OVER (PARTITION BY c2 ORDER BY c3 RANGE UNBOUNDED PRECEDING EXCLUDE CURRENT ROW) FROM albums
 
 === Schema Qualified Functions
@@ -551,8 +551,8 @@ You can also use the <tt>Sequel.asc</tt> and <tt>Sequel.desc</tt> methods:
 
 On some databases, you can specify null ordering:
 
-  Sequel.asc(:column, :nulls=>:first) # "column" ASC NULLS FIRST
-  Sequel.desc(Sequel[:table][:column], :nulls=>:last) # "table"."column" DESC NULLS LAST
+  Sequel.asc(:column, nulls: :first) # "column" ASC NULLS FIRST
+  Sequel.desc(Sequel[:table][:column], nulls: :last) # "table"."column" DESC NULLS LAST
 
 === All Columns (.*)
 
@@ -629,16 +629,16 @@ Also note that while the SELECT clause is displayed when you look at a dataset, 
 
   ds = DB[:albums]
   ds.all # SELECT * FROM albums
-  ds.insert(:name=>'RF') # INSERT INTO albums (name) VALUES ('RF')
-  ds.update(:name=>'RF') # UPDATE albums SET name = 'RF'
+  ds.insert(name: 'RF') # INSERT INTO albums (name) VALUES ('RF')
+  ds.update(name: 'RF') # UPDATE albums SET name = 'RF'
   ds.delete # DELETE FROM albums
 
 In general, the +insert+, +update+, and +delete+ methods use the appropriate clauses you defined on the dataset:
 
-  ds = DB[:albums].where(:id=>1)
+  ds = DB[:albums].where(id: 1)
   ds.all # SELECT * FROM albums WHERE (id = 1)
-  ds.insert(:name=>'RF') # INSERT INTO albums (name) VALUES ('RF')
-  ds.update(:name=>'RF') # UPDATE albums SET name = 'RF' WHERE (id = 1)
+  ds.insert(name: 'RF') # INSERT INTO albums (name) VALUES ('RF')
+  ds.update(name: 'RF') # UPDATE albums SET name = 'RF' WHERE (id = 1)
   ds.delete # DELETE FROM albums WHERE (id = 1)
 
 Note how +update+ and +delete+ used the +where+ argument, but +insert+ did not, because INSERT doesn't use a WHERE clause.

--- a/doc/testing.rdoc
+++ b/doc/testing.rdoc
@@ -15,7 +15,7 @@ These run each test in its own transaction, the recommended way to test.
   
   class Minitest::HooksSpec
     def around
-      DB.transaction(:rollback=>:always, :auto_savepoint=>true){super}
+      DB.transaction(rollback: :always, auto_savepoint: true){super}
     end
   end
 
@@ -24,7 +24,7 @@ These run each test in its own transaction, the recommended way to test.
   
   class Minitest::Spec
     def run(*args, &block)
-      DB.transaction(:rollback=>:always, :auto_savepoint=>true){super}
+      DB.transaction(rollback: :always, auto_savepoint: true){super}
     end
   end
 
@@ -34,7 +34,7 @@ These run each test in its own transaction, the recommended way to test.
   # Use this class as the base class for your tests
   class SequelTestCase < Minitest::Test
     def run(*args, &block)
-      DB.transaction(:rollback=>:always, :auto_savepoint=>true){super}
+      DB.transaction(rollback: :always, auto_savepoint: true){super}
     end
   end
 
@@ -43,7 +43,7 @@ These run each test in its own transaction, the recommended way to test.
   
   RSpec.configure do |c|
     c.around(:each) do |example|
-      DB.transaction(:rollback=>:always, :auto_savepoint=>true){example.run}
+      DB.transaction(rollback: :always, auto_savepoint: true){example.run}
     end
   end
 
@@ -51,11 +51,11 @@ These run each test in its own transaction, the recommended way to test.
 
 You can use the Sequel.transaction method to run a transaction on multiple databases, rolling all of them back.  Instead of:
 
-  DB.transaction(:rollback=>:always)
+  DB.transaction(rollback: :always)
 
 Use Sequel.transaction with an array of databases:
 
-  Sequel.transaction([DB1, DB2, DB3], :rollback=>:always)
+  Sequel.transaction([DB1, DB2, DB3], rollback: :always)
 
 == Transactional testing with savepoints
 
@@ -71,11 +71,11 @@ Example:
   require 'minitest/hooks/default'
   class Minitest::HooksSpec
     def around
-      DB.transaction(:rollback=>:always, :savepoint=>true, :auto_savepoint=>true){super}
+      DB.transaction(rollback: :always, savepoint: true, auto_savepoint: true){super}
     end
 
     def around_all
-      DB.transaction(:rollback=>:always){super}
+      DB.transaction(rollback: :always){super}
     end
   end
 

--- a/doc/transactions.rdoc
+++ b/doc/transactions.rdoc
@@ -127,28 +127,28 @@ Other exceptions, unless rescued inside the outer transaction block, will rollba
   end # ROLLBACK
   # ArgumentError raised
 
-If you want the current savepoint to be rolled back when the savepoint block exits instead of being committed (even if an exception is not raised), use <tt>Database#rollback_on_exit(:savepoint=>true)</tt>
+If you want the current savepoint to be rolled back when the savepoint block exits instead of being committed (even if an exception is not raised), use <tt>Database#rollback_on_exit(savepoint: true)</tt>
 
   DB.transaction do # BEGIN
     DB.transaction(savepoint: true) do # SAVEPOINT
-      DB.rollback_on_exit(:savepoint=>true)
+      DB.rollback_on_exit(savepoint: true)
     end # ROLLBACK TO SAVEPOINT
   end # COMMIT
 
   DB.transaction do # BEGIN
     DB.transaction(savepoint: true) do # SAVEPOINT
       DB.transaction(savepoint: true) do # SAVEPOINT
-        DB.rollback_on_exit(:savepoint=>true)
+        DB.rollback_on_exit(savepoint: true)
       end # ROLLBACK TO SAVEPOINT
     end # RELEASE SAVEPOINT
   end # COMMIT
 
-If you want the current savepoint and potentially enclosing savepoints to be rolled back when the savepoint blocks exit  (even if an exception is not raised), use <tt>Database#rollback_on_exit(:savepoint=>integer)</tt>
+If you want the current savepoint and potentially enclosing savepoints to be rolled back when the savepoint blocks exit  (even if an exception is not raised), use <tt>Database#rollback_on_exit(savepoint: integer)</tt>
 
   DB.transaction do # BEGIN
     DB.transaction(savepoint: true) do # SAVEPOINT
       DB.transaction(savepoint: true) do # SAVEPOINT
-        DB.rollback_on_exit(:savepoint=>2)
+        DB.rollback_on_exit(savepoint: 2)
       end # ROLLBACK TO SAVEPOINT
     end # ROLLBACK TO SAVEPOINT
   end # COMMIT
@@ -156,7 +156,7 @@ If you want the current savepoint and potentially enclosing savepoints to be rol
   DB.transaction do # BEGIN
     DB.transaction(savepoint: true) do # SAVEPOINT
       DB.transaction(savepoint: true) do # SAVEPOINT
-        DB.rollback_on_exit(:savepoint=>3)
+        DB.rollback_on_exit(savepoint: 3)
       end # ROLLBACK TO SAVEPOINT
     end # ROLLBACK TO SAVEPOINT
   end # ROLLBACK

--- a/lib/sequel/adapters/shared/access.rb
+++ b/lib/sequel/adapters/shared/access.rb
@@ -17,7 +17,7 @@ module Sequel
 
       # Doesn't work, due to security restrictions on MSysObjects
       #def tables
-      #  from(:MSysObjects).where(:Type=>1, :Flags=>0).select_map(:Name).map(&:to_sym)
+      #  from(:MSysObjects).where(Type: 1, Flags: 0).select_map(:Name).map(&:to_sym)
       #end
       
       # Access doesn't support renaming tables from an SQL query,

--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -668,7 +668,7 @@ module Sequel
       # 
       #   DB.refresh_view(:items_view)
       #   # REFRESH MATERIALIZED VIEW items_view
-      #   DB.refresh_view(:items_view, :concurrently=>true)
+      #   DB.refresh_view(:items_view, concurrently: true)
       #   # REFRESH MATERIALIZED VIEW CONCURRENTLY items_view
       def refresh_view(name, opts=OPTS)
         run "REFRESH MATERIALIZED VIEW#{' CONCURRENTLY' if opts[:concurrently]} #{quote_schema_table(name)}"

--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -576,7 +576,7 @@ module Sequel
     #   # SELECT * FROM table ORDER BY id LIMIT 1000 OFFSET 1000
     #   # ...
     #
-    #   DB[:table].order(:id).paged_each(:rows_per_fetch=>100){|row| }
+    #   DB[:table].order(:id).paged_each(rows_per_fetch: 100){|row| }
     #   # SELECT * FROM table ORDER BY id LIMIT 100
     #   # SELECT * FROM table ORDER BY id LIMIT 100 OFFSET 100
     #   # ...

--- a/lib/sequel/dataset/query.rb
+++ b/lib/sequel/dataset/query.rb
@@ -65,7 +65,7 @@ module Sequel
       Sequel.synchronize{EXTENSIONS[ext] = block}
     end
 
-    # On Ruby 2.4+, use clone(:freeze=>false) to create clones, because
+    # On Ruby 2.4+, use clone(freeze: false) to create clones, because
     # we use true freezing in that case, and we need to modify the opts
     # in the frozen copy.
     #
@@ -787,7 +787,7 @@ module Sequel
     #   DB[:items].order(Sequel.lit('a + b')) # SELECT * FROM items ORDER BY a + b
     #   DB[:items].order(Sequel[:a] + :b) # SELECT * FROM items ORDER BY (a + b)
     #   DB[:items].order(Sequel.desc(:name)) # SELECT * FROM items ORDER BY name DESC
-    #   DB[:items].order(Sequel.asc(:name, :nulls=>:last)) # SELECT * FROM items ORDER BY name ASC NULLS LAST
+    #   DB[:items].order(Sequel.asc(:name, nulls: :last)) # SELECT * FROM items ORDER BY name ASC NULLS LAST
     #   DB[:items].order{sum(name).desc} # SELECT * FROM items ORDER BY sum(name) DESC
     #   DB[:items].order(nil) # SELECT * FROM items
     def order(*columns, &block)
@@ -857,13 +857,13 @@ module Sequel
     #   DB[:items].returning(nil) # RETURNING NULL
     #   DB[:items].returning(:id, :name) # RETURNING id, name
     #
-    #   DB[:items].returning.insert(:a=>1) do |hash|
+    #   DB[:items].returning.insert(a: 1) do |hash|
     #     # hash for each row inserted, with values for all columns
     #   end
-    #   DB[:items].returning.update(:a=>1) do |hash|
+    #   DB[:items].returning.update(a: 1) do |hash|
     #     # hash for each row updated, with values for all columns
     #   end
-    #   DB[:items].returning.delete(:a=>1) do |hash|
+    #   DB[:items].returning.delete(a: 1) do |hash|
     #     # hash for each row deleted, with values for all columns
     #   end
     def returning(*values)
@@ -1102,7 +1102,7 @@ module Sequel
     # referenced in window functions. See Sequel::SQL::Window for a list of
     # options that can be passed in. Example:
     #
-    #   DB[:items].window(:w, :partition=>:c1, :order=>:c2)
+    #   DB[:items].window(:w, partition: :c1, order: :c2)
     #   # SELECT * FROM items WINDOW w AS (PARTITION BY c1 ORDER BY c2)
     def window(name, opts)
       clone(:window=>((@opts[:window]||EMPTY_ARRAY) + [[name, SQL::Window.new(opts)].freeze]).freeze)
@@ -1163,7 +1163,7 @@ module Sequel
     #   DB[:t].with_recursive(:t,
     #     DB[:i1].select(:id, :parent_id).where(parent_id: nil),
     #     DB[:i1].join(:t, id: :parent_id).select(Sequel[:i1][:id], Sequel[:i1][:parent_id]),
-    #     :args=>[:id, :parent_id])
+    #     args: [:id, :parent_id])
     #   
     #   # WITH RECURSIVE t(id, parent_id) AS (
     #   #   SELECT id, parent_id FROM i1 WHERE (parent_id IS NULL)
@@ -1241,7 +1241,7 @@ module Sequel
     #
     # You can also provide a method name and arguments to call to get the SQL:
     #
-    #   DB[:items].with_sql(:insert_sql, :b=>1) # INSERT INTO items (b) VALUES (1)
+    #   DB[:items].with_sql(:insert_sql, b: 1) # INSERT INTO items (b) VALUES (1)
     #
     # Note that datasets that specify custom SQL using this method will generally
     # ignore future dataset methods that modify the SQL used, as specifying custom SQL

--- a/lib/sequel/extensions/async_thread_pool.rb
+++ b/lib/sequel/extensions/async_thread_pool.rb
@@ -5,9 +5,9 @@
 # code
 #
 #   DB.extension :async_thread_pool
-#   foos = DB[:foos].async.where{:name=>'A'..'M'}.all
+#   foos = DB[:foos].async.where{name: 'A'..'M'}.all
 #   bar_names = DB[:bar].async.select_order_map(:name)
-#   baz_1 = DB[:bazes].async.first(:id=>1)
+#   baz_1 = DB[:bazes].async.first(id: 1)
 #
 # All 3 queries will be run in separate threads.  +foos+, +bar_names+
 # and +baz_1+ will be proxy objects.  Calling a method on the proxy
@@ -15,9 +15,9 @@
 # of calling that method on the result of the query method. For example,
 # if you run:
 #
-#   foos = DB[:foos].async.where{:name=>'A'..'M'}.all
+#   foos = DB[:foos].async.where{name: 'A'..'M'}.all
 #   bar_names = DB[:bars].async.select_order_map(:name)
-#   baz_1 = DB[:bazes].async.first(:id=>1)
+#   baz_1 = DB[:bazes].async.first(id: 1)
 #   sleep(1)
 #   foos.size
 #   bar_names.first
@@ -26,9 +26,9 @@
 # These three queries will generally be run concurrently in separate
 # threads.  If you instead run:
 #   
-#   DB[:foos].async.where{:name=>'A'..'M'}.all.size
+#   DB[:foos].async.where{name: 'A'..'M'}.all.size
 #   DB[:bars].async.select_order_map(:name).first
-#   DB[:bazes].async.first(:id=>1).name
+#   DB[:bazes].async.first(id: 1).name
 #
 # Then will run each query sequentially, since you need the result of
 # one query before running the next query.  The queries will still be
@@ -37,11 +37,11 @@
 # What is run in the separate thread is the entire method call that
 # returns results.  So with the original example:
 #
-#   foos = DB[:foos].async.where{:name=>'A'..'M'}.all
+#   foos = DB[:foos].async.where{name: 'A'..'M'}.all
 #   bar_names = DB[:bars].async.select_order_map(:name)
-#   baz_1 = DB[:bazes].async.first(:id=>1)
+#   baz_1 = DB[:bazes].async.first(id: 1)
 #
-# The +all+, <tt>select_order_map(:name)</tt>, and <tt>first(:id=>1)</tt>
+# The +all+, <tt>select_order_map(:name)</tt>, and <tt>first(id: 1)</tt>
 # calls are run in separate threads.  If a block is passed to a method
 # such as +all+ or +each+, the block is also run in that thread.  If you
 # have code such as:
@@ -156,10 +156,10 @@
 # so that the query will run in the current thread instead of waiting
 # for an async thread to become available.  With the following code:
 #
-#   foos = DB[:foos].async.where{:name=>'A'..'M'}.all
+#   foos = DB[:foos].async.where{name: 'A'..'M'}.all
 #   bar_names = DB[:bar].async.select_order_map(:name)
 #   if foos.length > 4
-#     baz_1 = DB[:bazes].async.first(:id=>1)
+#     baz_1 = DB[:bazes].async.first(id: 1)
 #   end
 # 
 # Whether you need the +baz_1+ variable depends on the value of foos.

--- a/lib/sequel/extensions/auto_literal_strings.rb
+++ b/lib/sequel/extensions/auto_literal_strings.rb
@@ -22,7 +22,7 @@
 #
 # Named placeholders can also be used with a hash:
 #
-#   ds.where("name > :a", :a=>"A")
+#   ds.where("name > :a", a: "A")
 #   # SELECT * FROM table WHERE (name > 'A')
 #
 # This extension also allows the use of a plain string passed to Dataset#update:

--- a/lib/sequel/extensions/constraint_validations.rb
+++ b/lib/sequel/extensions/constraint_validations.rb
@@ -126,7 +126,7 @@
 #   be emulated by dropping the table and recreating it with the constraints.
 #   If you want to use this plugin on SQLite with an alter_table block,
 #   you should drop all constraint validation metadata using
-#   <tt>drop_constraint_validations_for(:table=>'table')</tt>, and then
+#   <tt>drop_constraint_validations_for(table: 'table')</tt>, and then
 #   readd all constraints you want to use inside the alter table block,
 #   making no other changes inside the alter_table block.
 #

--- a/lib/sequel/extensions/date_arithmetic.rb
+++ b/lib/sequel/extensions/date_arithmetic.rb
@@ -25,7 +25,7 @@
 # By default, values are casted to the generic timestamp type for the
 # database.  You can override the cast type using the :cast option:
 #
-#   add = Sequel.date_add(:date_column, {years: 1, months: 2, days: 3}, :cast=>:timestamptz)
+#   add = Sequel.date_add(:date_column, {years: 1, months: 2, days: 3}, cast: :timestamptz)
 #
 # These expressions can be used in your datasets, or anywhere else that
 # Sequel expressions are allowed:

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -1141,7 +1141,7 @@ module Sequel
       #
       #   Artist[1] === Artist[1] # => true
       #   Artist.new === Artist.new # => false
-      #   Artist[1].set(:name=>'Bob') === Artist[1] # => true
+      #   Artist[1].set(name: 'Bob') === Artist[1] # => true
       def ===(obj)
         case pkv = pk
         when nil
@@ -1160,7 +1160,7 @@ module Sequel
       #
       #   Artist[1].pk_equal?(Artist[1]) # => true
       #   Artist.new.pk_equal?(Artist.new) # => false
-      #   Artist[1].set(:name=>'Bob').pk_equal?(Artist[1]) # => true
+      #   Artist[1].set(name: 'Bob').pk_equal?(Artist[1]) # => true
       alias pk_equal? ===
 
       # class is defined in Object, but it is also a keyword,
@@ -1232,7 +1232,7 @@ module Sequel
       #
       #   Artist[1] == Artist[1] # => true
       #   Artist.new == Artist.new # => true
-      #   Artist[1].set(:name=>'Bob') == Artist[1] # => false
+      #   Artist[1].set(name: 'Bob') == Artist[1] # => false
       def eql?(obj)
         (obj.class == model) && (obj.values == @values)
       end
@@ -1334,13 +1334,13 @@ module Sequel
       #   a = Artist[1]
       #   Artist.db.transaction do
       #     a.lock!
-      #     a.update(:name=>'A')
+      #     a.update(name: 'A')
       #   end
       #
       #   a = Artist[2]
       #   Artist.db.transaction do
       #     a.lock!('FOR NO KEY UPDATE')
-      #     a.update(:name=>'B')
+      #     a.update(name: 'B')
       #   end
       def lock!(style=:update)
         _refresh(this.lock_style(style)) unless new?

--- a/lib/sequel/plugins/class_table_inheritance.rb
+++ b/lib/sequel/plugins/class_table_inheritance.rb
@@ -104,7 +104,7 @@ module Sequel
     # should reference the subquery alias (and qualified identifiers should not be needed
     # unless joining to another table):
     #
-    #   a = Executive.where(:id=>1).first # works
+    #   a = Executive.where(id: 1).first # works
     #   a = Executive.where{{employees[:id]=>1}}.first # works
     #   a = Executive.where{{executives[:id]=>1}}.first # doesn't work
     #
@@ -115,7 +115,7 @@ module Sequel
     #
     #   pks = Executive.where{num_staff < 10}.select_map(:id)
     #   Executive.cti_tables.reverse_each do |table|
-    #     DB.from(table).where(:id=>pks).delete
+    #     DB.from(table).where(id: pks).delete
     #   end
     #
     # = Usage

--- a/lib/sequel/plugins/composition.rb
+++ b/lib/sequel/plugins/composition.rb
@@ -39,8 +39,8 @@ module Sequel
     # also be implemented as:
     #
     #   Album.composition :date,
-    #     :composer=>proc{Date.new(year, month, day) if year || month || day},
-    #     :decomposer=>(proc do
+    #     composer: proc{Date.new(year, month, day) if year || month || day},
+    #     decomposer: (proc do
     #       if d = compositions[:date]
     #         self.year = d.year
     #         self.month = d.month

--- a/lib/sequel/plugins/concurrent_eager_loading.rb
+++ b/lib/sequel/plugins/concurrent_eager_loading.rb
@@ -50,10 +50,10 @@ module Sequel
     # support concurrent eager loading.  Taking this example from the
     # {Advanced Associations guide}[rdoc-ref:doc/advanced_associations.rdoc]
     #
-    #   Album.many_to_one :artist, :eager_loader=>(proc do |eo_opts|
+    #   Album.many_to_one :artist, eager_loader: (proc do |eo_opts|
     #     eo_opts[:rows].each{|album| album.associations[:artist] = nil}
     #     id_map = eo_opts[:id_map]
-    #     Artist.where(:id=>id_map.keys).all do |artist|
+    #     Artist.where(id: id_map.keys).all do |artist|
     #       if albums = id_map[artist.id]
     #         albums.each do |album|
     #           album.associations[:artist] = artist
@@ -74,12 +74,12 @@ module Sequel
     # the code that loads the objects, since that will prevent concurrent loading.
     # So after the changes, the custom eager loader would look like this:
     #
-    #   Album.many_to_one :artist, :eager_loader=>(proc do |eo_opts|
+    #   Album.many_to_one :artist, eager_loader: (proc do |eo_opts|
     #     Sequel.synchronize_with(eo[:mutex]) do
     #       eo_opts[:rows].each{|album| album.associations[:artist] = nil}
     #     end
     #     id_map = eo_opts[:id_map]
-    #     rows = Artist.where(:id=>id_map.keys).all
+    #     rows = Artist.where(id: id_map.keys).all
     #     Sequel.synchronize_with(eo[:mutex]) do
     #       rows.each do |artist|
     #         if albums = id_map[artist.id]

--- a/lib/sequel/plugins/dirty.rb
+++ b/lib/sequel/plugins/dirty.rb
@@ -37,7 +37,7 @@ module Sequel
     #
     # It also saves the previously changed values after an update:
     #
-    #   artist.update(:name=>'Bar')
+    #   artist.update(name: 'Bar')
     #   artist.column_changes        # => {}
     #   artist.previous_changes      # => {:name=>['Foo', 'Bar']}
     #

--- a/lib/sequel/plugins/nested_attributes.rb
+++ b/lib/sequel/plugins/nested_attributes.rb
@@ -33,7 +33,7 @@ module Sequel
     # objects.  You just need to make sure that the primary key field is filled in for the
     # associated object:
     #
-    #   a.update(:albums_attributes => [{id: 1, name: 'T'}])
+    #   a.update(albums_attributes: [{id: 1, name: 'T'}])
     #
     # Since the primary key field is filled in, the plugin will update the album with id 1 instead
     # of creating a new album.
@@ -42,14 +42,14 @@ module Sequel
     # entry to the hash, and also pass the :destroy option when calling +nested_attributes+:
     #
     #   Artist.nested_attributes :albums, destroy: true
-    #   a.update(:albums_attributes => [{id: 1, _delete: true}])
+    #   a.update(albums_attributes: [{id: 1, _delete: true}])
     #
     # This will delete the related associated object from the database.  If you want to leave the
     # associated object in the database, but just remove it from the association, add a _remove
     # entry in the hash, and also pass the :remove option when calling +nested_attributes+:
     #
     #   Artist.nested_attributes :albums, remove: true
-    #   a.update(:albums_attributes => [{id: 1, _remove: true}])
+    #   a.update(albums_attributes: [{id: 1, _remove: true}])
     #
     # The above example was for a one_to_many association, but the plugin also works similarly
     # for other association types.  For one_to_one and many_to_one associations, you need to
@@ -84,7 +84,7 @@ module Sequel
     # nested attributes options for that association.  This is useful for per-call filtering
     # of the allowed fields:
     #
-    #   a.set_nested_attributes(:albums, params['artist'], :fields=>%w'name')
+    #   a.set_nested_attributes(:albums, params['artist'], fields: %w'name')
     module NestedAttributes
       # Depend on the validate_associated plugin.
       def self.apply(model)

--- a/lib/sequel/plugins/pg_auto_constraint_validations.rb
+++ b/lib/sequel/plugins/pg_auto_constraint_validations.rb
@@ -32,7 +32,7 @@ module Sequel
     #
     # Example:
     #
-    #   album = Album.new(:artist_id=>1) # Assume no such artist exists
+    #   album = Album.new(artist_id: 1) # Assume no such artist exists
     #   begin
     #     album.save
     #   rescue Sequel::ValidationFailed

--- a/lib/sequel/plugins/sql_comments.rb
+++ b/lib/sequel/plugins/sql_comments.rb
@@ -12,7 +12,7 @@ module Sequel
     #   # SELECT * FROM albums WHERE (id = 1) LIMIT 1
     #   # -- model:Album,method_type:class,method:[]
     #
-    #   album.update(:name=>'A')
+    #   album.update(name: 'A')
     #   # UPDATE albums SET name = 'baz' WHERE (id = 1)
     #   # -- model:Album,method_type:instance,method:update
     #


### PR DESCRIPTION
Most of the Sequel docs already use the modern Hash syntax, so this PR tries to convert all the remaining places.