### PR TITLE
Pass class name to Sequel::MassAssignmentRestriction error

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -2035,20 +2035,15 @@ module Sequel
           if meths.include?(m)
             set_column_value(m, v)
           elsif strict
-            err_msg = -> (msg) do
-              msg += " for class #{self.class.name}" if self.class.name
-              msg
-            end
-
             # Avoid using respond_to? or creating symbols from user input
             if public_methods.map(&:to_s).include?(m)
               if Array(model.primary_key).map(&:to_s).member?(k.to_s) && model.restrict_primary_key?
-                raise MassAssignmentRestriction, err_msg.call("#{k} is a restricted primary key")
+                raise MassAssignmentRestriction.new("#{k} is a restricted primary key", self)
               else
-                raise MassAssignmentRestriction, err_msg.call("#{k} is a restricted column")
+                raise MassAssignmentRestriction.new("#{k} is a restricted column", self)
               end
             else
-              raise MassAssignmentRestriction, err_msg.call("method #{m} doesn't exist")
+              raise MassAssignmentRestriction.new("method #{m} doesn't exist", self)
             end
           end
         end

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -2035,15 +2035,20 @@ module Sequel
           if meths.include?(m)
             set_column_value(m, v)
           elsif strict
+            err_msg = -> (msg) do
+              msg += " for class #{self.class.name}" if self.class.name
+              msg
+            end
+
             # Avoid using respond_to? or creating symbols from user input
             if public_methods.map(&:to_s).include?(m)
               if Array(model.primary_key).map(&:to_s).member?(k.to_s) && model.restrict_primary_key?
-                raise MassAssignmentRestriction, "#{k} is a restricted primary key"
+                raise MassAssignmentRestriction, err_msg.call("#{k} is a restricted primary key")
               else
-                raise MassAssignmentRestriction, "#{k} is a restricted column"
+                raise MassAssignmentRestriction, err_msg.call("#{k} is a restricted column")
               end
             else
-              raise MassAssignmentRestriction, "method #{m} doesn't exist"
+              raise MassAssignmentRestriction, err_msg.call("method #{m} doesn't exist")
             end
           end
         end

--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -2038,12 +2038,12 @@ module Sequel
             # Avoid using respond_to? or creating symbols from user input
             if public_methods.map(&:to_s).include?(m)
               if Array(model.primary_key).map(&:to_s).member?(k.to_s) && model.restrict_primary_key?
-                raise MassAssignmentRestriction.new("#{k} is a restricted primary key", self)
+                raise MassAssignmentRestriction.create("#{k} is a restricted primary key", self)
               else
-                raise MassAssignmentRestriction.new("#{k} is a restricted column", self)
+                raise MassAssignmentRestriction.create("#{k} is a restricted column", self)
               end
             else
-              raise MassAssignmentRestriction.new("method #{m} doesn't exist", self)
+              raise MassAssignmentRestriction.create("method #{m} doesn't exist", self)
             end
           end
         end

--- a/lib/sequel/model/exceptions.rb
+++ b/lib/sequel/model/exceptions.rb
@@ -31,9 +31,10 @@ module Sequel
     attr_reader :model
 
     def self.create(msg, model)
-      @model = model
       msg += " for class #{model.class.name}" if model.class.name
-      new(msg)
+      new(msg).tap do |err|
+        err.instance_variable_set(:@model, model)
+      end
     end
   end
   

--- a/lib/sequel/model/exceptions.rb
+++ b/lib/sequel/model/exceptions.rb
@@ -24,11 +24,18 @@ module Sequel
   UndefinedAssociation = Class.new(Error)
   ).name
 
-  (
   # Raised when a mass assignment method is called in strict mode with either a restricted column
   # or a column without a setter method.
-  MassAssignmentRestriction = Class.new(Error)
-  ).name
+  class MassAssignmentRestriction < Error
+    # The Sequel::Model object related to this exception.
+    attr_reader :model
+
+    def initialize(msg, model)
+      @model = model
+      msg += " for class #{model.class.name}" if model.class.name
+      super(msg)
+    end
+  end
   
   # Exception class raised when +raise_on_save_failure+ is set and validation fails
   class ValidationFailed < Error

--- a/lib/sequel/model/exceptions.rb
+++ b/lib/sequel/model/exceptions.rb
@@ -30,10 +30,10 @@ module Sequel
     # The Sequel::Model object related to this exception.
     attr_reader :model
 
-    def initialize(msg, model)
+    def self.create(msg, model)
       @model = model
       msg += " for class #{model.class.name}" if model.class.name
-      super(msg)
+      new(msg)
     end
   end
   

--- a/spec/extensions/csv_serializer_spec.rb
+++ b/spec/extensions/csv_serializer_spec.rb
@@ -163,7 +163,8 @@ describe "Sequel::Plugins::CsvSerializer" do
 
   it "should raise an error if attempting to set a restricted column and :all_columns is not used" do
     @Artist.restrict_primary_key
-    proc{@Artist.from_csv(@artist.to_csv)}.must_raise(Sequel::MassAssignmentRestriction)
+    err = proc{@Artist.from_csv(@artist.to_csv)}.must_raise(Sequel::MassAssignmentRestriction)
+    err.message.must_equal("id is a restricted primary key for class Artist")
   end
 
   it "should use a dataset's selected columns" do

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -683,6 +683,7 @@ describe Sequel::Model, ".strict_param_setting" do
 
     err = proc{item.new(:a=>1)}.must_raise(Sequel::MassAssignmentRestriction)
     err.message.must_equal("method a= doesn't exist for class Item")
+    err.model.class.must_equal(item)
   end
 
   it "should be disabled by strict_param_setting = false" do

--- a/spec/model/base_spec.rb
+++ b/spec/model/base_spec.rb
@@ -664,11 +664,25 @@ describe Sequel::Model, ".strict_param_setting" do
   end
 
   it "should raise an error if a missing/restricted column/method is accessed" do
-    proc{@c.new(:a=>1)}.must_raise(Sequel::MassAssignmentRestriction)
+    err = proc{@c.new(:a=>1)}.must_raise(Sequel::MassAssignmentRestriction)
+    err.message.must_equal("method a= doesn't exist")
     proc{@c.create(:a=>1)}.must_raise(Sequel::MassAssignmentRestriction)
     c = @c.new
     proc{c.set(:a=>1)}.must_raise(Sequel::MassAssignmentRestriction)
     proc{c.update(:a=>1)}.must_raise(Sequel::MassAssignmentRestriction)
+  end
+
+  it "should add class name to error message" do
+    item = Class.new(Sequel::Model(:items)) do
+      columns :id
+    end
+
+    item.class_eval do
+      def self.name; 'Item' end
+    end
+
+    err = proc{item.new(:a=>1)}.must_raise(Sequel::MassAssignmentRestriction)
+    err.message.must_equal("method a= doesn't exist for class Item")
   end
 
   it "should be disabled by strict_param_setting = false" do

--- a/spec/model/exceptions_spec.rb
+++ b/spec/model/exceptions_spec.rb
@@ -1,0 +1,15 @@
+require_relative "spec_helper"
+
+describe Sequel::MassAssignmentRestriction, "#create"  do
+  it "should set model attr" do
+    model_cls = Class.new
+    model_cls.class_eval do
+      def self.name; 'TestModel' end
+    end
+
+    model = model_cls.new
+    err = Sequel::MassAssignmentRestriction.create("method foo doesn't exist", model)
+    err.message.must_equal("method foo doesn't exist for class TestModel")
+    err.model.must_equal(model)
+  end
+end


### PR DESCRIPTION
If the instance has a class name, pass this name to the error message to better understand the error in monitoring systems such as Sentry.