### PR TITLE
Fix referencing Trilogy error class when disconnecting

### DIFF
--- a/lib/sequel/adapters/trilogy.rb
+++ b/lib/sequel/adapters/trilogy.rb
@@ -24,7 +24,7 @@ module Sequel
 
       def disconnect_connection(c)
         c.discard!
-      rescue Trilogy::Error
+      rescue ::Trilogy::Error
         nil
       end
 


### PR DESCRIPTION
I was looking at this commit in order to add support for the Trilogy adapter in sequel-activerecord_connection, when I noticed this and thought I'd send a pull request. It's very nice this will be supported :metal:
