### PR TITLE
[CI] Add Ruby 3.3 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ "1.9.3", "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, jruby-9.2, jruby-9.3, jruby-9.4, truffleruby-head ]
+        ruby: [ "1.9.3", "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, 3.3, jruby-9.2, jruby-9.3, jruby-9.4, truffleruby-head ]
     name: ${{ matrix.ruby }}
     env:
       BUNDLE_GEMFILE: .ci.gemfile
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: sudo apt-get -yqq install libpq-dev libmysqlclient-dev
     - run: sudo apt-get -yqq install libxml2-dev libxslt-dev
       if: startsWith(matrix.ruby, 'truffleruby')


### PR DESCRIPTION
Ruby 3.3 is out; see https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

It also has been added to GitHub Actions: https://github.com/ruby/setup-ruby/releases/tag/v1.163.0




-- thanks for maintaining this open source project! 🙇 