### PR TITLE
raise error when connection_validator is loaded in single threaded mode

### DIFF
--- a/lib/sequel/extensions/connection_validator.rb
+++ b/lib/sequel/extensions/connection_validator.rb
@@ -61,6 +61,10 @@ module Sequel
 
     # Initialize the data structures used by this extension.
     def self.extended(pool)
+      unless pool.pool_type == :threaded || pool.pool_type == :sharded_threaded
+        raise Error, "can only load connection_validator extension if using threaded or sharded_threaded connection pool"
+      end
+
       pool.instance_exec do
         sync do
           @connection_timestamps ||= {}
@@ -120,4 +124,3 @@ module Sequel
 
   Database.register_extension(:connection_validator){|db| db.pool.extend(ConnectionValidator)}
 end
-

--- a/spec/extensions/connection_validator_spec.rb
+++ b/spec/extensions/connection_validator_spec.rb
@@ -130,6 +130,12 @@ connection_validator_specs = Module.new do
   end
 end
 
+describe "Sequel::ConnectionValidator with single threaded pool" do
+  it "should raise an error if trying to load the connection_validator extension into a single connection pool" do
+    db = Sequel.mock(:test=>false, :single_threaded=>true)
+    proc{db.extension(:connection_validator)}.must_raise Sequel::Error
+  end
+end
 describe "Sequel::ConnectionValidator with threaded pool" do
   def db
     Sequel.mock(:test=>false)


### PR DESCRIPTION
While, as per the discussion in #2042 , `sequel` is doing what is supposed to as per what's documentedd, the error is still cryptic and not obvious when one falls in the trap.

This patch adds a more helpful error message, which is aligned with other similar messages for other extensions which aren't supported in single threaded mode as well.