### PR TITLE
Add sequel_tools gem to list of external extensions

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -1050,6 +1050,10 @@
 <span class="ul__span">A Sequel extension to make seeds/fixtures manageable like migrations.</span>
 </li>
 <li class="ul__li ul__li--grid">
+<a class="a" href="https://github.com/rosenfeld/sequel_tools">sequel_tools </a>
+<span class="ul__span">Tools to help with managing database operations with Sequel through Rake tasks.</span>
+</li>
+<li class="ul__li ul__li--grid">
 <a class="a" href="http://github.com/jsvd/sequel_vectorized">sequel_vectorized </a>
 <span class="ul__span">Allows Sequel::Dataset to be exported as an Hash of Arrays and NArrays.</span>
 </li>


### PR DESCRIPTION
I found it really convenient for quickly setting up Rake tasks for managing the database, similar to what Active Record provides. I was even thinking of mentioning it in the migration guide, but I didn't see official guides mentioning any 3rd-party gems, so I assumed it was a convention.
