### PR TITLE
Declare csv dependency

### DIFF
--- a/sequel.gemspec
+++ b/sequel.gemspec
@@ -24,6 +24,7 @@ SEQUEL_GEMSPEC = Gem::Specification.new do |s|
   s.bindir = 'bin'
   s.executables << 'sequel'
   s.add_dependency "bigdecimal"
+  s.add_dependency "csv"
   s.add_development_dependency "minitest", '>=5.7.0'
   s.add_development_dependency "minitest-hooks"
   s.add_development_dependency "minitest-global_expectations"


### PR DESCRIPTION
## Problem

[Ruby 3.3 warns](https://github.com/jeremyevans/sequel/actions/runs/8273014466/job/22635954106):

```
/home/runner/work/sequel/sequel/spec/extensions/csv_serializer_spec.rb:3: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.
```

## Solution

Declare the CSV library as a dependency.