### PR TITLE
Update plugin link and name

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -1142,7 +1142,7 @@
 <span class="ul__span">Allows Sequel::Dataset to be exported as an Hash of Arrays and NArrays.</span>
 </li>
 <li class="ul__li ul__li--grid">
-<a class="a" href="https://github.com/eriklovmo/sequel_more_than">sequel_more_than </a>
+<a class="a" href="https://github.com/eriklovmo/sequel_count_comparisons">sequel_count_comparisons </a>
 <span class="ul__span">Efficiently compare a Sequel::Dataset's row count against a given number.</span>
 </li>
 </ul>


### PR DESCRIPTION
In commit b779cb427afc87b62250d2129f08c527070a2a88, we added a link to the [sequel_more_than](https://github.com/eriklovmo/sequel_more_than) plugin to the plugins page on sequel.jeremyevans.net. Since then, I’ve archived that repository and replaced it with [sequel_count_comparisons](https://github.com/eriklovmo/sequel_count_comparisons), which offers the same functionality but with an improved API and a new name.