### PR TITLE
Remove duplicate section in Connecting to DB doc

### DIFF
--- a/doc/opening_databases.rdoc
+++ b/doc/opening_databases.rdoc
@@ -68,7 +68,6 @@ multiple times (say once per request), can result in a memory leak.  For any app
 database access is needed for a long period of time, it's best to store the result of
 +Sequel.connect+ in a constant, as recommended above.
 
-== Using the Sequel.connect method
 == General connection options
 
 These options are shared by all adapters unless otherwise noted.


### PR DESCRIPTION
Remove an empty duplicate "Using the Sequel.connect method" section in the

[Connecting to a database](https://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html)

documentation.  The same section heading already appears earlier in the document.