### PR TITLE
Add bigdecimal as an explicit dependency

### DIFF
--- a/sequel.gemspec
+++ b/sequel.gemspec
@@ -23,6 +23,7 @@ SEQUEL_GEMSPEC = Gem::Specification.new do |s|
   s.require_path = "lib"
   s.bindir = 'bin'
   s.executables << 'sequel'
+  s.add_dependency "bigdecimal"
   s.add_development_dependency "minitest", '>=5.7.0'
   s.add_development_dependency "minitest-hooks"
   s.add_development_dependency "minitest-global_expectations"


### PR DESCRIPTION
While sequel always requires bigdecimal, it's not listed as a dependency. It's possible to have a Ruby installation without bigdecimal (on EL8 / Fedora: `dnf install ruby --setopt=install_weak_deps=False`) and this helps. While Fedora already explicitly adds it as a dependency, listing it in the gemspec allows the dependency generator to pick it up automatically.