### PR TITLE
doc: adds sequel-pgt_outbox extension reference

### DIFF
--- a/www/pages/plugins.html.erb
+++ b/www/pages/plugins.html.erb
@@ -1118,6 +1118,10 @@
 <span class="ul__span">Document your schema by setting comments on all your PgSQL objects.</span>
 </li>
 <li class="ul__li ul__li--grid">
+<a class="a" href="https://github.com/rubyists/sequel-pgt_outbox">sequel-pgt_outbox </a>
+<span class="ul__span">Transactional Outbox for PostgreSQL utilizing triggers.</span>
+</li>
+<li class="ul__li ul__li--grid">
 <a class="a" href="http://github.com/mwlang/sequel_plus">sequel_plus </a>
 <span class="ul__span">Collection of sequel extensions.</span>
 </li>


### PR DESCRIPTION
Just a documentation change, adding a link to sequel-pgt_outbox.