### PR TITLE
Expose the model class inside the dataset module

### DIFF
--- a/lib/sequel/model/dataset_module.rb
+++ b/lib/sequel/model/dataset_module.rb
@@ -8,6 +8,9 @@ module Sequel
     # automatically creates class methods for public dataset
     # methods.
     class DatasetModule < Dataset::DatasetModule
+      # The model class related to this dataset module.
+      attr_reader :model
+
       # Store the model related to this dataset module.
       def initialize(model)
         @model = model

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -180,7 +180,11 @@ describe Sequel::Model, ".dataset_module" do
   before do
     @c = Class.new(Sequel::Model(:items))
   end
-  
+ 
+  it "should expose the model class on the dataset module" do
+    @c.dataset_module.model.must_equal @c
+  end
+
   it "should extend the dataset with the module if the model has a dataset" do
     @c.dataset_module{def return_3() 3 end}
     @c.dataset.return_3.must_equal 3


### PR DESCRIPTION
One reason you might want this is to qualify the columns in your method. For example, `where :kept, Sequel[model.table_name][:discarded_at] => nil`

See discussion https://github.com/jeremyevans/sequel/discussions/2038. I'm not sure the test is up to standards, I struggled at first so happy for any feedback/adjustments needed.