### PR TITLE
Replace gsub with tr on_delete_clause method

### DIFF
--- a/lib/sequel/database/schema_methods.rb
+++ b/lib/sequel/database/schema_methods.rb
@@ -900,7 +900,7 @@ module Sequel
     #
     # Any other object given is just converted to a string, with "_" converted to " " and upcased.
     def on_delete_clause(action)
-      action.to_s.gsub("_", " ").upcase
+      action.to_s.tr("_", " ").upcase
     end
 
     # Alias of #on_delete_clause, since the two usually behave the same.


### PR DESCRIPTION
As per https://github.com/fastruby/fast-ruby/blob/main/code/string/gsub-vs-tr.rb `tr` is faster than `gsub` for simple replacements that do not require regexp