### PR TITLE
Sharding docs: Cleary state that :read_only is a special key

### DIFF
--- a/doc/sharding.rdoc
+++ b/doc/sharding.rdoc
@@ -39,7 +39,9 @@ is the simplest configuration:
     servers: {read_only: {host: 'replica_server'}})
 
 This will use the replica_server for SELECT queries and primary_server for
-other queries.
+other queries. Note that `:read_only` is a special key. Using any other key
+will result in the main database connection being used for all queries, unless
+one or more of the methods described below are used to switch to another connection.
 
 If you want to ensure your queries are going to a specific database, you
 can force this for a given query by using the .server method and passing 


### PR DESCRIPTION
One of my senior teammates is not convinced from the documentation that `:read_only` is a special key that induces a certain automatic behavior with how read vs write queries are handled.

After I read the docs again, I was not sure anymore either. It seems implied, but never clearly stated.

This PR adds additional description that is to my best understanding. 

Please update or correct as needed. I feel that some additional clarification here could definitely help Sequel users