### PR TITLE
Support enum value as array

### DIFF
--- a/lib/sequel/plugins/enum.rb
+++ b/lib/sequel/plugins/enum.rb
@@ -34,6 +34,14 @@ module Sequel
     # Album.dataset.bad:: Return a dataset filtered to rows where +status_id+ is +2+
     # Album.dataset.not_bad:: Return a dataset filtered to rows where +status_id+ is not +2+
     #
+    # The enum value can also be an array, for example:
+    #
+    #   Album.enum :status_id, good: [1, 2], bad: 3
+    #
+    # Note that it will prioritize the first value on the assign method <tt>:status_id=</tt>
+    #
+    #   album.status_id = :good # 1
+    #
     # When calling +enum+, you can also provide the following options:
     #
     # :prefix :: Use a prefix for methods defined for each enum value. If +true+ is provided at the value, use the column name as the prefix.
@@ -98,12 +106,20 @@ module Sequel
 
             values.each do |key, value|
               define_method(:"#{prefix}#{key}#{suffix}!") do
-                self[column] = value
+                if value.is_a?(Array)
+                  self[column] = value.first
+                else
+                  self[column] = value
+                end
                 nil
               end
 
               define_method(:"#{prefix}#{key}#{suffix}?") do
-                self[column] == value
+                if value.is_a?(Array)
+                  value.include?(self[column])
+                else
+                  self[column] == value
+                end
               end
             end
           end

--- a/lib/sequel/plugins/enum.rb
+++ b/lib/sequel/plugins/enum.rb
@@ -100,7 +100,10 @@ module Sequel
               end
 
               define_method(:"#{column}=") do |v|
-                super(values.fetch(v, v))
+                enum_v = values.fetch(v, v)
+
+                assign_v = enum_v.is_a?(Array) ? enum_v.first : enum_v
+                super(assign_v)
               end
             end
 

--- a/spec/extensions/enum_spec.rb
+++ b/spec/extensions/enum_spec.rb
@@ -71,6 +71,23 @@ describe "Sequel enum plugin" do
     @album = @Album.load(:status_id=>3)
   end
 
+  it "should handle value as an array" do
+    @Album.enum :status_id, {:good=>[3, nil], :bad=>5}
+    @album.good?.must_equal true
+    @album.bad?.must_equal false
+
+    @album.status_id = nil
+    @album.good?.must_equal true
+    @album.bad?.must_equal false
+
+    @album.status_id = :good
+    @album[:status_id].must_equal 3
+
+    ds = @Album.where(:id=>1)
+    ds.good.sql.must_equal "SELECT * FROM albums WHERE ((id = 1) AND (status_id IN (3, NULL)))"
+    ds.bad.sql.must_equal "SELECT * FROM albums WHERE ((id = 1) AND (status_id = 5))"
+  end
+
   it "should allow overriding methods in class and calling super" do
     @Album.enum :status_id, {:good=>3, :bad=>5}, :override_accessors=>false
     bad = nil


### PR DESCRIPTION
The existing enum plugin uses primitive values such as string or integer.
This PR enhances it by supporting array type to the enum values.

Background: on a large dataset of table X, I am working on schema migration, then data migration for column Y
Schema migration can be done easily, but data migration is not that quick. Y is currently nil.

To support multi values enum for my half-migrated case, I need to define the enum value as an array, obviously [1, nil] for column Y. Surprisingly, I can use an array for the value, the dataset method for query `:enum` work well
>#<Sequel::Postgres::Dataset: "SELECT * FROM \"X\" WHERE (\"Y\" IN (1, NULL))">

But other methods eg. instance enum assignment could not work as expected, that's why I make this PR.