### PR TITLE
Fix documentation typos

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -26,7 +26,7 @@ Archived Discussion Forum (sequel-talk Google Group) :: https://www.mail-archive
 
 If you have questions about how to use Sequel, please ask on
 GitHub Discussions.
-Only use the the bug tracker to report
+Only use the bug tracker to report
 bugs in Sequel, not to ask for help on using Sequel.
 
 To check out the source code:

--- a/doc/extensions.rdoc
+++ b/doc/extensions.rdoc
@@ -10,7 +10,7 @@ Global extensions are loaded via <tt>Sequel.extension</tt>:
 
   Sequel.extension :named_timezones
 
-All this does is require the relevent extension from <tt>sequel/extensions/named_timezones</tt> somewhere in the ruby path.  Global extensions are just a simpler, consistent way to require code that modifies Sequel.
+All this does is require the relevant extension from <tt>sequel/extensions/named_timezones</tt> somewhere in the ruby path.  Global extensions are just a simpler, consistent way to require code that modifies Sequel.
 
 == Database Extensions
 
@@ -18,7 +18,7 @@ Database extensions should add or modify the behavior of a single <tt>Sequel::Da
 
   DB.extension :server_block
 
-The first thing that this does is load the relevent extension globally.  However, Database extensions should be structured in a way that loading the relevent extension globally just adds a module with the related behavior, it doesn't modify any other state.  After loading the extension globally, it modifies the related <tt>Sequel::Database</tt> object to modify it's behavior, usually by extending it with a module.
+The first thing that this does is load the relevant extension globally.  However, Database extensions should be structured in a way that loading the relevant extension globally just adds a module with the related behavior, it doesn't modify any other state.  After loading the extension globally, it modifies the related <tt>Sequel::Database</tt> object to modify it's behavior, usually by extending it with a module.
 
 If you want a Database extension loaded into all future Database instances, you can use <tt>Sequel::Database.extension</tt>:
 
@@ -32,7 +32,7 @@ Dataset extensions should add or modify the behavior of a single <tt>Sequel::Dat
 
   ds = DB[:a].extension(:columns_introspection)
 
-The first thing loading a Dataset extension does is load the relevent extension globally.  Similar to Database extensions, loading a Dataset extension globally should not affect state other than maybe adding a module.  After loading the extension globally, it returned a modified copy of the <tt>Sequel::Dataset</tt> with the extension loaded into it.
+The first thing loading a Dataset extension does is load the relevant extension globally.  Similar to Database extensions, loading a Dataset extension globally should not affect state other than maybe adding a module.  After loading the extension globally, it returned a modified copy of the <tt>Sequel::Dataset</tt> with the extension loaded into it.
 
 If you want to load an extension into all future datasets for a given <tt>Sequel::Database</tt> instance, you can also load it as a Database extension:
 

--- a/doc/postgresql.rdoc
+++ b/doc/postgresql.rdoc
@@ -17,7 +17,7 @@ rarely used PostgreSQL features that Sequel supports which are not mentioned her
 
 == Adapter/Driver Specific Support
 
-Some of this this support depends on the specific adapter or underlying driver in use.  
+Some of this support depends on the specific adapter or underlying driver in use.  
 <tt>postgres only</tt> will denote support specific to the postgres adapter (i.e.
 not available when connecting to PostgreSQL via the jdbc adapter).
 <tt>postgres/pg only</tt> will denote support specific to the postgres adapter when

--- a/doc/querying.rdoc
+++ b/doc/querying.rdoc
@@ -30,7 +30,7 @@ then come back here.
 
 === Retrieving a Single Object
 
-Sequel offers quite a few ways to to retrieve a single object.
+Sequel offers quite a few ways to retrieve a single object.
 
 ==== Using a Primary Key [Sequel::Model]
 

--- a/doc/schema_modification.rdoc
+++ b/doc/schema_modification.rdoc
@@ -325,7 +325,7 @@ to +create_table+, provide a dataset to the :as option:
 == +alter_table+
 
 +alter_table+ is used to alter existing tables, changing their columns, indexes,
-or constraints.  It it used just like +create_table+, accepting a block which
+or constraints.  It is used just like +create_table+, accepting a block which
 is instance_evaled, and providing its own methods:
 
 === +add_column+


### PR DESCRIPTION
While reading the documentation I noticed a few small typos. This corrects them:

- `README.rdoc`: "use the the bug tracker" -> "use the bug tracker"
- `doc/postgresql.rdoc`: "Some of this this support" -> "Some of this support"
- `doc/querying.rdoc`: "quite a few ways to to retrieve" -> "quite a few ways to retrieve"
- `doc/schema_modification.rdoc`: "It it used just like" -> "It is used just like" (matches the preceding "+alter_table+ is used" phrasing)
- `doc/extensions.rdoc`: "relevent" -> "relevant" (spelling, 4 occurrences)

Documentation only; no code or behavior changes.
