### PR TITLE
MySQL and Postgres schema: retrieve columns' comments

### DIFF
--- a/doc/reflection.rdoc
+++ b/doc/reflection.rdoc
@@ -59,6 +59,7 @@ The hash may also contain entries for:
 Database#schema takes a table symbol and returns column information in an array with each element being an array with two elements.  The first elements of the subarray is a column symbol, and the second element is a hash of information about that column.  The hash should include the following keys:
 
 :allow_null :: Whether NULL/nil is an allowed value for this column. Used by the Sequel::Model typecasting code.
+:comment:: The comment of the column (MySQL and PostreSQL).
 :db_type :: The type of column the database provided, as a string.  Used by the schema_dumper plugin for a more specific type translation.
 :default :: The default value of the column, as either a string or nil.  Uses a database specific format. Used by the schema_dumper plugin for converting to a ruby value.
 :primary_key :: Whether this column is one of the primary key columns for the table.  Used by the Sequel::Model code to determine primary key columns.

--- a/lib/sequel/adapters/shared/mysql.rb
+++ b/lib/sequel/adapters/shared/mysql.rb
@@ -578,6 +578,7 @@ module Sequel
           end
           row[:allow_null] = row.delete(:Null) == 'YES'
           row[:comment] = row.delete(:Comment)
+          row[:comment] = nil if row[:comment] == ""
           row[:default] = row.delete(:Default)
           row[:db_type] = row.delete(:Type)
           row[:type] = schema_column_type(row[:db_type])

--- a/lib/sequel/adapters/shared/mysql.rb
+++ b/lib/sequel/adapters/shared/mysql.rb
@@ -567,7 +567,7 @@ module Sequel
         im = input_identifier_meth(opts[:dataset])
         table = SQL::Identifier.new(im.call(table_name))
         table = SQL::QualifiedIdentifier.new(im.call(opts[:schema]), table) if opts[:schema]
-        metadata_dataset.with_sql("DESCRIBE ?", table).map do |row|
+        metadata_dataset.with_sql("SHOW FULL COLUMNS FROM ?", table).map do |row|
           extra = row.delete(:Extra)
           if row[:primary_key] = row.delete(:Key) == 'PRI'
             row[:auto_increment] = !!(extra.to_s =~ /auto_increment/i)
@@ -577,10 +577,13 @@ module Sequel
             row[:generated] = !!(extra.to_s =~ /VIRTUAL|STORED|PERSISTENT/i)
           end
           row[:allow_null] = row.delete(:Null) == 'YES'
+          row[:comment] = row.delete(:Comment)
           row[:default] = row.delete(:Default)
           row[:db_type] = row.delete(:Type)
           row[:type] = schema_column_type(row[:db_type])
           row[:extra] = extra
+          row.delete(:Collation)
+          row.delete(:Privileges)
           [m.call(row.delete(:Field)), row]
         end
       end

--- a/lib/sequel/adapters/shared/postgres.rb
+++ b/lib/sequel/adapters/shared/postgres.rb
@@ -1075,6 +1075,7 @@ module Sequel
               pg_attribute[:attname].as(:name),
               SQL::Cast.new(pg_attribute[:atttypid], :integer).as(:oid),
               SQL::Cast.new(basetype[:oid], :integer).as(:base_oid),
+              SQL::Function.new(:col_description, pg_class[:oid], pg_attribute[:attnum]).as(:comment),
               SQL::Function.new(:format_type, basetype[:oid], pg_type[:typtypmod]).as(:db_base_type),
               SQL::Function.new(:format_type, pg_type[:oid], pg_attribute[:atttypmod]).as(:db_type),
               SQL::Function.new(:pg_get_expr, pg_attrdef[:adbin], pg_class[:oid]).as(:default),

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -42,6 +42,15 @@ describe "MySQL", '#create_table' do
     @db.schema(:dolls).map{|k, v| v[:db_type]}.must_equal %w"blob tinyblob mediumblob longblob blob"
   end
 
+  it "should returns the columns' comments" do
+    @db.create_table(:dolls) do
+      Integer :a
+      Integer :b
+    end
+    @db.run("ALTER TABLE dolls CHANGE b b INT COMMENT 'blah'")
+    @db.schema(:dolls).map{|k, v| v[:comment]}.must_equal ["", 'blah']
+  end
+
   it "should include an :auto_increment schema attribute if auto incrementing" do
     @db.create_table(:dolls) do
       primary_key :n4

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -48,7 +48,7 @@ describe "MySQL", '#create_table' do
       Integer :b
     end
     @db.run("ALTER TABLE dolls CHANGE b b INT COMMENT 'blah'")
-    @db.schema(:dolls).map{|k, v| v[:comment]}.must_equal ["", 'blah']
+    @db.schema(:dolls).map{|k, v| v[:comment]}.must_equal [nil, 'blah']
   end
 
   it "should include an :auto_increment schema attribute if auto incrementing" do

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -714,6 +714,12 @@ describe "PostgreSQL", '#create_table' do
     @db.schema(:tmp_dolls).map{|_,v| v[:generated]}.must_equal [false, false, true]
   end if DB.server_version >= 120000
 
+  it "should include :comment entry in schema for whether the column is commented" do
+    @db.create_table(:tmp_dolls){Integer :a; Integer :b}
+    @db.run("COMMENT ON COLUMN tmp_dolls.b IS 'blah'")
+    @db.schema(:tmp_dolls).map{|_,v| v[:comment]}.must_equal [nil, 'blah']
+  end
+
   it "should support deferred primary key and unique constraints on columns" do
     @db.create_table(:tmp_dolls){primary_key :id, :primary_key_deferrable=>true; Integer :i, :unique=>true, :unique_deferrable=>true}
     @db[:tmp_dolls].insert(:i=>10)


### PR DESCRIPTION
Following this discussion:
- https://github.com/jeremyevans/sequel/discussions/2248

Here is a PR to retrieve columns' comments (+ collation + privileges for MySQL).

As @jeremyevans shared, it may be more appropriate to build an extension, similar to @mpalmer's https://github.com/mpalmer/sequel-pg-comment. No hard feeling if the PR is rejected, I mostly pushed it because it fixes my use case, and it could help people who would come across the same issue.

Thank you for your help finding this solution!

### Usage

```ruby
DB.schema(table_name)
# Each column now has a "comment" key
```

### Implementation notes

#### MySQL vs Postgres adapters:

For other fields, MySQL adapter returns empty string when there is nothing; while Postgres adapter returns nil. I followed this pattern–but it means the behavior isn't the same for the two of them. I don't have an opinion for this, feel free to comment.

#### Adding vs retrieving comment

This PR is only about retrieving comment, hence hardcoded SQL queries in the tests.

### Tests

```sh
rake spec_mysql
rake spec_postgres
```