### PR TITLE
sqlite adapter - allow create_table with :without_rowid option

### DIFF
--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -145,6 +145,11 @@ module Sequel
         sqlite_version >= 30608
       end
 
+      # SQLite 3.8.2+ supports the without rowid table constraint
+      def support_without_rowid?
+        sqlite_version >= 30802
+      end
+
       # Override the default setting for whether to use timezones in timestamps.
       # It is set to +false+ by default, as SQLite's date/time methods do not
       # support timezones in timestamps.
@@ -344,9 +349,17 @@ module Sequel
         ps
       end
 
-      # Support creating STRICT tables via :strict option
+      # Support creating STRICT AND/OR WITHOUT ROWID tables via :strict and :without_rowid options
       def create_table_sql(name, generator, options)
-        "#{super}#{' STRICT' if options[:strict]}"
+        if options[:strict] && options[:without_rowid]
+          "#{super} STRICT, WITHOUT ROWID"
+        elsif options[:strict]
+          "#{super} STRICT"
+        elsif options[:without_rowid]
+          "#{super} WITHOUT ROWID"
+        else
+          super
+        end
       end
 
       # SQLite support creating temporary views.

--- a/lib/sequel/database/schema_methods.rb
+++ b/lib/sequel/database/schema_methods.rb
@@ -191,6 +191,12 @@ module Sequel
     #            The +any+ type is treated like a SQLite column in a non-strict table,
     #            allowing any type of data to be stored. This option is supported on
     #            SQLite 3.37.0+.
+    # :without_rowid :: Create a WITHOUT ROWID table. Every row in SQLite has a special
+    #                   'rowid' column, that uniquely identifies that row within the table.
+    #                   If this option is used, the 'rowid' column is omitted, which can
+    #                   sometimes provide some space and speed advantages. Note that you
+    #                   must then provide an explicit primary key when you create the table.
+    #                   This option is supported on SQLite 3.8.2+.
     #
     # See <tt>Schema::CreateTableGenerator</tt> and the {"Schema Modification" guide}[rdoc-ref:doc/schema_modification.rdoc].
     def create_table(name, options=OPTS, &block)


### PR DESCRIPTION
Proposal to add support for the sqlite `WITHOUT ROWID` table option in the sqlite adapter.