### PR TITLE
Add MariaDB to CI running on ruby odd versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
           MYSQL_DATABASE: sequel_test
         ports: ["3306:3306"]
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      mariadb:
+        image: mariadb:latest
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: sequel_test
+        ports: ["3307:3306"]
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
     strategy:
       fail-fast: false
       matrix:
@@ -46,8 +53,16 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: bundle exec rake spec_ci
+    - name: Run rake spec_ci
+      run: |
+        set -x -v
+        RUBY_VERSION="${{ matrix.ruby }}"
+        if [ $(( "${RUBY_VERSION##*.}" % 2 )) -eq 0 ]; then
+          export MYSQL_ROOT_PASSWORD=1
+        else
+          export MARIADB_ROOT_PASSWORD=1
+        fi
+        bundle exec rake spec_ci
       env:
         DEFAULT_DATABASE: 1
-        MYSQL_ROOT_PASSWORD: 1
       continue-on-error: ${{ startsWith(matrix.ruby, 'truffleruby') }}

--- a/Rakefile
+++ b/Rakefile
@@ -157,16 +157,23 @@ end
 task :spec_ci=>[:spec_core, :spec_model, :spec_plugin, :spec_core_ext] do
   mysql_host = "localhost"
   pg_database = "sequel_test" unless ENV["DEFAULT_DATABASE"]
+  mysql_jdbc = "&allowPublicKeyRetrieval=true"
 
   if ENV["MYSQL_ROOT_PASSWORD"]
     mysql_password = "&password=root"
     mysql_host= "127.0.0.1:3306"
   end
 
+  if ENV["MARIADB_ROOT_PASSWORD"]
+    mysql_password = "&password=root"
+    mysql_host = "127.0.0.1:3307"
+    mysql_jdbc = ""
+  end
+
   if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
     ENV['SEQUEL_SQLITE_URL'] = "jdbc:sqlite::memory:"
     ENV['SEQUEL_POSTGRES_URL'] = "jdbc:postgresql://localhost/#{pg_database}?user=postgres&password=postgres"
-    ENV['SEQUEL_MYSQL_URL'] = "jdbc:mysql://#{mysql_host}/sequel_test?user=root#{mysql_password}&useSSL=false&allowPublicKeyRetrieval=true"
+    ENV['SEQUEL_MYSQL_URL'] = "jdbc:mysql://#{mysql_host}/sequel_test?user=root#{mysql_password}&useSSL=false#{mysql_jdbc}"
   else
     ENV['SEQUEL_SQLITE_URL'] = "sqlite:/"
     ENV['SEQUEL_POSTGRES_URL'] = "postgres://localhost/#{pg_database}?user=postgres&password=postgres"


### PR DESCRIPTION
Based on the minor release number in the Ruby version.

Run this on github services port 3307
and remove the MySQL specific JDBC string.

from #2305 it seemed an easy option and hopefully not too messy. I looked at timing different for starting a not-needed mariadb/mysql service and it was 1-2 seconds on a 30 second total and the complexity of making it conditional wasn't as nice a a neat service matrix.

Note MariaDB is hitting the test error:

Database#test_0002_should raise when trying to create a schema qualified temporary table [/home/runner/work/sequel/sequel/spec/integration/schema_test.rb:412]

I'm unsure if intended at the moment but MariaDB does allow it:
```
MariaDB [test]> create temporary table somewhere.chicken(corn int);
Query OK, 0 rows affected (0.020 sec)
```