### PR TITLE
Adds expiration for existing connections when added to a db

### DIFF
--- a/lib/sequel/extensions/connection_expiration.rb
+++ b/lib/sequel/extensions/connection_expiration.rb
@@ -55,11 +55,41 @@ module Sequel
           @connection_expiration_timestamps ||= {}
           @connection_expiration_timeout ||= 14400
           @connection_expiration_random_delay ||= 0
+
+          # Record an expiration timestamp for any connections that already
+          # exist in the pool, so that a connection opened before the extension
+          # was loaded (e.g. via Sequel.connect) will eventually be expired.
+          register = method(:register_connection)
+          case pool_type
+          when :threaded
+            @available_connections.each(&register)
+            @allocated.each_value(&register)
+          when :sharded_threaded
+            @available_connections.each_value{|conns| conns.each(&register)}
+            @allocated.each_value{|threads| threads.each_value(&register)}
+          when :timed_queue
+            register_queued_connections(@queue, register)
+            @allocated.each_value(&register)
+          when :sharded_timed_queue
+            @queues.each_value{|queue| register_queued_connections(queue, register)}
+            @allocated.each_value{|threads| threads.each_value(&register)}
+          end
         end
       end
     end
 
     private
+
+    # Drain the given queue, yield each connection to the registration callable,
+    # then push the connections back onto the queue.
+    def register_queued_connections(queue, register)
+      conns = []
+      while conn = queue.pop(timeout: 0)
+        conns << conn
+      end
+      conns.each(&register)
+      conns.each{|conn| queue.push(conn)}
+    end
 
     # Clean up expiration timestamps during disconnect.
     def disconnect_connection(conn)
@@ -70,8 +100,13 @@ module Sequel
     # Record the time the connection was created.
     def make_new(*)
       conn = super
-      @connection_expiration_timestamps[conn] = [Sequel.start_timer, @connection_expiration_timeout + (rand * @connection_expiration_random_delay)].freeze
+      register_connection(conn)
       conn
+    end
+
+    # Record an expiration entry for a connection
+    def register_connection(conn)
+      @connection_expiration_timestamps[conn] ||= [Sequel.start_timer, @connection_expiration_timeout + (rand * @connection_expiration_random_delay)].freeze
     end
 
     # When acquiring a connection, check if the connection is expired.

--- a/spec/extensions/connection_expiration_spec.rb
+++ b/spec/extensions/connection_expiration_spec.rb
@@ -93,6 +93,25 @@ connection_expiration_specs = Module.new do
     @db.pool.instance_variable_get(:@connection_expiration_timestamps).size.must_equal 0
   end
 
+  it "should record expiration timestamps for connections opened before the extension was loaded" do
+    @db = db
+    c1 = @db.synchronize{|c| c}
+    @db.pool.instance_variable_get(:@connection_expiration_timestamps).must_be_nil
+    @db.extension(:connection_expiration)
+    timestamps = @db.pool.instance_variable_get(:@connection_expiration_timestamps)
+    timestamps.must_include(c1)
+    timestamps[c1].last.must_equal 14400
+  end
+
+  it "should record expiration timestamps for held connections when loading the extension" do
+    @db = db
+    @db.synchronize do |c|
+      @db.pool.instance_variable_get(:@connection_expiration_timestamps).must_be_nil
+      @db.extension(:connection_expiration)
+      @db.pool.instance_variable_get(:@connection_expiration_timestamps).must_include(c)
+    end
+  end
+
   it "should not vary expiration timestamps by default" do
     c1 = @db.synchronize{|c| c}
     @db.pool.instance_variable_get(:@connection_expiration_timestamps)[c1].last.must_equal 2


### PR DESCRIPTION
When connection expiration is added to a db it does not register existing connections. This loops through all available and allocated connections and sets an expiration value for them on initial load.

One alternative approach I though of was to instead lazy apply the expiration on connection checkout if it's missing. Might result in cleaner code but it would result in an extra check every time a connection is checked out.

Related discussion: https://github.com/jeremyevans/sequel/discussions/2365