### PR TITLE
fix typo in test doc_string

### DIFF
--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -728,7 +728,7 @@ describe "A PostgreSQL database" do
     proc{@db.values([])}.must_raise(Sequel::Error)
   end
 
-  it "#empty? should return true for datasets using VALUES" do
+  it "#empty? should return false for datasets using VALUES" do
     @db.values([[nil]]).empty?.must_equal false
   end
 

--- a/spec/adapters/sqlite_spec.rb
+++ b/spec/adapters/sqlite_spec.rb
@@ -197,7 +197,7 @@ describe "SQLite VALUES support" do
     proc{@db.values([])}.must_raise(Sequel::Error)
   end
 
-  it "#empty? should return true for datasets using VALUES" do
+  it "#empty? should return false for datasets using VALUES" do
     @db.values([[nil]]).empty?.must_equal false
   end
 


### PR DESCRIPTION
Just fixing typos for some of a638268ce08892cd06d7b858a2b9770f0ed2e183's new test [doc_string](https://rspec.info/documentation/3.12/rspec-core/RSpec/Core/ExampleGroup.html#it-class_method)s.

This PR does not include logic changes. In particular, it does not fix [the regression](https://github.com/jeremyevans/sequel/pull/1990#issuecomment-1416648145).