### PR TITLE
Use empty? instead of count for validate uniqueness

### DIFF
--- a/lib/sequel/plugins/validation_helpers.rb
+++ b/lib/sequel/plugins/validation_helpers.rb
@@ -295,7 +295,7 @@ module Sequel
               h = ds.joined_dataset? ? qualified_pk_hash : pk_hash
               ds = ds.exclude(h)
             end
-            errors.add(a, message) unless ds.count == 0
+            errors.add(a, message) unless ds.empty?
           end
         end
         

--- a/spec/extensions/validation_helpers_spec.rb
+++ b/spec/extensions/validation_helpers_spec.rb
@@ -395,9 +395,9 @@ describe "Sequel::Plugins::ValidationHelpers" do
     @c.set_validations{validates_unique(:username, :only_if_modified=>false)}
     @c.dataset = @c.dataset.with_fetch(proc do |sql|
       case sql
-      when /count.*username = '0records'/
-        {:v => 0}
-      when /count.*username = '1record'/
+      when /1 AS one.*username = '0records'/
+        {:v => nil}
+      when /1 AS one.*username = '1record'/
         {:v => 1}
       end
     end)
@@ -421,10 +421,10 @@ describe "Sequel::Plugins::ValidationHelpers" do
 
     @user = @c.load(:id=>1, :username => "0records", :password => "anothertest")
     @user.must_be :valid?
-    DB.sqls.last.must_equal "SELECT count(*) AS count FROM items WHERE ((username = '0records') AND (id != 1)) LIMIT 1"
+    DB.sqls.last.must_equal "SELECT 1 AS one FROM items WHERE ((username = '0records') AND (id != 1)) LIMIT 1"
     @user = @c.new(:username => "0records", :password => "anothertest")
     @user.must_be :valid?
-    DB.sqls.last.must_equal "SELECT count(*) AS count FROM items WHERE (username = '0records') LIMIT 1"
+    DB.sqls.last.must_equal "SELECT 1 AS one FROM items WHERE (username = '0records') LIMIT 1"
   end
   
   it "should support validates_unique with multiple attributes" do
@@ -433,9 +433,9 @@ describe "Sequel::Plugins::ValidationHelpers" do
     @c.set_validations{validates_unique([:username, :password], :only_if_modified=>false)}
     @c.dataset = @c.dataset.with_fetch(proc do |sql|
       case sql
-      when /count.*username = '0records'/
-        {:v => 0}
-      when /count.*username = '1record'/
+      when /1 AS one.*username = '0records'/
+        {:v => nil}
+      when /1 AS one.*username = '1record'/
         {:v => 1}
       end
     end)
@@ -466,36 +466,36 @@ describe "Sequel::Plugins::ValidationHelpers" do
 
     @user = @c.load(:id=>1, :username => "0records", :password => "anothertest")
     @user.must_be :valid?
-    DB.sqls.last.must_equal "SELECT count(*) AS count FROM items WHERE ((username = '0records') AND (password = 'anothertest') AND (id != 1)) LIMIT 1"
+    DB.sqls.last.must_equal "SELECT 1 AS one FROM items WHERE ((username = '0records') AND (password = 'anothertest') AND (id != 1)) LIMIT 1"
     @user = @c.new(:username => "0records", :password => "anothertest")
     @user.must_be :valid?
-    DB.sqls.last.must_equal "SELECT count(*) AS count FROM items WHERE ((username = '0records') AND (password = 'anothertest')) LIMIT 1"
+    DB.sqls.last.must_equal "SELECT 1 AS one FROM items WHERE ((username = '0records') AND (password = 'anothertest')) LIMIT 1"
   end
 
   it "should support validates_unique with a block" do
     @c.columns(:id, :username, :password)
     @c.set_dataset DB[:items]
     @c.set_validations{validates_unique(:username, :only_if_modified=>false){|ds| ds.filter(:active)}}
-    @c.dataset = @c.dataset.with_fetch(:v=>0)
+    @c.dataset = @c.dataset.with_fetch(:v=>nil)
     
     DB.reset
     @c.new(:username => "0records", :password => "anothertest").must_be :valid?
     @c.load(:id=>3, :username => "0records", :password => "anothertest").must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items WHERE ((username = '0records') AND active) LIMIT 1",
-                    "SELECT count(*) AS count FROM items WHERE ((username = '0records') AND active AND (id != 3)) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items WHERE ((username = '0records') AND active) LIMIT 1",
+                    "SELECT 1 AS one FROM items WHERE ((username = '0records') AND active AND (id != 3)) LIMIT 1"]
   end
 
   it "should support validates_unique with :where option" do
     @c.columns(:id, :username, :password)
     @c.set_dataset DB[:items]
     @c.set_validations{validates_unique(:username, :only_if_modified=>false, :where=>proc{|ds, obj, cols| ds.where(cols.map{|c| [Sequel.function(:lower, c), obj.send(c).downcase]})})}
-    @c.dataset = @c.dataset.with_fetch(:v=>0)
-    
+    @c.dataset = @c.dataset.with_fetch(:v=>nil)
+      
     DB.reset
     @c.new(:username => "0RECORDS", :password => "anothertest").must_be :valid?
     @c.load(:id=>3, :username => "0RECORDS", :password => "anothertest").must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items WHERE (lower(username) = '0records') LIMIT 1",
-                    "SELECT count(*) AS count FROM items WHERE ((lower(username) = '0records') AND (id != 3)) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items WHERE (lower(username) = '0records') LIMIT 1",
+                    "SELECT 1 AS one FROM items WHERE ((lower(username) = '0records') AND (id != 3)) LIMIT 1"]
   end
 
   it "should support validates_unique with :dataset option" do
@@ -503,13 +503,13 @@ describe "Sequel::Plugins::ValidationHelpers" do
     @c.set_dataset DB[:items]
     c = @c
     @c.set_validations{validates_unique(:username, :only_if_modified=>false, :dataset=>c.where(:a=>[1,2,3]))}
-    @c.dataset = @c.dataset.with_fetch(:v=>0)
+    @c.dataset = @c.dataset.with_fetch(:v=>nil)
     
     DB.reset
     @c.new(:username => "0records", :password => "anothertest").must_be :valid?
     @c.load(:id=>3, :username => "0records", :password => "anothertest").must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items WHERE ((a IN (1, 2, 3)) AND (username = '0records')) LIMIT 1",
-                    "SELECT count(*) AS count FROM items WHERE ((a IN (1, 2, 3)) AND (username = '0records') AND (id != 3)) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items WHERE ((a IN (1, 2, 3)) AND (username = '0records')) LIMIT 1",
+                    "SELECT 1 AS one FROM items WHERE ((a IN (1, 2, 3)) AND (username = '0records') AND (id != 3)) LIMIT 1"]
   end
 
   it "should use qualified primary keys for validates_unique when the dataset is joined" do
@@ -517,24 +517,24 @@ describe "Sequel::Plugins::ValidationHelpers" do
     @c.set_dataset DB[:items]
     c = @c
     @c.set_validations{validates_unique(:username, :only_if_modified=>false, :dataset=>c.cross_join(:a))}
-    @c.dataset = @c.dataset.with_fetch(:v=>0)
+    @c.dataset = @c.dataset.with_fetch(:v=>nil)
     
     DB.reset
     @c.new(:username => "0records", :password => "anothertest").must_be :valid?
     @c.load(:id=>3, :username => "0records", :password => "anothertest").must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items CROSS JOIN a WHERE (username = '0records') LIMIT 1",
-                    "SELECT count(*) AS count FROM items CROSS JOIN a WHERE ((username = '0records') AND (items.id != 3)) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items CROSS JOIN a WHERE (username = '0records') LIMIT 1",
+                    "SELECT 1 AS one FROM items CROSS JOIN a WHERE ((username = '0records') AND (items.id != 3)) LIMIT 1"]
   end
 
   it "should not have validates_unique check uniqueness for existing records if values haven't changed" do
     @c.columns(:id, :username, :password)
     @c.set_dataset DB[:items]
     @c.set_validations{validates_unique([:username, :password])}
-    @c.dataset = @c.dataset.with_fetch(:v=>0)
+    @c.dataset = @c.dataset.with_fetch(:v=>nil)
     
     DB.reset
     @c.new(:username => "0records", :password => "anothertest").must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items WHERE ((username = '0records') AND (password = 'anothertest')) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items WHERE ((username = '0records') AND (password = 'anothertest')) LIMIT 1"]
     DB.reset
     m = @c.load(:id=>3, :username => "0records", :password => "anothertest")
     m.must_be :valid?
@@ -542,17 +542,17 @@ describe "Sequel::Plugins::ValidationHelpers" do
 
     m.username = '1'
     m.must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items WHERE ((username = '1') AND (password = 'anothertest') AND (id != 3)) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items WHERE ((username = '1') AND (password = 'anothertest') AND (id != 3)) LIMIT 1"]
 
     m = @c.load(:id=>3, :username => "0records", :password => "anothertest")
     DB.reset
     m.password = '1'
     m.must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items WHERE ((username = '0records') AND (password = '1') AND (id != 3)) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items WHERE ((username = '0records') AND (password = '1') AND (id != 3)) LIMIT 1"]
     DB.reset
     m.username = '2'
     m.must_be :valid?
-    DB.sqls.must_equal ["SELECT count(*) AS count FROM items WHERE ((username = '2') AND (password = '1') AND (id != 3)) LIMIT 1"]
+    DB.sqls.must_equal ["SELECT 1 AS one FROM items WHERE ((username = '2') AND (password = '1') AND (id != 3)) LIMIT 1"]
   end
 
   it "should not attempt a database query if the underlying columns have validation errors" do


### PR DESCRIPTION
Using `empty` provides a more efficient way to check for records that violate the uniqueness constraint. Unlike `count`, which counts all matching rows, `empty` stops as soon as it finds a match, thereby reducing the load on the database. This change is particularly beneficial for tables with a large number of rows, where performance can be an issue.