### PR TITLE
Make it possible to use create_or_replace_view with materialized view.

### DIFF
--- a/lib/sequel/database/schema_methods.rb
+++ b/lib/sequel/database/schema_methods.rb
@@ -252,10 +252,10 @@ module Sequel
     # For databases where replacing a view is not natively supported, support
     # is emulated by dropping a view with the same name before creating the view.
     def create_or_replace_view(name, source, options = OPTS)
-      if supports_create_or_replace_view?
+      if supports_create_or_replace_view? && !options[:materialized]
         options = options.merge(:replace=>true)
       else
-        swallow_database_error{drop_view(name)}
+        swallow_database_error{drop_view(name, options)}
       end
 
       create_view(name, source, options)

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -849,6 +849,15 @@ describe "PostgreSQL views" do
     @db.views(@opts).must_include :items_view
   end if DB.server_version >= 90300
 
+  it "should support replacing materialized views" do
+    @opts = {:materialized=>true}
+    @db[:items].insert(15)
+    @db.create_or_replace_view(:items_view, @db[:items].where{number > 10}, @opts)
+    @db[:items_view].select_order_map(:number).must_equal [15, 20]
+    @db.create_or_replace_view(:items_view, @db[:items].where{number > 15}, @opts)
+    @db[:items_view].select_order_map(:number).must_equal [20]
+  end if DB.server_version >= 90300
+
   it "should support refreshing materialized views concurrently" do
     @opts = {:materialized=>true}
     @db.create_view(:items_view, @db[:items].where{number >= 10}, @opts)


### PR DESCRIPTION
It's not possible to use CREATE OR REPLACE with materialized view in Postgres so we should fallback to `drop_view`/`create_view` calls when we use `create_or_replace_view` method with `:materialized` option.

Currently when `create_or_replace_view` is called you get

```
Sequel::DatabaseError: PG::SyntaxError: ERROR:  syntax error at or near "MATERIALIZED"
LINE 1: CREATE OR REPLACE MATERIALIZED VIEW "items_view" AS SELECT *...
```