### PR TITLE
Support :query_plan option in Dataset#explain on SQLite

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 === master
 
+* Support Dataset#explain :query_plan option on SQLite, for EXPLAIN QUERY PLAN (cllns)
+
 * Add Database#set_property_graph_schema to support changing the schema for a property graph on PostgreSQL 19+ (jeremyevans)
 
 * Add Database#rename_property_graph to support renaming property graphs on PostgreSQL 19+ (jeremyevans)

--- a/lib/sequel/adapters/shared/sqlite.rb
+++ b/lib/sequel/adapters/shared/sqlite.rb
@@ -677,14 +677,15 @@ module Sequel
         super
       end
 
-      # Return an array of strings specifying a query explanation for a SELECT of the
-      # current dataset. Currently, the options are ignored, but it accepts options
-      # to be compatible with other adapters.
+      # Return a string specifying a query explanation for a SELECT of the
+      # current dataset. Options:
+      # :query_plan :: Use EXPLAIN QUERY PLAN instead of EXPLAIN if true.
       def explain(opts=nil)
         # Load the PrettyTable class, needed for explain output
         Sequel.extension(:_pretty_table) unless defined?(Sequel::PrettyTable)
 
-        ds = db.send(:metadata_dataset).clone(:sql=>"EXPLAIN #{select_sql}".freeze)
+        keyword = (opts && opts[:query_plan]) ? "EXPLAIN QUERY PLAN" : "EXPLAIN"
+        ds = db.send(:metadata_dataset).clone(:sql=>"#{keyword} #{select_sql}".freeze)
         rows = ds.all
         Sequel::PrettyTable.string(rows, ds.columns)
       end

--- a/spec/adapters/sqlite_spec.rb
+++ b/spec/adapters/sqlite_spec.rb
@@ -515,6 +515,13 @@ describe "SQLite dataset" do
   it "should support #explain" do
     DB[:test].explain.must_be_kind_of(String)
   end
+
+  it "should support #explain with :query_plan option" do
+    ds = DB[:test]
+    plan = ds.explain(:query_plan=>true)
+    plan.must_be_kind_of(String)
+    plan.wont_equal ds.explain
+  end
   
   it "should have #explain work when identifier_output_method is modified" do
     DB[:test].with_identifier_output_method(:upcase).explain.must_be_kind_of(String)


### PR DESCRIPTION
I noticed that SQLite's `Dataset#explain` when using SQLite just dumps VDBE bytecode (OpenRead, Rowid, …), which is rarely what people want. `EXPLAIN QUERY PLAN` is the form people actually reach for (index usage, SCAN vs SEARCH, temp B-trees), and Sequel had no way to get that from `Dataset#explain`. The rdoc said "Currently, the options are ignored, but it accepts options to be compatible with other adapters." This wires that up, keeping the default behavior for backwards compatibility.

This brings SQLite's `Dataset#explain` to parity with the other adapters, which already accept explain options: MySQL has `:extended`, and PostgreSQL supports the full EXPLAIN option set. This is the only option SQLite takes so this shouldn't need any more changes.

**`DB[:t].explain`** uses bare `EXPLAIN` (VDBE bytecode):

| addr | opcode | p1 | p2 | p3 | p4 | p5 | comment |
|-----:|--------|---:|---:|---:|----|---:|---------|
| 0 | Init | 0 | 8 | 0 |  | 0 | |
| 1 | OpenRead | 0 | 2 | 0 | 2 | 0 | |
| 2 | Rewind | 0 | 7 | 0 |  | 0 | |
| 3 | Rowid | 0 | 1 | 0 |  | 0 | |
| 4 | Column | 0 | 1 | 2 |  | 0 | |
| 5 | ResultRow | 1 | 2 | 0 |  | 0 | |
| 6 | Next | 0 | 3 | 0 |  | 1 | |
| 7 | Halt | 0 | 0 | 0 |  | 0 | |
| 8 | Transaction | 0 | 0 | 1 | 0 | 1 | |
| 9 | Goto | 0 | 1 | 0 |  | 0 | |

**`DB[:users].join(:orgs, id: :org_id).where(...).order(...).explain(query_plan: true)`** uses `EXPLAIN QUERY PLAN`:

| id | parent | notused | detail |
|---:|-------:|--------:|--------|
| 5 | 0 | 63 | SEARCH users USING INDEX users_email_index (email=?) |
| 10 | 0 | 45 | SEARCH orgs USING INTEGER PRIMARY KEY (rowid=?) |
| 21 | 0 | 0 | USE TEMP B-TREE FOR ORDER BY |

Happy to address any feedback, or feel free to add commits of your own to change things, naturally.