### PR TITLE
Improve error message when migrator is not current

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -377,7 +377,7 @@ module Sequel
     # Raise a NotCurrentError unless the migrator is current, takes the same
     # arguments as #run.
     def self.check_current(*args)
-      raise(NotCurrentError, 'migrator is not current') unless is_current?(*args)
+      raise(NotCurrentError, 'current migration version does not match latest available version') unless is_current?(*args)
     end
 
     # Return whether the migrator is current (i.e. it does not need to make


### PR DESCRIPTION
Given that `Sequel::Migrator::NotCurrentError` exception class name already contains the information "migrator is not current", we could use the exception message to provide more details, so that it's clearer to the developer what the error means (if they don't know about checking of current migration).
