### PR TITLE
Add the more_than plugin to list of exernal extensions

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -1125,6 +1125,9 @@
 <a class="a" href="http://github.com/jsvd/sequel_vectorized">sequel_vectorized </a>
 <span class="ul__span">Allows Sequel::Dataset to be exported as an Hash of Arrays and NArrays.</span>
 </li>
+<li class="ul__li ul__li--grid">
+<a class="a" href="https://github.com/eriklovmo/sequel_more_than">sequel_more_than </a>
+<span class="ul__span">Efficiently compare a Sequel::Dataset's row count against a given number.</span> </li>
 </ul>
 
 <a name="extensions-external-adapters"></a>

--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -1127,7 +1127,8 @@
 </li>
 <li class="ul__li ul__li--grid">
 <a class="a" href="https://github.com/eriklovmo/sequel_more_than">sequel_more_than </a>
-<span class="ul__span">Efficiently compare a Sequel::Dataset's row count against a given number.</span> </li>
+<span class="ul__span">Efficiently compare a Sequel::Dataset's row count against a given number.</span>
+</li>
 </ul>
 
 <a name="extensions-external-adapters"></a>


### PR DESCRIPTION
Hi Jeremy, 

Thanks for all your hard work on Sequel!

I wrote a small [plugin](https://github.com/eriklovmo/sequel_more_than) to decide whether a dataset's row count is less than, less than or equal to, greater than, or greater than or equal to a given number. This pull request adds it to the Sequel website's list of external extensions.