### PR TITLE
Add support for hostaddr param in postgres

### DIFF
--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -348,7 +348,8 @@ The following additional options are supported:
                 <tt>Sequel.postgres(search_path: ['schema1', 'schema2'])</tt>).
 :use_iso_date_format :: This can be set to false to not force the ISO date format.  Sequel forces
                         it by default to allow for an optimization.
-
+:hostaddr :: Numeric IP address of host to connect to. Only supported with pg library.
+             See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-HOSTADDR
 === sqlanywhere
 
 The sqlanywhere driver works off connection strings, so a connection string

--- a/lib/sequel/adapters/postgres.rb
+++ b/lib/sequel/adapters/postgres.rb
@@ -223,7 +223,8 @@ module Sequel
             :password => opts[:password],
             :connect_timeout => opts[:connect_timeout] || 20,
             :sslmode => opts[:sslmode],
-            :sslrootcert => opts[:sslrootcert]
+            :sslrootcert => opts[:sslrootcert],
+            :hostaddr => opts[:hostaddr]
           }.delete_if { |key, value| blank_object?(value) }
           # :nocov:
           connection_params.merge!(opts[:driver_options]) if opts[:driver_options]


### PR DESCRIPTION
This is useful for when you want to tell your connection specifically which host IP to connect to but still optionally use hostname for authentication with tls.

Supported in pg gem since 1.4.0 and postgres since version 12. I'm not sure if we need to codify those constraints?