### PR TITLE
Update rcte plugin to allow the user to specify union_all in rcte

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 === master
 
+* Support generating rcte queries using UNION or UNION ALL in the rcte plugin (jonathanfrias)
+
 * Make Database#table_exists? on PostgreSQL handle lock or statement timeout errors as evidence the table exists (jeremyevans) (#2106)
 
 * Work around DateTime.jd fractional second bug on JRuby in named_timezones extension (jeremyevans)


### PR DESCRIPTION
Support UNION style recursive common table expressions to remove duplicates by exposing a passthrough option :union_all