### PR TITLE
test: fix `must_raise` assertions on minitest 6.0.5

### DIFF
--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -844,9 +844,10 @@ describe "PostgreSQL temporary table/view support" do
   end
 
   it "should not allow to pass both :temp and :unlogged" do
-    proc do
+    err = proc do
       @db.create_table(:temp_unlogged_dolls, :temp => true, :unlogged => true){text :name}
-    end.must_raise(Sequel::Error, "can't provide both :temp and :unlogged to create_table")
+    end.must_raise(Sequel::Error)
+    err.message.must_equal("can't provide both :temp and :unlogged to create_table")
   end
 
   it "should support temporary views" do
@@ -1669,7 +1670,8 @@ describe "A PostgreSQL dataset" do
   end
 
   it "should raise an error if attempting to update a joined dataset with a single FROM table" do
-    proc{@db[:test].join(:test, [:name]).update(:name=>'a')}.must_raise(Sequel::Error, 'Need multiple FROM tables if updating/deleting a dataset with JOINs')
+    err = proc{@db[:test].join(:test, [:name]).update(:name=>'a')}.must_raise Sequel::Error
+    err.message.must_equal("Need multiple FROM tables if updating/deleting a dataset with JOINs")
   end
 
   it "should truncate with options" do

--- a/spec/core/database_spec.rb
+++ b/spec/core/database_spec.rb
@@ -3287,9 +3287,10 @@ describe "Database.after_initialize" do
   end
 
   it "should raise an error if registration is called without a block" do
-    proc {
+    err = proc {
       Sequel::Database.after_initialize
-    }.must_raise(Sequel::Error, /must provide block/i)
+    }.must_raise Sequel::Error
+    err.message.must_match(/must provide block/i)
   end
 end
 

--- a/spec/integration/plugin_test.rb
+++ b/spec/integration/plugin_test.rb
@@ -1090,7 +1090,8 @@ describe "Instance Filters plugin" do
   
   it "should not raise an error if deleting only deletes one row" do
     @i.destroy
-    proc{@i.refresh}.must_raise(Sequel::Error, 'Record not found')
+    err = proc{@i.refresh}.must_raise(Sequel::Error)
+    err.message.must_equal('Record not found')
   end
   
   it "should raise error if destroying doesn't delete a row" do

--- a/spec/model/hooks_spec.rb
+++ b/spec/model/hooks_spec.rb
@@ -23,7 +23,8 @@ describe "Model#before_create && Model#after_create" do
 
   it ".create should cancel the save and raise an error if before_create calls cancel_action and raise_on_save_failure is true" do
     @c.send(:define_method, :before_create){cancel_action 'not good'}
-    proc{@c.create(:x => 2)}.must_raise(Sequel::HookFailed, 'not good')
+    err = proc{@c.create(:x => 2)}.must_raise(Sequel::HookFailed)
+    err.message.must_equal('not good')
     DB.sqls.must_equal []
     @c.load(:id => 2233).save
   end

--- a/spec/model/validations_spec.rb
+++ b/spec/model/validations_spec.rb
@@ -148,7 +148,8 @@ describe Sequel::Model do
   end
 
   it "should allow raising of ValidationFailed with a string" do
-    proc{raise Sequel::ValidationFailed, "no reason"}.must_raise(Sequel::ValidationFailed, "no reason")
+    err = proc{raise Sequel::ValidationFailed, "no reason"}.must_raise(Sequel::ValidationFailed)
+    err.message.must_equal "no reason"
   end
 end
 


### PR DESCRIPTION
On Minitest 6.0.5 these assertions now throw errors if passed a regex into `must_raise`

Don't think Minitest ever strictly supported this syntax as originally intended (noted at https://github.com/minitest/minitest/issues/1068#issuecomment-4263808393 ) since the string is a custom error for the assertion, not an expectation on the message.

e.g
```
  1) Error:
Database.after_initialize#test_0003_should raise an error if registration is called without a block:
TypeError: class or module required for rescue clause. Got [Sequel::Error, /must provide block/i]
    spec/core/database_spec.rb:3292:in 'block in <main>'
    org/jruby/RubyArray.java:2093:in 'each'
    org/jruby/RubyArray.java:2892:in 'map'
```

https://github.com/minitest/minitest/blob/master/History.rdoc#605--2026-04-20

This change fixes the assertions for all `must_raise` I could find. CI passing on my fork.