### PR TITLE
alias key? has_key?

### DIFF
--- a/lib/sequel/extensions/pg_json_ops.rb
+++ b/lib/sequel/extensions/pg_json_ops.rb
@@ -421,6 +421,7 @@ module Sequel
         bool_op(HAS_KEY, key)
       end
       alias include? has_key?
+      alias key? has_key?
 
       # Inserts the given jsonb value at the given path in the receiver.
       # The default is to insert the value before the given path, but


### PR DESCRIPTION
`Hash#key?` and `Hash#has_key?` are aliases of each other in Ruby. This would bring pg_json_ops in line with similar aliases.

Additionally, Rubocop has Style/PreferredHashMethods which prefers `key?` over `has_key?` by default. Of course rubocop does not know which objects are Hashes and which are pg json op, it registers offenses when using `has_key?` on pg json op objects.

This would be a small QOL improvement for users of rubocop, and all accustomed to `key?` over `has_key?`