### PR TITLE
Support using no_auto_parameterize to remove the insert limit

### DIFF
--- a/lib/sequel/extensions/pg_auto_parameterize.rb
+++ b/lib/sequel/extensions/pg_auto_parameterize.rb
@@ -394,7 +394,7 @@ module Sequel
         # there can be more than one parameter per column, so this doesn't prevent going
         # over the limit, though it does make it less likely.
         def default_import_slice
-          40
+          @opts[:no_auto_parameterize] ? super : 40
         end
 
         # Handle parameterization of multi_insert_sql

--- a/spec/extensions/pg_auto_parameterize_spec.rb
+++ b/spec/extensions/pg_auto_parameterize_spec.rb
@@ -63,6 +63,14 @@ describe "pg_auto_parameterize extension" do
     sqls[1].must_equal 'INSERT INTO "table" ("a") VALUES ' + args[0...40].map{|i| "($#{i}::int4)"}.join(', ') + " -- args: #{args[40...80].inspect}"
   end
 
+  it "should not split inserts of multiple rows to 40 at a time with no_auto_parameterize" do
+    args = (1...81).to_a
+    @db[:table].no_auto_parameterize.import([:a], args)
+    sqls = @db.sqls
+    sqls.size.must_equal 1
+    sqls[0].must_equal 'INSERT INTO "table" ("a") VALUES ' + args.map{|i| "(#{i})"}.join(', ')
+  end
+
   it "should automatically parameterize queries strings, blobs, numerics, dates, and times" do
     ds = @db[:table]
     pr = proc do |sql, *args|


### PR DESCRIPTION
Before this change, if you enabled the pg_auto_parameterize extension, all inserts were limited to 40 rows at a time.

Now, you can use the `#no_auto_parameterize` method to turn off this behavior since inserts without parameterization can handle much higher rows at a time.