### PR TITLE
Update model docs for clarity

### DIFF
--- a/lib/sequel/model/base.rb
+++ b/lib/sequel/model/base.rb
@@ -87,7 +87,7 @@ module Sequel
       attr_reader :simple_pk
   
       # Should be the literal table name if this Model's dataset is a simple table (no select, order, join, etc.),
-      # or nil otherwise.  This and simple_pk are used for an optimization in Model.[].
+      # or nil otherwise.  This and simple_pk are used for an optimization in Model[].
       attr_reader :simple_table
   
       # Whether mass assigning via .create/.new/#set/#update should raise an error
@@ -398,7 +398,7 @@ module Sequel
       end
   
       # Finds a single record according to the supplied filter.
-      # You are encouraged to use Model.[] or Model.first instead of this method.
+      # You are encouraged to use Model[] or Model.first instead of this method.
       #
       #   Artist.find(name: 'Bob')
       #   # SELECT * FROM artists WHERE (name = 'Bob') LIMIT 1


### PR DESCRIPTION
I just learned of the `Model.first` alternative `Model[]`, but when reading the docs I initially attempted to use it as the docs show `Model.[]` which is a syntax error. My apologies if this is intentional, but it was confusing for me as a Sequel noob and thought I'd help clarify for others.