### PR TITLE
support ILIKE ANY in Postgres, similar to LIKE ANY

### DIFF
--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1745,10 +1745,6 @@ module Sequel
           literal_append(sql, args[0])
           sql << ' ' << op.to_s << ' '
           literal_append(sql, args[1])
-          if requires_like_escape?
-            sql << " ESCAPE "
-            literal_append(sql, "\\")
-          end
           sql << ')'
         else
           super

--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1745,8 +1745,10 @@ module Sequel
           literal_append(sql, args[0])
           sql << ' ' << op.to_s << ' '
           literal_append(sql, args[1])
-          sql << " ESCAPE "
-          literal_append(sql, "\\")
+          if requires_like_escape?
+            sql << " ESCAPE "
+            literal_append(sql, "\\")
+          end
           sql << ')'
         else
           super

--- a/lib/sequel/dataset/sql.rb
+++ b/lib/sequel/dataset/sql.rb
@@ -392,10 +392,6 @@ module Sequel
         literal_append(sql, args[0])
         sql << ' ' << op.to_s << ' '
         literal_append(sql, args[1])
-        if requires_like_escape?
-          sql << " ESCAPE "
-          literal_append(sql, "\\")
-        end
         sql << ')'
       when :ILIKE, :'NOT ILIKE'
         complex_expression_sql_append(sql, (op == :ILIKE ? :LIKE : :"NOT LIKE"), args.map{|v| Sequel.function(:UPPER, v)})

--- a/lib/sequel/dataset/sql.rb
+++ b/lib/sequel/dataset/sql.rb
@@ -391,6 +391,10 @@ module Sequel
         sql << '('
         literal_append(sql, args[0])
         sql << ' ' << op.to_s << ' '
+        if requires_like_escape?
+          sql << " ESCAPE "
+          literal_append(sql, "\\")
+        end
         literal_append(sql, args[1])
         sql << ')'
       when :ILIKE, :'NOT ILIKE'

--- a/lib/sequel/dataset/sql.rb
+++ b/lib/sequel/dataset/sql.rb
@@ -391,11 +391,11 @@ module Sequel
         sql << '('
         literal_append(sql, args[0])
         sql << ' ' << op.to_s << ' '
+        literal_append(sql, args[1])
         if requires_like_escape?
           sql << " ESCAPE "
           literal_append(sql, "\\")
         end
-        literal_append(sql, args[1])
         sql << ')'
       when :ILIKE, :'NOT ILIKE'
         complex_expression_sql_append(sql, (op == :ILIKE ? :LIKE : :"NOT LIKE"), args.map{|v| Sequel.function(:UPPER, v)})


### PR DESCRIPTION
this PR applies the same change from 9e9a5d7eadfba6f549eb7adbd6000a4fbf6ff3fc to Postgres-specific `ILIKE` code, with the same intention: to support use cases like `ILIKE ANY`.

since the feature method is hard-coded to `true`, checking its value is not actually necessary, but implementing the change this way means that this code looks just like the other code in `lib/sequel/dataset/sql.rb` which it is emulating.

that code is here:

https://github.com/jeremyevans/sequel/blob/c280ff50517e7a8dccc5e3a56ba2e316c4379b91/lib/sequel/dataset/sql.rb#L395

apologies for the lack of tests. the contributing guidelines say they're needed for any "substantial bug fixes," and this is just a two-line fix. but I can take a second to write some tests up, if needed.

thanks!