### PR TITLE
Add UTF-8 support for ODBC adapter by use_odbc_utf8 option

### DIFF
--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -300,6 +300,8 @@ The :host and :port options are not respected. The following additional options 
 :db_type :: Can be specified as 'mssql', 'progress', or 'db2' to use SQL syntax specific to those databases.
 :drvconnect :: Can be given an ODBC connection string, and will use ODBC::Database#drvconnect to
                do the connection.  Typical usage would be: <tt>Sequel.odbc(drvconnect: 'driver={...};...')</tt>
+:use_odbc_utf8 :: When set to true, uses the ODBC_UTF8 module instead of the standard ODBC module.
+                  This enables proper handling of UTF-8 encoded data when communicating with the ODBC driver.
 
 === oracle 
 


### PR DESCRIPTION
# Background

There have been some problems with the ODBC adapter handling UTF-8 strings, including problems allocating buffers to store the strings. Details are described in the following blog.

https://mnmandahalf.hatenablog.com/entry/2025/03/31/003137

# What this PR is doing

This PR implements the `:use_odbc_utf8` option for the ODBC adapter that allows using the `ODBC_UTF8` module instead of the standard `ODBC` module.  (see: http://www.ch-werner.de/rubyodbc/README)

This enables proper handling of UTF-8 encoded data when communicating with the ODBC driver.

Changes include:
- Dynamic module selection based on `:use_odbc_utf8` option
- Support for both `ODBC` and `ODBC_UTF8` error types
- Proper type conversion for date/time/bit values from both modules
- Updated documentation explaining the new option

# Other considerations
I considered switching by `encoding` option, but avoided it because it would be an implicit change and would have a significant impact on error handling based on the content of error messages.

The behavior was checked in a local environment with the Snowflake ODBC driver, but the appropriate spec file could not be found.