### PR TITLE
fix empty? for datasets containing null

### DIFF
--- a/lib/sequel/dataset/actions.rb
+++ b/lib/sequel/dataset/actions.rb
@@ -173,9 +173,9 @@ module Sequel
     #   DB[:table].empty? # SELECT 1 AS one FROM table LIMIT 1
     #   # => false
     def empty?
-      cached_dataset(:_empty_ds) do
+      with_sql_first((cached_dataset(:_empty_ds) do
         single_value_ds.unordered.select(EMPTY_SELECT)
-      end.single_value!.nil?
+      end).select_sql).nil?
     end
 
     # Returns the first matching record if no arguments are given.

--- a/spec/core/dataset_spec.rb
+++ b/spec/core/dataset_spec.rb
@@ -2279,6 +2279,14 @@ describe "Dataset#empty?" do
     db.sqls.must_equal ["SELECT 1 AS one FROM test WHERE 'f' LIMIT 1"]
   end
 
+  it "should return false if dataset contains record with null field" do
+    db = Sequel.mock(:fetch=>proc{|sql| {1=>nil} unless sql =~ /WHERE 'f'/})
+    db.from(:test).wont_be :empty?
+    db.sqls.must_equal ['SELECT 1 AS one FROM test LIMIT 1']
+    db.from(:test).filter(false).must_be :empty?
+    db.sqls.must_equal ["SELECT 1 AS one FROM test WHERE 'f' LIMIT 1"]
+  end
+
   it "should ignore order" do
     db = Sequel.mock(:fetch=>proc{|sql| {1=>1}})
     db.from(:test).wont_be :empty?


### PR DESCRIPTION
`#empty?` was not returning `false` for some non-empty datasets.

```ruby
irb(main):001:0> require "sequel"
=> true
irb(main):002:0> DB = Sequel.sqlite
=> #<Sequel::SQLite::Database: {:adapter=>:sqlite}>
irb(main):003:0> DB["select null"].empty?
=> true
irb(main):004:0> DB["values (null, 1), (2, 3)"].empty?
=> true
irb(main):005:0> DB.values([[nil, 1], [2, 3]]).empty?
=> true
irb(main):006:0> 
```