### PR TITLE
Added run_single method to run single migration by version and direction

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -831,16 +831,5 @@ module Sequel
       end
       ds
     end
-
-    # An array of numbers corresponding to the migrations
-    def version_numbers
-      @version_numbers ||= begin
-        versions = files.
-          compact.
-          map{|f| migration_version_from_file(File.basename(f))}.
-          sort
-        versions
-      end
-    end
   end
 end

--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -697,7 +697,6 @@ module Sequel
     def initialize(db, directory, opts=OPTS)
       super
       @target = opts[:target]
-      @direction = opts[:direction]
       @applied_migrations = get_applied_migrations
       @migration_tuples = get_migration_tuples
     end

--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -730,7 +730,7 @@ module Sequel
     def run_single
       if version_numbers.include?(target)
         path = files.select{|f| f.match(target.to_s)}.first
-        file_name = File.basename(path).downcase
+        file_name = File.basename(path)
         migration = load_migration_file(path)
         m_direction = direction ? direction : :up
 

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -966,4 +966,15 @@ describe "Sequel::TimestampMigrator" do
     proc{Sequel::TimestampMigrator.run(@db, "spec/files/transaction_unspecified_migrations", :use_transactions=>false)}.must_raise Sequel::DatabaseError
     @db.sqls.must_equal ["SELECT NULL AS nil FROM schema_migrations LIMIT 1", "CREATE TABLE schema_migrations (filename varchar(255) PRIMARY KEY)"]
   end
+
+  it "should handle single migrating up or down to specific timestamps" do
+    @dir = 'spec/files/timestamped_migrations'
+    @m.apply(@db, @dir, 1273253851)
+
+    Sequel::TimestampMigrator.run_single(@db, @dir, target: 1273253849, direction: :down)
+    @db[:schema_migrations].select_order_map(:filename).must_equal %w'1273253851_create_nodes.rb'
+
+    Sequel::TimestampMigrator.run_single(@db, @dir, target: 1273253849, direction: :up)
+    @db[:schema_migrations].select_order_map(:filename).must_equal %w'1273253849_create_sessions.rb 1273253851_create_nodes.rb'
+  end
 end

--- a/spec/extensions/migration_spec.rb
+++ b/spec/extensions/migration_spec.rb
@@ -971,10 +971,12 @@ describe "Sequel::TimestampMigrator" do
     @dir = 'spec/files/timestamped_migrations'
     @m.apply(@db, @dir, 1273253851)
 
-    Sequel::TimestampMigrator.run_single(@db, @dir, target: 1273253849, direction: :down)
+    migration_path = 'spec/files/timestamped_migrations/1273253849_create_sessions.rb'
+
+    Sequel::TimestampMigrator.run_single(@db, migration_path, direction: :down)
     @db[:schema_migrations].select_order_map(:filename).must_equal %w'1273253851_create_nodes.rb'
 
-    Sequel::TimestampMigrator.run_single(@db, @dir, target: 1273253849, direction: :up)
+    Sequel::TimestampMigrator.run_single(@db, migration_path, direction: :up)
     @db[:schema_migrations].select_order_map(:filename).must_equal %w'1273253849_create_sessions.rb 1273253851_create_nodes.rb'
   end
 end


### PR DESCRIPTION
The new method was added only for TimestampMigrator because I'm not sure that this is the correct way to do it.

Reference: https://github.com/jeremyevans/sequel/discussions/2045