### PR TITLE
Reduce queries made on startup when the `pg_enum` and `pg_array` plugins are enabled

### DIFF
--- a/lib/sequel/extensions/pg_enum.rb
+++ b/lib/sequel/extensions/pg_enum.rb
@@ -149,12 +149,12 @@ module Sequel
             from(:pg_type).
             where(:oid=>enum_labels.keys).
             exclude(:typarray=>0).
-            select_map([:typname, Sequel.cast(:typarray, Integer).as(:v)])
+            select_map([:typname, Sequel.cast(:typarray, Integer).as(:v), Sequel.cast(:oid, Integer).as(:sv)])
 
           existing_oids = conversion_procs.keys
-          array_types.each do |name, oid|
+          array_types.each do |name, oid, scalar_oid|
             next if existing_oids.include?(oid)
-            register_array_type(name, :oid=>oid)
+            register_array_type(name, :oid=>oid, :scalar_oid=>scalar_oid)
           end
         end
 


### PR DESCRIPTION
By not providing the scalar OID, the `pg_array` plugin will lookup each custom type individually. I've updated the `pg_enum` plugin to call `pg_array`'s `#register_array_type` with the scalar type's OID so it doesn't have to do the lookup. We've been running this in production today and we're no longer seeing our app make these a query per custom type.

Existing discussion: https://github.com/jeremyevans/sequel/discussions/2278