### PR TITLE
Recognize disconnects in the mysql and mysql2 adapters using client error codes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 === master
 
-* Recognize disconnects using client error codes in the mysql and mysql2 adapters, fixing disconnect detection when the client library or driver does not use libmysqlclient's error messages (sdalu) (#2382)
+* Recognize additional disconnect errors in the mysql and mysql2 adapters (sdalu) (#2382)
 
 * Deprecate Sequel.require (jeremyevans)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 === master
 
+* Recognize disconnects using client error codes in the mysql and mysql2 adapters, fixing disconnect detection when the client library or driver does not use libmysqlclient's error messages (sdalu) (#2382)
+
 * Deprecate Sequel.require (jeremyevans)
 
 * Add ndims, position, positions, prepend, sample, shuffle, and trim to pg_array_ops extension (jeremyevans)

--- a/lib/sequel/adapters/mysql.rb
+++ b/lib/sequel/adapters/mysql.rb
@@ -284,8 +284,13 @@ module Sequel
         Dataset
       end
 
+      # If the error is a Mysql::Error, check the client error code and exception
+      # message for disconnects.
       def disconnect_error?(e, opts)
-        super || (e.is_a?(::Mysql::Error) && MYSQL_DATABASE_DISCONNECT_ERRORS.match(e.message))
+        super ||
+          (e.is_a?(::Mysql::Error) &&
+            (MYSQL_DISCONNECT_ERROR_CODES.include?(e.errno) ||
+             MYSQL_DATABASE_DISCONNECT_ERRORS.match(e.message)))
       end
       
       # Convert tinyint(1) type to boolean if convert_tinyint_to_bool is true

--- a/lib/sequel/adapters/mysql2.rb
+++ b/lib/sequel/adapters/mysql2.rb
@@ -215,13 +215,14 @@ module Sequel
       end
 
       # If a connection object is available, try pinging it.  Otherwise, if the
-      # error is a Mysql2::Error, check the SQL state and exception message for
-      # disconnects.
+      # error is a Mysql2::Error, check the client error code, SQL state, and
+      # exception message for disconnects.
       def disconnect_error?(e, opts)
         super ||
           ((conn = opts[:conn]) && !conn.ping) ||
           (e.is_a?(::Mysql2::Error) &&
-            ((e.sql_state && e.sql_state.start_with?("08")) ||
+            (MYSQL_DISCONNECT_ERROR_CODES.include?(e.errno) ||
+             (e.sql_state && e.sql_state.start_with?("08")) ||
              MYSQL_DATABASE_DISCONNECT_ERRORS.match(e.message)))
       end
 

--- a/lib/sequel/adapters/utils/mysql_mysql2.rb
+++ b/lib/sequel/adapters/utils/mysql_mysql2.rb
@@ -31,6 +31,7 @@ module Sequel
           2014, # CR_COMMANDS_OUT_OF_SYNC
           2055, # CR_SERVER_LOST_EXTENDED
         ].freeze
+        private_constant :MYSQL_DISCONNECT_ERROR_CODES
 
         # Support stored procedures on MySQL
         def call_sproc(name, opts=OPTS, &block)

--- a/lib/sequel/adapters/utils/mysql_mysql2.rb
+++ b/lib/sequel/adapters/utils/mysql_mysql2.rb
@@ -22,7 +22,20 @@ module Sequel
         END
         # Error messages for mysql and mysql2 that indicate the current connection should be disconnected
         MYSQL_DATABASE_DISCONNECT_ERRORS = /\A#{Regexp.union(disconnect_errors)}/
-       
+
+        # Client error codes for mysql and mysql2 that indicate the current connection
+        # should be disconnected.  Unlike the related error messages, these do not
+        # differ between client libraries.  2027 (CR_MALFORMED_PACKET) is deliberately
+        # not included, as it indicates a protocol error and not necessarily a lost
+        # connection.
+        MYSQL_DISCONNECT_ERROR_CODES = [
+          2002, # CR_CONNECTION_ERROR
+          2006, # CR_SERVER_GONE_ERROR
+          2013, # CR_SERVER_LOST
+          2014, # CR_COMMANDS_OUT_OF_SYNC
+          2055, # CR_SERVER_LOST_EXTENDED
+        ].freeze
+
         # Support stored procedures on MySQL
         def call_sproc(name, opts=OPTS, &block)
           args = opts[:args] || [] 

--- a/lib/sequel/adapters/utils/mysql_mysql2.rb
+++ b/lib/sequel/adapters/utils/mysql_mysql2.rb
@@ -23,11 +23,7 @@ module Sequel
         # Error messages for mysql and mysql2 that indicate the current connection should be disconnected
         MYSQL_DATABASE_DISCONNECT_ERRORS = /\A#{Regexp.union(disconnect_errors)}/
 
-        # Client error codes for mysql and mysql2 that indicate the current connection
-        # should be disconnected.  Unlike the related error messages, these do not
-        # differ between client libraries.  2027 (CR_MALFORMED_PACKET) is deliberately
-        # not included, as it indicates a protocol error and not necessarily a lost
-        # connection.
+        # 2027 (CR_MALFORMED_PACKET) deliberately not included (protocol error, not connection error)
         MYSQL_DISCONNECT_ERROR_CODES = [
           2002, # CR_CONNECTION_ERROR
           2006, # CR_SERVER_GONE_ERROR

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -1059,6 +1059,42 @@ if DB.adapter_scheme == :mysql2
   end
 end
 
+if [:mysql, :mysql2].include?(DB.adapter_scheme)
+  describe "MySQL disconnect detection" do
+    def driver_error_class
+      DB.adapter_scheme == :mysql2 ? ::Mysql2::Error : ::Mysql::Error
+    end
+
+    def disconnect_error?(message, errno)
+      e = driver_error_class.new(message)
+      e.define_singleton_method(:errno){errno}
+      !!DB.send(:disconnect_error?, e, {})
+    end
+
+    it "should be able to get the client error code from the driver" do
+      driver_error_class.new("").must_respond_to(:errno)
+    end
+
+    it "should handle client error codes as disconnects" do
+      # Wordings used by libmysqlclient
+      disconnect_error?("MySQL server has gone away", 2006).must_equal true
+      disconnect_error?("Lost connection to MySQL server during query", 2013).must_equal true
+
+      # Wordings used by MariaDB Connector/C and ruby-mysql for the same error codes
+      disconnect_error?("Server has gone away", 2006).must_equal true
+      disconnect_error?("Lost connection to server during query", 2013).must_equal true
+    end
+
+    it "should handle errors raised by the driver without a client error code as disconnects" do
+      disconnect_error?("MySQL client is not connected", nil).must_equal true
+    end
+
+    it "should not handle server errors as disconnects" do
+      disconnect_error?("Table 'test.foo' doesn't exist", 1146).must_equal false
+    end
+  end
+end
+
 describe "MySQL joined datasets" do
   before do
     @db = DB

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -1059,42 +1059,6 @@ if DB.adapter_scheme == :mysql2
   end
 end
 
-if [:mysql, :mysql2].include?(DB.adapter_scheme)
-  describe "MySQL disconnect detection" do
-    def driver_error_class
-      DB.adapter_scheme == :mysql2 ? ::Mysql2::Error : ::Mysql::Error
-    end
-
-    def disconnect_error?(message, errno)
-      e = driver_error_class.new(message)
-      e.define_singleton_method(:errno){errno}
-      !!DB.send(:disconnect_error?, e, {})
-    end
-
-    it "should be able to get the client error code from the driver" do
-      driver_error_class.new("").must_respond_to(:errno)
-    end
-
-    it "should handle client error codes as disconnects" do
-      # Wordings used by libmysqlclient
-      disconnect_error?("MySQL server has gone away", 2006).must_equal true
-      disconnect_error?("Lost connection to MySQL server during query", 2013).must_equal true
-
-      # Wordings used by MariaDB Connector/C and ruby-mysql for the same error codes
-      disconnect_error?("Server has gone away", 2006).must_equal true
-      disconnect_error?("Lost connection to server during query", 2013).must_equal true
-    end
-
-    it "should handle errors raised by the driver without a client error code as disconnects" do
-      disconnect_error?("MySQL client is not connected", nil).must_equal true
-    end
-
-    it "should not handle server errors as disconnects" do
-      disconnect_error?("Table 'test.foo' doesn't exist", 1146).must_equal false
-    end
-  end
-end
-
 describe "MySQL joined datasets" do
   before do
     @db = DB


### PR DESCRIPTION
The disconnect error messages both adapters check are the wordings used by libmysqlclient.  MariaDB Connector/C omits the "MySQL" prefix from three of them, and ruby-mysql raises "Lost connection to server during query" when a connection is lost mid-query, so with either driver a lost connection was raised as a plain Sequel::DatabaseError and the dead connection was returned to the connection pool instead of being removed.

The numeric client error codes do not differ between client libraries, so check those in addition to the SQL state and the error message.  Message matching is still needed for errors raised by the driver itself, which have no client error code.