### PR TITLE
Use deep copy when returning default value

### DIFF
--- a/lib/sequel/plugins/defaults_setter.rb
+++ b/lib/sequel/plugins/defaults_setter.rb
@@ -118,6 +118,7 @@ module Sequel
           if new? && !values.has_key?(k)
             v = model.default_values.fetch(k){return}
             v = v.call if v.respond_to?(:call)
+            v = Marshal.load(Marshal.dump(v))
             values[k] = v if model.cache_default_values?
             v
           else

--- a/spec/extensions/defaults_setter_spec.rb
+++ b/spec/extensions/defaults_setter_spec.rb
@@ -162,4 +162,12 @@ describe "Sequel::Plugins::DefaultsSetter" do
     c.freeze
     c.default_values.frozen?.must_equal true
   end
+
+  it "should work correctly for complex data types" do
+    @c.dataset = @pr.call([[]]).dataset
+    instance_1 = @c.new
+    instance_1.a.first << 1
+    instance_2 = @c.new
+    instance_2.a.must_equal [[]]
+  end
 end


### PR DESCRIPTION
Previously, default values were returned as a shallow copy, which works fine for most of the cases. However if the returned object is a complex object such as Hash or Array, which can be representation of PostgreSQL's JSONB column for example, shallow copy is not enough. If caller updates the returned object, default value also gets overwritten, thus all subsequent calls use the updated value.

Marshal.dump & Marshal.load is used to generate a deep copy of the object, which might be an overkill, but this seems like a most reliable way of creating a deep copy.