### PR TITLE
Improve performance of regexp matching in the sqlite adapter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@
 
 * Add auto_cast_date_and_time extension, for casting date and time values using SQL standard functions (jeremyevans)
 
-* Cache regexp objects in the sqlite adapter to improve performance (paddor)
+* Improve performance and flexibility of regexp matching in sqlite adapter (paddor)
 
 === 5.75.0 (2023-12-01)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,8 @@
 
 * Add auto_cast_date_and_time extension, for casting date and time values using SQL standard functions (jeremyevans)
 
+* Cache regexp objects in the sqlite adapter to improve performance (paddor)
+
 === 5.75.0 (2023-12-01)
 
 * Make any_not_empty? extension support passing pattern argument to any? (jeremyevans) (#2100)

--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -388,8 +388,8 @@ The following additional options are supported:
 :readonly :: open database in read-only mode
 :timeout :: the busy timeout to use in milliseconds (default: 5000).
 :setup_regexp_function :: Whether to setup a REGEXP function in the underlying SQLite3::Database object. Doing so
-                          allows you to use regexp support in dataset expressions.  Note that this caches each
-                          unique regex in the database instance.
+                          allows you to use regexp support in dataset expressions.  If ':cached', caches each
+                          unique regex (risk of memory leak).
 
 Note that SQLite memory databases are restricted to a single connection by
 default.  This is because SQLite does not allow multiple connections to

--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -388,8 +388,8 @@ The following additional options are supported:
 :readonly :: open database in read-only mode
 :timeout :: the busy timeout to use in milliseconds (default: 5000).
 :setup_regexp_function :: Whether to setup a REGEXP function in the underlying SQLite3::Database object. Doing so
-                          allows you to use regexp support in dataset expressions.  Note that this creates a new
-                          Regexp object per call to the function, so it is not an efficient implementation.
+                          allows you to use regexp support in dataset expressions.  Note that this caches each
+                          unique regex in the database instance.
 
 Note that SQLite memory databases are restricted to a single connection by
 default.  This is because SQLite does not allow multiple connections to

--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -389,7 +389,9 @@ The following additional options are supported:
 :timeout :: the busy timeout to use in milliseconds (default: 5000).
 :setup_regexp_function :: Whether to setup a REGEXP function in the underlying SQLite3::Database object. Doing so
                           allows you to use regexp support in dataset expressions.  If ':cached', caches each
-                          unique regex (risk of memory leak).
+                          unique regex (more efficient but risk of memory leak). If a Proc like 
+                          +proc{|regex_str,str| ...}+ is provided, it is used to determine whether the string
+                          in question matches.
 
 Note that SQLite memory databases are restricted to a single connection by
 default.  This is because SQLite does not allow multiple connections to

--- a/lib/sequel/adapters/sqlite.rb
+++ b/lib/sequel/adapters/sqlite.rb
@@ -111,6 +111,8 @@ module Sequel
       #              static data that you do not want to modify
       # :timeout :: how long to wait for the database to be available if it
       #             is locked, given in milliseconds (default is 5000)
+      # :setup_regexp_function :: enable use of Regexp objects with SQL
+      #             'REGEXP' operator (with regexp cache if ':cached')
       def connect(server)
         opts = server_opts(server)
         opts[:database] = ':memory:' if blank_object?(opts[:database])
@@ -126,10 +128,7 @@ module Sequel
         connection_pragmas.each{|s| log_connection_yield(s, db){db.execute_batch(s)}}
 
         if typecast_value_boolean(opts[:setup_regexp_function])
-          @regexp_cache = Hash.new{|h,k| h[k] = Regexp.new(k)}
-          db.create_function("regexp", 2) do |func, regexp_str, string|
-            func.result = @regexp_cache[regexp_str].match(string) ? 1 : 0
-          end
+          setup_regexp_function(db, opts[:setup_regexp_function])
         end
         
         class << db
@@ -202,6 +201,18 @@ module Sequel
         @conversion_procs = SQLITE_TYPES.dup
         @conversion_procs['datetime'] = @conversion_procs['timestamp'] = method(:to_application_timestamp)
         set_integer_booleans
+      end
+
+      def setup_regexp_function(db, how)
+        case how
+        when :cached
+          cache = Hash.new{|h,k| h[k] = Regexp.new(k)}
+          cb = proc { |func, regexp_str, str| func.result = cache[regexp_str].match(str) ? 1 : 0 }
+        else
+          cb = proc { |func, regexp_str, str| func.result = Regexp.new(regexp_str).match(str) ? 1 : 0 }
+        end
+
+        db.create_function("regexp", 2, &cb)
       end
       
       # Yield an available connection.  Rescue

--- a/lib/sequel/adapters/sqlite.rb
+++ b/lib/sequel/adapters/sqlite.rb
@@ -126,8 +126,9 @@ module Sequel
         connection_pragmas.each{|s| log_connection_yield(s, db){db.execute_batch(s)}}
 
         if typecast_value_boolean(opts[:setup_regexp_function])
+          @regexp_cache = Hash.new{|h,k| h[k] = Regexp.new(k)}
           db.create_function("regexp", 2) do |func, regexp_str, string|
-            func.result = Regexp.new(regexp_str).match(string) ? 1 : 0
+            func.result = @regexp_cache[regexp_str].match(string) ? 1 : 0
           end
         end
         


### PR DESCRIPTION
Nothing much, just what the title says. Theoretically, if an infinite amount of different regexp are used in SQL queries, it could of course fill up RAM, but I think that's uncommon.

In my case, this brought the runtime from ~300ms down to ~70ms for a query that uses one single regexp in a table with around ~5700 rows.