### PR TITLE
Add advice for making migrations work with code reloading

### DIFF
--- a/doc/migration.rdoc
+++ b/doc/migration.rdoc
@@ -643,3 +643,11 @@ If you need to use database extensions in migrations (e.g. +:pg_enum+), you shou
       # migration here
     end
   end
+
+== Code Reloading
+
+When using code reloading in development, you need to make sure that Sequel models are reloaded when new migrations are applied, so that they pick up schema changes such as newly added or removed columns. One way you could do that is ensure schema is dumped when running the migrations, and trigger a reload when the schema file has changed.
+
+You'll also want to configure Sequel models to reload the schema cache when they're re-defined, to ensure current schema is picked up:
+
+  Sequel::Model.cache_associations = false if ENV["RACK_ENV"] == "development"


### PR DESCRIPTION
When I was setting up a Roda & Sequel application with Zeitwerk, I was pondering on how to solve syncing models after running migrations in development. One idea was to disable schema caching globally altogether in development, at the cost of more verbose SQL logs and performance. Another idea was to somehow clear the schema cache when model classes are unloaded, but I couldn't find any public methods that do that.

It's only when I looked at the roda-sequel-stack project that I discovered the `cache_associations` config, which the docs say is recommended to disable when using code reloading. It's perfect, because it doesn't require hooking into code reloading. And reading the Rails source code gave me the idea to trigger the reload when the schema file changes.

Since it took me a while to arrive to these strategies, I thought it would be useful to include them in the migration guide. For those curious, this is how I implemented it in my project (the Listen gem doesn't support listening on individual files, so it listens on the whole `db/` directory):

```rb
# config/loader.rb
loader = Zeitwerk::Loader.new
loader.enable_reloading if ENV["RACK_ENV"] == "development"
# ...

if ENV["RACK_ENV"] == "development"
  listener = Listen.to("app", "db") { loader.reload }
  listener.start
end
```
```rb
# config/initializers/sequel.rb
# ...
Sequel::Model.cache_associations = false if ENV["RACK_ENV"] == "development"
```
