### PR TITLE
Use nested module format for Java package names

### DIFF
--- a/lib/sequel/adapters/jdbc.rb
+++ b/lib/sequel/adapters/jdbc.rb
@@ -20,7 +20,7 @@ module Sequel
 
     # Create custom NativeException alias for nicer access, and also so that
     # JRuby 9.2+ so it doesn't use the deprecated ::NativeException
-    NativeException = java.lang.Exception
+    NativeException = Java::JavaLang::Exception
     
     # Default database error classes
     DATABASE_ERROR_CLASSES = [NativeException]
@@ -227,7 +227,7 @@ module Sequel
             raise e unless driver
             # If the DriverManager can't get the connection - use the connect
             # method of the driver. (This happens under Tomcat for instance)
-            props = java.util.Properties.new
+            props = Java::JavaUtil::Properties.new
             if opts && opts[:user] && opts[:password]
               props.setProperty("user", opts[:user])
               props.setProperty("password", opts[:password])
@@ -506,7 +506,7 @@ module Sequel
       # Gets the connection from JNDI.
       def get_connection_from_jndi
         jndi_name = JNDI_URI_REGEXP.match(uri)[1]
-        javax.naming.InitialContext.new.lookup(jndi_name).connection
+        Java::JavaxNaming::InitialContext.new.lookup(jndi_name).connection
       end
             
       # Gets the JDBC connection uri from the JNDI resource.
@@ -530,19 +530,19 @@ module Sequel
 
       # Support Date objects used in bound variables
       def java_sql_date(date)
-        java.sql.Date.new(Time.local(date.year, date.month, date.day).to_i * 1000)
+        Java::JavaSql::Date.new(Time.local(date.year, date.month, date.day).to_i * 1000)
       end
 
       # Support DateTime objects used in bound variables
       def java_sql_datetime(datetime)
-        ts = java.sql.Timestamp.new(Time.local(datetime.year, datetime.month, datetime.day, datetime.hour, datetime.min, datetime.sec).to_i * 1000)
+        ts = Java::JavaSql::Timestamp.new(Time.local(datetime.year, datetime.month, datetime.day, datetime.hour, datetime.min, datetime.sec).to_i * 1000)
         ts.setNanos((datetime.sec_fraction * 1000000000).to_i)
         ts
       end
 
       # Support fractional seconds for Time objects used in bound variables
       def java_sql_timestamp(time)
-        ts = java.sql.Timestamp.new(time.to_i * 1000)
+        ts = Java::JavaSql::Timestamp.new(time.to_i * 1000)
         ts.setNanos(time.nsec)
         ts
       end 

--- a/lib/sequel/adapters/jdbc/db2.rb
+++ b/lib/sequel/adapters/jdbc/db2.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('com.ibm.db2.jcc.DB2Driver')
+Sequel::JDBC.load_driver('Java::ComIbmDb2Jcc::DB2Driver')
 require_relative '../shared/db2'
 require_relative 'transactions'
 
@@ -25,7 +25,7 @@ module Sequel
           end
         end
         db.extend_datasets Sequel::DB2::DatasetMethods
-        com.ibm.db2.jcc.DB2Driver
+        Java::ComIbmDb2Jcc::DB2Driver
       end
     end
 

--- a/lib/sequel/adapters/jdbc/derby.rb
+++ b/lib/sequel/adapters/jdbc/derby.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('org.apache.derby.jdbc.EmbeddedDriver', :Derby)
+Sequel::JDBC.load_driver('Java::OrgApacheDerbyJdbc::EmbeddedDriver', :Derby)
 require_relative 'transactions'
 require_relative '../utils/columns_limit_1'
 
@@ -10,7 +10,7 @@ module Sequel
       DATABASE_SETUP[:derby] = proc do |db|
         db.extend(Sequel::JDBC::Derby::DatabaseMethods)
         db.dataset_class = Sequel::JDBC::Derby::Dataset
-        org.apache.derby.jdbc.EmbeddedDriver
+        Java::OrgApacheDerbyJdbc::EmbeddedDriver
       end
     end
 

--- a/lib/sequel/adapters/jdbc/h2.rb
+++ b/lib/sequel/adapters/jdbc/h2.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('org.h2.Driver', :H2)
+Sequel::JDBC.load_driver('Java::OrgH2::Driver', :H2)
 require_relative '../../extensions/auto_cast_date_and_time'
 
 module Sequel
@@ -9,7 +9,7 @@ module Sequel
       DATABASE_SETUP[:h2] = proc do |db|
         db.extend(Sequel::JDBC::H2::DatabaseMethods)
         db.dataset_class = Sequel::JDBC::H2::Dataset
-        org.h2.Driver
+        Java::OrgH2::Driver
       end
     end
 

--- a/lib/sequel/adapters/jdbc/hsqldb.rb
+++ b/lib/sequel/adapters/jdbc/hsqldb.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('org.hsqldb.jdbcDriver', :HSQLDB)
+Sequel::JDBC.load_driver('Java::OrgHsqldb::jdbcDriver', :HSQLDB)
 require_relative 'transactions'
 require_relative '../../extensions/auto_cast_date_and_time'
 
@@ -10,7 +10,7 @@ module Sequel
       DATABASE_SETUP[:hsqldb] = proc do |db|
         db.extend(Sequel::JDBC::HSQLDB::DatabaseMethods)
         db.dataset_class = Sequel::JDBC::HSQLDB::Dataset
-        org.hsqldb.jdbcDriver
+        Java::OrgHsqldb::jdbcDriver
       end
     end
 

--- a/lib/sequel/adapters/jdbc/jtds.rb
+++ b/lib/sequel/adapters/jdbc/jtds.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('Java::net.sourceforge.jtds.jdbc.Driver', :JTDS)
+Sequel::JDBC.load_driver('Java::NetSourceforgeJtdsJdbc::Driver', :JTDS)
 require_relative 'mssql'
 
 module Sequel
@@ -10,7 +10,7 @@ module Sequel
         db.extend(Sequel::JDBC::JTDS::DatabaseMethods)
         db.extend_datasets Sequel::MSSQL::DatasetMethods
         db.send(:set_mssql_unicode_strings)
-        Java::net.sourceforge.jtds.jdbc.Driver
+        Java::NetSourceforgeJtdsJdbc::Driver
       end
     end
 

--- a/lib/sequel/adapters/jdbc/mysql.rb
+++ b/lib/sequel/adapters/jdbc/mysql.rb
@@ -2,7 +2,7 @@
 
 module Sequel
   module JDBC
-    driver = Sequel::JDBC.load_driver(%w'com.mysql.cj.jdbc.Driver com.mysql.jdbc.Driver', :MySQL)
+    driver = Sequel::JDBC.load_driver(%w'Java::ComMysqlCjJdbc::Driver Java::ComMysqlJdbc::Driver', :MySQL)
     require_relative '../shared/mysql'
 
     Sequel.synchronize do

--- a/lib/sequel/adapters/jdbc/oracle.rb
+++ b/lib/sequel/adapters/jdbc/oracle.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('Java::oracle.jdbc.driver.OracleDriver')
+Sequel::JDBC.load_driver('Java::OracleJdbcDriver::OracleDriver')
 require_relative '../shared/oracle'
 require_relative 'transactions'
 
@@ -10,12 +10,12 @@ module Sequel
       DATABASE_SETUP[:oracle] = proc do |db|
         db.extend(Sequel::JDBC::Oracle::DatabaseMethods)
         db.dataset_class = Sequel::JDBC::Oracle::Dataset
-        Java::oracle.jdbc.driver.OracleDriver
+        Java::OracleJdbcDriver::OracleDriver
       end
     end
 
     module Oracle
-      JAVA_BIG_DECIMAL_CONSTRUCTOR = java.math.BigDecimal.java_class.constructor(Java::long).method(:new_instance)
+      JAVA_BIG_DECIMAL_CONSTRUCTOR = Java::JavaMath::BigDecimal.java_class.constructor(Java::long).method(:new_instance)
       ORACLE_DECIMAL = Object.new
       def ORACLE_DECIMAL.call(r, i)
         if v = r.getBigDecimal(i)
@@ -76,7 +76,7 @@ module Sequel
                 rs = log_connection_yield(sql, conn){stmt.executeQuery(sql)}
                 rs.next
                 rs.getLong(1)
-              rescue java.sql.SQLException
+              rescue Java::JavaSql::SQLException
                 nil
               end
             end
@@ -122,7 +122,7 @@ module Sequel
         NUMERIC_TYPE = Java::JavaSQL::Types::NUMERIC
         TIMESTAMP_TYPE = Java::JavaSQL::Types::TIMESTAMP
         CLOB_TYPE = Java::JavaSQL::Types::CLOB
-        TIMESTAMPTZ_TYPES = [Java::oracle.jdbc.OracleTypes::TIMESTAMPTZ, Java::oracle.jdbc.OracleTypes::TIMESTAMPLTZ].freeze
+        TIMESTAMPTZ_TYPES = [Java::OracleJdbc::OracleTypes::TIMESTAMPTZ, Java::OracleJdbc::OracleTypes::TIMESTAMPLTZ].freeze
 
         def type_convertor(map, meta, type, i)
           case type

--- a/lib/sequel/adapters/jdbc/postgresql.rb
+++ b/lib/sequel/adapters/jdbc/postgresql.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('org.postgresql.Driver', :Postgres)
+Sequel::JDBC.load_driver('Java::OrgPostgresql::Driver', :Postgres)
 require_relative '../shared/postgres'
 
 module Sequel
@@ -9,7 +9,7 @@ module Sequel
       DATABASE_SETUP[:postgresql] = proc do |db|
         db.dataset_class = Sequel::JDBC::Postgres::Dataset
         db.extend(Sequel::JDBC::Postgres::DatabaseMethods)
-        org.postgresql.Driver
+        Java::OrgPostgresql::Driver
       end
     end
 
@@ -43,7 +43,7 @@ module Sequel
 
           synchronize(opts[:server]) do |conn|
             begin
-              copy_manager = org.postgresql.copy.CopyManager.new(conn)
+              copy_manager = Java::OrgPostgresqlCopy::CopyManager.new(conn)
               copier = copy_manager.copy_in(copy_into_sql(table, opts))
               if defined?(yield)
                 while buf = yield
@@ -74,7 +74,7 @@ module Sequel
         # See Sequel::Postgres::Adapter#copy_table
         def copy_table(table, opts=OPTS)
           synchronize(opts[:server]) do |conn|
-            copy_manager = org.postgresql.copy.CopyManager.new(conn)
+            copy_manager = Java::OrgPostgresqlCopy::CopyManager.new(conn)
             copier = copy_manager.copy_out(copy_table_sql(table, opts))
             begin
               if defined?(yield)
@@ -148,7 +148,7 @@ module Sequel
         # and set that as the prepared statement argument.
         def set_ps_arg(cps, arg, i)
           if v = bound_variable_arg(arg, nil)
-            obj = org.postgresql.util.PGobject.new
+            obj = Java::OrgPostgresqlUtil::PGobject.new
             obj.setType("unknown")
             obj.setValue(v)
             cps.setObject(i, obj)

--- a/lib/sequel/adapters/jdbc/sqlanywhere.rb
+++ b/lib/sequel/adapters/jdbc/sqlanywhere.rb
@@ -6,12 +6,12 @@ require_relative 'transactions'
 module Sequel
   module JDBC
     drv = [
-      lambda{Java::sybase.jdbc4.sqlanywhere.IDriver},
-      lambda{Java::ianywhere.ml.jdbcodbc.jdbc4.IDriver},
-      lambda{Java::sybase.jdbc.sqlanywhere.IDriver},
-      lambda{Java::ianywhere.ml.jdbcodbc.jdbc.IDriver},
-      lambda{Java::com.sybase.jdbc4.jdbc.Sybdriver},
-      lambda{Java::com.sybase.jdbc3.jdbc.Sybdriver}
+      lambda{Java::SybaseJdbc4Sqlanywhere::IDriver},
+      lambda{Java::IanywhereMlJdbcodbcJdbc4::IDriver},
+      lambda{Java::SybaseJdbcSqlanywhere::IDriver},
+      lambda{Java::IanywhereMlJdbcodbcJdbc::IDriver},
+      lambda{Java::ComSybaseJdbc4Jdbc::Sybdriver},
+      lambda{Java::ComSybaseJdbc3Jdbc::Sybdriver}
     ].each do |class_proc|
       begin
         break class_proc.call

--- a/lib/sequel/adapters/jdbc/sqlite.rb
+++ b/lib/sequel/adapters/jdbc/sqlite.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('org.sqlite.JDBC', :SQLite3)
+Sequel::JDBC.load_driver('Java::OrgSqlite::JDBC', :SQLite3)
 require_relative '../shared/sqlite'
 
 module Sequel
@@ -10,7 +10,7 @@ module Sequel
         db.extend(Sequel::JDBC::SQLite::DatabaseMethods)
         db.extend_datasets Sequel::SQLite::DatasetMethods
         db.set_integer_booleans
-        org.sqlite.JDBC
+        Java::OrgSqlite::JDBC
       end
     end
 

--- a/lib/sequel/adapters/jdbc/sqlserver.rb
+++ b/lib/sequel/adapters/jdbc/sqlserver.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-Sequel::JDBC.load_driver('com.microsoft.sqlserver.jdbc.SQLServerDriver')
+Sequel::JDBC.load_driver('Java::ComMicrosoftSqlserverJdbc::SQLServerDriver')
 require_relative 'mssql'
 
 module Sequel
@@ -10,7 +10,7 @@ module Sequel
         db.extend(Sequel::JDBC::SQLServer::DatabaseMethods)
         db.extend_datasets Sequel::MSSQL::DatasetMethods
         db.send(:set_mssql_unicode_strings)
-        com.microsoft.sqlserver.jdbc.SQLServerDriver
+        Java::ComMicrosoftSqlserverJdbc::SQLServerDriver
       end
     end
 


### PR DESCRIPTION
JRuby provides two formats for referring to java package [1].  Sequel has historically used a mix of both formats.  This consolidates on the "nested module" format (Java::JavaSql::Date) vs the java style format (java.sql.Date).  Apart from internal consistency, this format also presents as more idiomatic Ruby, since there are no invalid module names, such as Java::oracle.jdbc.driver.OracleDriver (`oracle` is not a valid module name).

[1] https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#referencing-java-classes-using-full-qualified-class-name