### PR TITLE
Fix specs on TruffleRuby and restore it on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [ "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, 3.3, 3.4, "4.0", jruby-9.3, jruby-9.4, jruby-10.0, jruby-10.1 ]
+        ruby: [ "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, 3.3, 3.4, "4.0", jruby-9.3, jruby-9.4, jruby-10.0, jruby-10.1, truffleruby ]
         include:
           - { os: ubuntu-22.04, ruby: "1.9.3" }
           - { os: ubuntu-22.04, ruby: jruby-9.2 }

--- a/lib/sequel/database/schema_generator.rb
+++ b/lib/sequel/database/schema_generator.rb
@@ -17,7 +17,9 @@ module Sequel
             if RUBY_VERSION >= "3.2"
             # :nocov:
               caller_loc = Thread.each_caller_location do |loc|
-                break loc unless loc.path == __FILE__
+                # Skip core library methods implemented in Ruby
+                path = loc.path
+                break loc unless path == __FILE__ || (path && path.start_with?('<internal:'))
               end
               caller_loc &&= "#{caller_loc.path}:#{caller_loc.lineno}: "
             end

--- a/spec/extensions/caller_logging_spec.rb
+++ b/spec/extensions/caller_logging_spec.rb
@@ -39,7 +39,10 @@ describe "caller_logging extension" do
     @log_stream.rewind
     lines = @log_stream.read.split("\n")
     lines.length.must_equal 1
-    lines[0].must_match(/ \(source: #{__FILE__}:#{line}:in [`']block.+\) SELECT \* FROM items\z/)
+
+    # TruffleRuby names block frames after the compiled/optimized test method name
+    # (e.g. test_0003_...) instead of 'block'.
+    lines[0].must_match(/ \(source: #{__FILE__}:#{line}:in [`'](block|test_).+\) SELECT \* FROM items\z/)
   end
 
   it "should not log caller information if all callers lines are filtered" do


### PR DESCRIPTION
Wondering if it is OK to add TruffleRuby back on CI.

I have fixed a couple of issues that lead to specs failures and were caused by minor differences between CRuby and TruffleRuby.

cc @eregon 