### PR TITLE
Recommend disabling association reflection cache when using code reloading

### DIFF
--- a/doc/association_basics.rdoc
+++ b/doc/association_basics.rdoc
@@ -342,6 +342,12 @@ instance method:
   @album.artists # [<Artist ...>, ...]
   @album.associations[:artists] # [<Artist ...>, ...]
 
+=== Code Reloading
+
+When declaring associations, Sequel caches association metadata in the association reflection. If you're doing any code reloading that doesn't involve restarting the related process, you should disable caching of the association reflection, to avoid stale model classes still being referenced after reloading:
+
+  Sequel::Model.cache_associations = false
+
 == Dataset Method
 
 In addition to the above methods, associations also add an instance method


### PR DESCRIPTION
*Follow-up to https://github.com/jeremyevans/sequel/pull/1951*

When using a code reloader that only reloads model classes that changed, the association reflection cache should be disabled, to avoid stale model classes still being referenced after they were reloaded.

This is not needed when using code reloaders like Zeitwerk, which always reload all the code regardless of which file changed, which includes all model classes. It's still recommended if you're reloading models after running schema migrations, as it causes the table schema cache to be automatically reloaded when the model is reloaded.
