### PR TITLE
Allow tactical eager loading in combination with class table inheritance

### DIFF
--- a/lib/sequel/model/associations.rb
+++ b/lib/sequel/model/associations.rb
@@ -3552,11 +3552,11 @@ module Sequel
         end
 
         # Eagerly load all specified associations.
-        def eager_load(a, eager_assoc=@opts[:eager])
+        def eager_load(a, m=model, eager_assoc=@opts[:eager])
           return if a.empty?
 
           # Reflections for all associations to eager load
-          reflections = eager_assoc.keys.map{|assoc| model.association_reflection(assoc) || (raise Sequel::UndefinedAssociation, "Model: #{self}, Association: #{assoc}")}
+          reflections = eager_assoc.keys.map{|assoc| m.association_reflection(assoc) || (raise Sequel::UndefinedAssociation, "Model: #{self}, Association: #{assoc}")}
 
           perform_eager_loads(prepare_eager_load(a, reflections, eager_assoc))
 

--- a/lib/sequel/model/associations.rb
+++ b/lib/sequel/model/associations.rb
@@ -3552,7 +3552,7 @@ module Sequel
         end
 
         # Eagerly load all specified associations.
-        def eager_load(a, m=model, eager_assoc=@opts[:eager])
+        def eager_load(a, eager_assoc=@opts[:eager], m=model)
           return if a.empty?
 
           # Reflections for all associations to eager load

--- a/lib/sequel/plugins/eager_graph_eager.rb
+++ b/lib/sequel/plugins/eager_graph_eager.rb
@@ -127,7 +127,7 @@ module Sequel
                 current.uniq!(&:object_id)
               end
 
-              last_class.dataset.send(:eager_load, current, model, assocs)
+              last_class.dataset.send(:eager_load, current, assocs)
             end
           end
 

--- a/lib/sequel/plugins/eager_graph_eager.rb
+++ b/lib/sequel/plugins/eager_graph_eager.rb
@@ -127,7 +127,7 @@ module Sequel
                 current.uniq!(&:object_id)
               end
 
-              last_class.dataset.send(:eager_load, current, assocs)
+              last_class.dataset.send(:eager_load, current, model, assocs)
             end
           end
 

--- a/lib/sequel/plugins/tactical_eager_loading.rb
+++ b/lib/sequel/plugins/tactical_eager_loading.rb
@@ -158,7 +158,7 @@ module Sequel
                 retrieved_with.reject{|x| x.frozen? || x.associations.include?(name)}
               end
             objects = objects.select { |x| x.is_a?(model) }
-            retrieved_by.send(:eager_load, objects, model, name=>dynamic_opts[:eager] || OPTS)
+            retrieved_by.send(:eager_load, objects, {name=>dynamic_opts[:eager] || OPTS}, model)
           end
           super
         end

--- a/lib/sequel/plugins/tactical_eager_loading.rb
+++ b/lib/sequel/plugins/tactical_eager_loading.rb
@@ -152,20 +152,13 @@ module Sequel
           name = opts[:name]
           eager_reload = dynamic_opts[:eager_reload]
           if (!associations.include?(name) || eager_reload) && opts[:allow_eager] != false && retrieved_by && !frozen? && !dynamic_opts[:callback] && !dynamic_opts[:reload]
-            begin
               objects = if eager_reload
                 retrieved_with.reject(&:frozen?)
               else
                 retrieved_with.reject{|x| x.frozen? || x.associations.include?(name)}
               end
-              retrieved_by.send(:eager_load, objects, name=>dynamic_opts[:eager] || OPTS)
-            rescue Sequel::UndefinedAssociation
-              # This can happen if class table inheritance is used and the association
-              # is only defined in a subclass.  This particular instance can use the
-              # association, but it can't be eagerly loaded as the parent class doesn't
-              # have access to the association, and that's the class doing the eager loading.
-              nil
-            end
+            objects = objects.select { |x| x.is_a?(model) }
+            retrieved_by.send(:eager_load, objects, model, name=>dynamic_opts[:eager] || OPTS)
           end
           super
         end

--- a/spec/extensions/tactical_eager_loading_spec.rb
+++ b/spec/extensions/tactical_eager_loading_spec.rb
@@ -130,7 +130,7 @@ describe "tactical_eager_loading plugin" do
     c = Class.new(@c)
     c.many_to_one :parent2, :class=>@c, :key=>:parent_id
     @c.dataset.with_row_proc(proc{|r| (r[:parent_id] == 101 ? c : @c).call(r)}).all{|x| x.parent2 if x.is_a?(c)}
-    sql_match('SELECT * FROM t', 'SELECT * FROM t WHERE id = 101')
+    sql_match('SELECT * FROM t', 'SELECT * FROM t WHERE (t.id IN (101))')
   end
 
   it "association getter methods should not eagerly load the association if an instance is frozen" do


### PR DESCRIPTION
Class table inheritance doesn't work in combination with tactical eager loading. There are no errors, but eager loading just isn't happening. I know this is intentional, but it makes it very difficult to manage performance when rendering a list of objects that use CTI if they make use of any association of the child classes.

This is a draft fix which seems to work nicely with our application. I'm opening this pull request to get your opinion. Is this on the right track? If so we'd be happy to polish and/or add more test cases.

The idea is that the `eager_load` method uses a concrete subclass rather than the parent model when performing eager loading. The tactical eager loading plugin takes care of passing in only the objects that are instances of the model on which the association was first used. This would always be a model that has access to this association.

I guess in theory it could still lead to some mild inefficiencies with very large hierarchies of inheritance. But that seems better than the status quo.