### PR TITLE
Prevent connection pool starvation.

### DIFF
--- a/lib/sequel/connection_pool/threaded.rb
+++ b/lib/sequel/connection_pool/threaded.rb
@@ -274,6 +274,12 @@ class Sequel::ThreadedConnectionPool < Sequel::ConnectionPool
     end
 
     @waiter.signal
+    
+    # Ensure that after signalling the condition, some other thread is given the
+    # opportunity to acquire the mutex.
+    # See <https://github.com/socketry/async/issues/99> for more context.
+    sleep(0)
+    
     nil
   end
 


### PR DESCRIPTION
See <https://github.com/socketry/async/issues/99> for context/background.

This should be a temporary fix, we need to (1) establish whether there is a bug in CRuby or (2) establish whether there is faulty usage of condition variable in the connection pool. I don't know which yet.

The code related to this investigation is <https://github.com/ioquatix/ruby-condition-variable-timeout>.