### PR TITLE
Add :port to Sequel.connect general options doc

### DIFF
--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -90,6 +90,7 @@ These options are shared by all adapters unless otherwise noted.
 :log_connection_info :: Whether to include connection information in log messages (false by default)
 :log_warn_duration :: The amount of seconds after which the queries are logged at :warn level
 :password :: The password for the user account
+:port :: The port of the database server to which to connect
 :preconnect :: Whether to automatically make the maximum number of connections when setting up the pool.
                Can be set to "concurrently" to connect in parallel.
 :preconnect_extensions :: Similar to the :extensions option, but loads the extensions before the


### PR DESCRIPTION
I noticed that `:port` is not listed in the

[General connection options](https://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-General+connection+options)

section of the "Connecting to a database" documentation.  This PR adds it.  Because `:host` is there, I'm fairly sure `:port` should be there too, but if I'm wrong about that, then of course just reject this PR.  I see references to the `:port` option in other parts of the same document, and a quick search of the source code finds references to it, so I think it's considered to be a general connection option, but that's about the extent of my looking into this.