### PR TITLE
Add string_agg support on sqlite >= 3.44

### DIFF
--- a/spec/extensions/string_agg_spec.rb
+++ b/spec/extensions/string_agg_spec.rb
@@ -17,6 +17,7 @@ describe "string_agg extension" do
     @sa3 = Sequel.string_agg(:c, '-').order(:o)
     @sa4 = Sequel.string_agg(:c).order(:o).distinct
     @sa5 = Sequel.string_agg(:c).distinct.order(:o)
+    @sa6 = Sequel.string_agg(:c, '-').distinct.order(:o)
   end
 
   it "should use existing method" do
@@ -37,6 +38,16 @@ describe "string_agg extension" do
     ds.literal(@sa3).must_equal "string_agg(c, '-' ORDER BY o)"
     ds.literal(@sa4).must_equal "string_agg(DISTINCT c, ',' ORDER BY o)"
     ds.literal(@sa5).must_equal "string_agg(DISTINCT c, ',' ORDER BY o)"
+  end
+
+  it "should correctly literalize on SQLite" do
+    ds = dbf.call(:sqlite).dataset.with_quote_identifiers(false)
+    ds.literal(@sa1).must_equal "group_concat(c, ',')"
+    ds.literal(@sa2).must_equal "group_concat(c, '-')"
+    ds.literal(@sa3).must_equal "group_concat(c, '-' ORDER BY o)"
+    ds.literal(@sa4).must_equal "group_concat(DISTINCT c ORDER BY o)"
+    ds.literal(@sa5).must_equal "group_concat(DISTINCT c ORDER BY o)"
+    proc{ds.literal(@sa6)}.must_raise Sequel::Error
   end
 
   it "should correctly literalize on SQLAnywhere" do

--- a/spec/integration/plugin_test.rb
+++ b/spec/integration/plugin_test.rb
@@ -2545,7 +2545,7 @@ describe "string_agg extension" do
     @db.drop_table?(:string_agg_test)
   end
 
-  cspecify "should have string_agg return aggregated concatenation", :mssql, :sqlite, :derby do
+  cspecify "should have string_agg return aggregated concatenation", :mssql, :derby do
     h = @ds.select_append(Sequel.string_agg(:s).as(:v)).to_hash(:id, :v)
     h[1].must_match(/\A[abc],[abc],[abc],[abc]\z/)
     h[2].must_match(/\A(aa|bb),(aa|bb)\z/)
@@ -2554,10 +2554,10 @@ describe "string_agg extension" do
     @ds.select_append(Sequel.string_agg(:s, '-').order(:o).as(:v)).map([:id, :v]).must_equal [[1, 'a-a-c-b'], [2, 'bb-aa']]
   end
 
-  cspecify "should have string_agg return aggregated concatenation for distinct values", :mssql, :sqlite, :oracle, :db2, :derby do
+  cspecify "should have string_agg return aggregated concatenation for distinct values", :mssql, :oracle, :db2, :derby do
     @ds.select_group(:id).select_append(Sequel.string_agg(:s).order(:s).distinct.as(:v)).map([:id, :v]).must_equal [[1, 'a,b,c'], [2, 'aa,bb']]
   end
-end if (DB.database_type != :postgres || DB.server_version >= 90000)
+end if (DB.database_type == :postgres && DB.server_version >= 90000) || (DB.database_type == :sqlite && DB.sqlite_version >= 3044000) || ![:postgres, :sqlite].include?(DB.database_type)
 
 describe "insert_conflict plugin" do
   before(:all) do


### PR DESCRIPTION
See https://www.sqlite.org/lang_aggfunc.html#group_concat for details

Distinct with a non-default separator is not supported due to a sqlite parser limitation